### PR TITLE
Remove standardHelper deletion usage for inFile destructiveChanges building

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,164 @@
+# Contributing to SFDX-Git-Delta
+
+We encourage the developer community to contribute to this repository. This guide has instructions to install, build, test and contribute to the framework.
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Building LWC](#building-lwc)
+- [Testing](#testing)
+- [Git Workflow](#git-workflow)
+
+## Requirements
+
+- [Node](https://nodejs.org/) >= 10
+- [NPM](https://www.npmjs.com// >= 6.14
+
+## Installation
+
+### 1) Download the repository
+
+```bash
+git clone git@github.com:scolladon/sfdx-git-delta.git
+```
+
+### 2) Install Dependencies
+
+```bash
+npm install
+```
+
+## Testing
+
+### Unit Testing sgd
+
+When developing, utilize [jest](https://jestjs.io/en/) unit testing to provide test coverage for new functionality. To run the jest tests use the following command from the root directory:
+
+```bash
+npm run test
+```
+
+To execute a particular test, use the following command:
+
+```bash
+npm run test -- <path_to_test>
+```
+
+## Editor Configurations
+
+Configuring your editor to use our lint and code style rules will make the code review process delightful!
+
+### Code formatting
+
+[Prettier](https://prettier.io/) is a code formatter used to ensure consistent formatting across your code base. To use Prettier with Visual Studio Code, install [this extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) from the Visual Studio Code Marketplace. The [.prettierignore](/.prettierignore) and [.prettierrc](/.prettierrc.json) files are provided as part of this repository to control the behavior of the Prettier formatter.
+
+### Code linting
+
+[ESLint](https://eslint.org/) is a popular JavaScript linting tool used to identify stylistic errors and erroneous constructs. The [.eslintignore](/.eslintignore) file is provided as part of this repository to exclude specific files from the linting process.
+
+## Git Workflow
+
+The process of submitting a pull request is fairly straightforward and
+generally follows the same pattern each time:
+
+1. [Fork the LWC repo](#fork-the-lwc-repo)
+1. [Create a feature branch](#create-a-feature-branch)
+1. [Make your changes](#make-your-changes)
+1. [Rebase](#rebase)
+1. [Check your submission](#check-your-submission)
+1. [Create a pull request](#create-a-pull-request)
+1. [Update the pull request](#update-the-pull-request)
+
+### Fork the LWC repo
+
+[Fork][fork-a-repo] the [scolladon/sfdx-git-delta](https://github.com/scolladon/sfdx-git-delta) repo. Clone your fork in your local workspace and [configure][configuring-a-remote-for-a-fork] your remote repository settings.
+
+```bash
+git clone git@github.com:<YOUR-USERNAME>/sfdx-git-delta.git
+cd sfdx-git-delta
+git remote add upstream git@github.com:scolladon/sfdx-git-delta.git
+```
+
+### Create a feature branch
+
+```bash
+git checkout master
+git pull origin master
+git checkout -b feature/<name-of-the-feature>
+```
+
+### Make your changes
+
+Modify the files, build, test, lint and eventually commit your code using the following command:
+
+```bash
+git add <path/to/file/to/commit>
+git commit ...
+git push origin feature/<name-of-the-feature>
+```
+
+Commit your changes using a descriptive commit message
+
+The above commands will commit the files into your feature branch. You can keep
+pushing new changes into the same branch until you are ready to create a pull
+request.
+
+### Rebase
+
+Sometimes your feature branch will get stale with respect to the master branch,
+and it will require a rebase. The following steps can help:
+
+```bash
+git checkout master
+git pull upstream master
+git checkout feature/<name-of-the-feature>
+git rebase upstream/master
+```
+
+_note: If no conflicts arise, these commands will ensure that your changes are applied on top of the master branch. Any conflicts will have to be manually resolved._
+
+### Check your submission
+
+#### Lint your changes
+
+```bash
+npm run lint
+```
+
+The above command may display lint issues that are unrelated to your changes.
+The recommended way to avoid lint issues is to [configure your
+editor][eslint-integrations] to warn you in real time as you edit the file.
+
+Fixing all existing lint issues is a tedious task so please pitch in by fixing
+the ones related to the files you make changes to!
+
+#### Run tests
+
+Test your change by running the unit tests and integration tests. Instructions [here](#testing).
+
+### Create a pull request
+
+If you've never created a pull request before, follow [these
+instructions][creating-a-pull-request]. Pull request samples can be found [here](https://github.com/salesforce/lwc/pulls)
+
+### Update the pull request
+
+```sh
+git fetch origin
+git rebase origin/${base_branch}
+
+# If there were no merge conflicts in the rebase
+git push origin ${feature_branch}
+
+# If there was a merge conflict that was resolved
+git push origin ${feature_branch} --force
+```
+
+_note: If more changes are needed as part of the pull request, just keep committing and pushing your feature branch as described above and the pull request will automatically update._
+
+CI validates prettifying, linting and tests
+
+[fork-a-repo]: https://help.github.com/en/articles/fork-a-repo
+[configuring-a-remote-for-a-fork]: https://help.github.com/en/articles/configuring-a-remote-for-a-fork
+[setup-github-ssh]: https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/
+[creating-a-pull-request]: https://help.github.com/articles/creating-a-pull-request/
+[eslint-integrations]: http://eslint.org/docs/user-guide/integrations

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ _Content of the `package.xml` file in our scenario:_
 _Content of the `destructivePackage.xml` file in our scenario:_
 ![destructivePackage](/img/example_destructiveChange.png)
 
-
 In addition, we could also have generated a copy of the **force-app** folder with only the added and changed metadata, by using the `--generate-delta (-d)` option (more on that later).
 
 ### Deploy only the added/modified metadata:
@@ -176,8 +175,6 @@ In addition to the `package` and `destructiveChanges` folders, the `sgd` command
 _Content of the output folder when using the --generate-delta option, with the same scenario as above:_
 ![delta-source](/img/example_generateDelta.png)
 
-
-
 ## Javascript Module
 
 ```
@@ -215,6 +212,12 @@ console.log(JSON.stringify(work));
 
 - **Sebastien Colladon** - Developer - [scolladon](https://github.com/scolladon)
 - **Mehdi Cherfaoui** - Tester - [mehdisfdc](https://github.com/mehdisfdc)
+
+## Contributing
+
+Contributions are what make the trailblazer community such an amazing place. I regard this component as a way to inspire and learn from others. Any contributions you make are **greatly appreciated**.
+
+See [contributing.md](/CONTRIBUTING.md) for lwcc principles.
 
 ## License
 

--- a/__tests__/unit/lib/service/inFileHandler.test.js
+++ b/__tests__/unit/lib/service/inFileHandler.test.js
@@ -103,6 +103,9 @@ describe(`test if inFileHandler`, () => {
         expect(work.diffs.destructiveChanges).toMatchObject(
           testContext.expectedData[expectedType]
         )
+        expect(work.diffs.destructiveChanges).not.toHaveProperty('workflows')
+        expect(work.diffs.destructiveChanges).not.toHaveProperty('labels')
+        expect(work.diffs.destructiveChanges).not.toHaveProperty('sharingRules')
       })
       test('modification', () => {
         const work = {

--- a/lib/service/inFileHandler.js
+++ b/lib/service/inFileHandler.js
@@ -41,7 +41,6 @@ class InFileHandler extends StandardHandler {
   }
 
   handleDeletion() {
-    super.handleDeletion()
     this._handleInFile()
   }
 


### PR DESCRIPTION
## What does this pull request contains? Explain your changes.

---

- [ ] Added for new features.
- [x] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

Fix the building of the destructiveChanges.xml file for inFile metadata type (SharingRule, WorkflowRule and CustomLabel) when deleting the file.

The destructiveChanges contains also the metadata containing the inFile subtype which create an issue when deploying the destructiveChanges.xml.

We could have just kept the file deletion and not take care of the inFile but we decided to be more verbose and to delete explicitly what was tracked in the repository instead of the whole file. 

It allow to delete only what is tracked and so everything that should be in the file but are just in the org will not be deleted 

## Does this close any currently open issues?

---

#38 
- [ ] Jest test to check the fix is applied are added.

## Where has this been tested?

---

**Operating System:** Mac OS Mojave version 10.14.6

**NPM version:** 6.14.5

**Node version:** v14.5.0

**sgd version:** latest
