### PR TITLE
Fix XML parsing strict behavior

### DIFF
--- a/lib/service/inFileHandler.js
+++ b/lib/service/inFileHandler.js
@@ -54,14 +54,17 @@ class InFileHandler extends StandardHandler {
     if (!this.config.generateDelta) return
     const result = this._parseFile()
     const metadataContent = Object.values(result.fileContent)[0]
-    result.authorizedKeys.forEach(
-      subType =>
-        (metadataContent[subType] = metadataContent[subType].filter(elem =>
-          toAdd[this.xmlObjectToPackageType[subType].directoryName]?.has(
-            elem.fullName
-          )
-        ))
-    )
+
+    result.authorizedKeys.forEach(subType => {
+      const meta = Array.isArray(metadataContent[subType])
+        ? metadataContent[subType]
+        : [metadataContent[subType]]
+      metadataContent[subType] = meta.filter(elem =>
+        toAdd[this.xmlObjectToPackageType[subType].directoryName]?.has(
+          elem.fullName
+        )
+      )
+    })
     const xmlBuilder = new fxp.j2xParser(JSON_PARSER_OPTION)
     const xmlContent = XML_HEADER + xmlBuilder.parse(result.fileContent)
     fse.outputFileSync(path.join(this.config.output, this.line), xmlContent)


### PR DESCRIPTION
Convert parsed XML to JSON array when it contains only one element

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains? Explain your changes.

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

XML to JSON converter create JSON object for element containing one element
The code execute on array so it needs to put json objet into an array   when subtype contains only one element

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

fix #54 

- [X] Jest test to check the fix is applied are added.

## Where has this been tested?

---

**Operating System:** Mac OS Mojave 10.14.6

**NPM version:** 6.14.8

**Node version:** v14.11.0

**sgd version:** 3.3.1

**git version:** 2.28.0
