### PR TITLE
Fix quick action generation in the package.xml

### DIFF
--- a/__tests__/unit/lib/service/standardHandler.test.js
+++ b/__tests__/unit/lib/service/standardHandler.test.js
@@ -10,6 +10,16 @@ const testContext = {
       'force-app/main/default/objects/Account/Account.object-meta.xml',
       new Set(['Account']),
     ],
+    [
+      'quickActions',
+      'force-app/main/default/quickActions/Account.New.quickAction-meta.xml',
+      new Set(['Account.New']),
+    ],
+    [
+      'quickActions',
+      'force-app/main/default/quickActions/NewGlobal.quickAction-meta.xml',
+      new Set(['NewGlobal']),
+    ],
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },

--- a/lib/service/inResourceHandler.js
+++ b/lib/service/inResourceHandler.js
@@ -51,6 +51,11 @@ class ResourceHandler extends StandardHandler {
       super.handleDeletion()
     }
   }
+
+  _getElementName() {
+    const parsedPath = this._getParsedPath()
+    return parsedPath.dir + parsedPath.name
+  }
 }
 
 module.exports = ResourceHandler

--- a/lib/service/standardHandler.js
+++ b/lib/service/standardHandler.js
@@ -63,7 +63,7 @@ class StandardHandler {
         .replace(`.${this.metadata[this.type].suffix}`, '')
     )
 
-    return parsedPath.dir + parsedPath.name
+    return parsedPath.dir + parsedPath.base
   }
 
   _fillPackage(packageObject) {

--- a/lib/service/standardHandler.js
+++ b/lib/service/standardHandler.js
@@ -56,13 +56,17 @@ class StandardHandler {
     this.handleAddition(this)
   }
 
-  _getElementName() {
+  _getParsedPath() {
     const parsedPath = path.parse(
       this.splittedLine[this.splittedLine.indexOf(this.type) + 1]
         .replace(StandardHandler.METAFILE_SUFFIX, '')
         .replace(`.${this.metadata[this.type].suffix}`, '')
     )
+    return parsedPath
+  }
 
+  _getElementName() {
+    const parsedPath = this._getParsedPath()
     return parsedPath.dir + parsedPath.base
   }
 


### PR DESCRIPTION
Improve the way to get the element name in order to build the member in the package.xml correctly depending the type of the element