### PR TITLE
Escape path into Regexp

### DIFF
--- a/lib/service/inFolderHandler.js
+++ b/lib/service/inFolderHandler.js
@@ -18,11 +18,15 @@ class InFolderHandler extends StandardHandler {
   handleAddition() {
     super.handleAddition()
 
-    let [, folderPath, folderName] = path
+    const regexRepo = this.config.repo !== '.' ? this.config.repo : ''
+
+    let [, , folderPath, folderName] = path
       .join(this.config.repo, this.line)
       .match(
         new RegExp(
-          `${this.config.repo}(?<path>.*[/\\\\]${this.metadata[this.type].directoryName})[/\\\\](?<name>[^/\\\\]*)+`,
+          `(${RegExp.escape(regexRepo)})(?<path>.*[/\\\\]${RegExp.escape(
+            this.metadata[this.type].directoryName
+          )})[/\\\\](?<name>[^/\\\\]*)+`,
           'u'
         )
       )
@@ -41,3 +45,5 @@ class InFolderHandler extends StandardHandler {
 
 InFolderHandler.INFOLDER_METAFILE_SUFFIX = `Folder${StandardHandler.METAFILE_SUFFIX}`
 module.exports = InFolderHandler
+
+RegExp.escape = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')


### PR DESCRIPTION
Use escaping function from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
And also check if repo is dot to not append it... If someone has a more elegant way to do it please rise your hand