### PR TITLE
Fix businessProcess metadata name

### DIFF
--- a/lib/metadata/a48.json
+++ b/lib/metadata/a48.json
@@ -161,8 +161,8 @@
     "directoryName": "businessProcesses",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "businessProcesse",
-    "xmlName": "BusinessProcesse"
+    "suffix": "businessProcess",
+    "xmlName": "BusinessProcess"
   },
   {
     "directoryName": "compactLayouts",

--- a/lib/metadata/v46.json
+++ b/lib/metadata/v46.json
@@ -154,8 +154,8 @@
     "directoryName": "businessProcesses",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "businessProcesse",
-    "xmlName": "BusinessProcesse"
+    "suffix": "businessProcess",
+    "xmlName": "BusinessProcess"
   },
   {
     "directoryName": "compactLayouts",


### PR DESCRIPTION
Fixing Typo (removing the extra "e" in businessProcess**e**)