### PR TITLE
Set git quotepath off

### DIFF
--- a/lib/diffHandler.js
+++ b/lib/diffHandler.js
@@ -8,10 +8,14 @@ const metadata = require('./metadata/metadata')('directoryName')
 const UTF8_ENCODING = 'utf8'
 const diffParams = ['diff', '--name-status', '--no-renames']
 const revlistParams = ['rev-list', '--max-parents=0', 'HEAD']
+const gitConfig = ['config', 'core.quotepath', 'off']
 
 module.exports = class DiffHandler {
   constructor(config) {
     this.config = config
+    childProcess.spawnSync('git', gitConfig, {
+      cwd: this.config.repo,
+    }).stdout
     if (!this.config.from) {
       const firstCommitSHARaw = childProcess.spawnSync('git', revlistParams, {
         cwd: this.config.repo,


### PR DESCRIPTION
Update git config with quotepath off, to prevent non-ASCII file names from being printed in quoted octal notation (which would cause the script to fail if a file name contains special characters)