### PR TITLE
Bugfix/report types incorrect type handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 coverage
 output
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-node_modules
-coverage
-output
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 output
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+coverage
+output
+.idea

--- a/__tests__/unit/lib/service/typeHandlerFactory.test.js
+++ b/__tests__/unit/lib/service/typeHandlerFactory.test.js
@@ -30,7 +30,6 @@ describe('the type handler factory', () => {
         'fields',
         'listViews',
         'recordTypes',
-        'reportTypes',
         'sharingReasons',
         'validationRules',
         'webLinks',

--- a/lib/service/typeHandlerFactory.js
+++ b/lib/service/typeHandlerFactory.js
@@ -26,7 +26,6 @@ const classes = {
   objects: CustomObject,
   objectTranslations: InTranslation,
   recordTypes: SubCustomObject,
-  reportTypes: SubCustomObject,
   reports: InFolder,
   rules: SubCustomObject,
   sharingReasons: SubCustomObject,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains? Explain your changes.

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [x] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Set reportTypes to use standard handler as when generating the package.xml a report type comes out as default.Report_Type_Name - which won't deploy.

Added .idea into .gitignore to ignore JetBrain IDE settings. 

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->
no

- [ ] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

_(Write your answer here.)_

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

_(Write your answer here.)_

## Where has this been tested?

Tested on local box using sfdx cli after package generation. 
---

**Operating System:** …
windows 10/ wsl ubuntu 20.04
**NPM version:** …
6.14
**Node version:** …
14.9
**sgd version:** …
3.31
**git version:** …
2.17.1