### PR TITLE
Set git quotepath off

### DIFF
--- a/lib/diffHandler.js
+++ b/lib/diffHandler.js
@@ -12,6 +12,9 @@ module.exports = class DiffHandler {
   diff() {
     return new Promise((resolve, reject) => {
       const fullResult = [];
+      const quotePathOff = child_process.spawnSync('git', ['config', 'core.quotepath', 'off'],{
+        "cwd": this.config.repo
+      }).stdout;
       if(!this.config.from) {
         const firstCommitSHARaw = child_process.spawnSync('git', ['rev-list', '--max-parents=0', 'HEAD'],{
             "cwd": this.config.repo


### PR DESCRIPTION
This commit disables default git behaviour where non-ASCII file names are printed in quoted octal notation. This default behaviour would cause the script to fail if file names contain special characters.