### PR TITLE
Improve ignore parameter handling

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -22,15 +22,13 @@ program
     'source package specific output [./output]',
     './output'
   )
-  .option (
-    '-i, --ignore [file]',
-     'ignore file to use [./.forceignore]',
-     './.forceignore'
-  )
+  .option('-i, --ignore [file]', 'ignore file to use [./.forceignore]')
   .option('-a, --api-version [version]', 'salesforce API version [49]', '49')
   .option('-r, --repo [dir]', 'git repository location [./repo]', './repo')
   .option('-d, --generate-delta', 'generate delta files in [./output] folder')
   .parse(process.argv)
+
+program.ignore = program.ignore === true ? './.forceignore' : program.ignore
 
 const output = {
   error: null,


### PR DESCRIPTION
## What does this pull request contains? Explain your changes.

---

- [ ] Added for new features.
- [X] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---
Before today -i parameter was handled this way: 
- -i not set => ignore with default ./.forceignore
- -i set => ignore with default ./.forceignore
- -i set with value => ignore with value

Here are the changes on the way the -i parameter is handled
- -i not set => **do not ignore**
- -i set => ignore with default ./.forceignore
- -i set with value => ignore with value


## Where has this been tested?

---

**Operating System:** Mac OS Mojave 10.14.6

**NPM version:** 6.14.8

**Node version:** v14.11.0

**sgd version:** 3.3.1

**git version:** 2.28.0
