### PR TITLE
Output consistency

### DIFF
--- a/__tests__/unit/lib/packageConstructor.test.js
+++ b/__tests__/unit/lib/packageConstructor.test.js
@@ -35,6 +35,10 @@ const tests = [
     `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
+        <members>Object</members>
+        <name>CustomObject</name>
+    </types>
+    <types>
         <members>Dashboard</members>
         <name>Dashboard</name>
     </types>
@@ -49,10 +53,6 @@ const tests = [
     <types>
         <members>Component</members>
         <name>LightningComponentBundle</name>
-    </types>
-    <types>
-        <members>Object</members>
-        <name>CustomObject</name>
     </types>
     <version>${options.apiVersion}.0</version>
 </Package>`,

--- a/bin/cli
+++ b/bin/cli
@@ -34,7 +34,7 @@ const output = {
   error: null,
   output: program.output,
   success: true,
-  warnings: null,
+  warnings: [],
 }
 try {
   const jobResult = orchestrator(program)

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -31,7 +31,7 @@ export default class SourceDeltaGenerate extends SfdxCommand {
         error: null,
         output: this.flags.output,
         success: true,
-        warnings: null
+        warnings: []
       };
       try {
         const jobResult = sgd({

--- a/src/utils/packageConstructor.js
+++ b/src/utils/packageConstructor.js
@@ -23,6 +23,8 @@ module.exports = class PackageConstructor {
           type.startsWith(mc.WAVE_SUB_TYPES_PREFIX)
       )
       .sort()
+      // @deprecated To remove when the order will not impact the result of the deployment
+      .sort((x, y) => (x === 'objects' ? -1 : x.localeCompare(y)))
       .forEach(metadataType =>
         [...strucDiffPerType[metadataType]] // transform set to array
           .reduce((type, member) => {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains? Explain your changes.

This Pull Request allow to have output attribute always set in a consistant manner


   | Target Success | Target Failure
  -- | -- | --
error |  null | error message
output | program.output | program.output
success | TRUE | FALSE
warning | [warning messages] | []

Also put CustomObject type at the top of the {package|destructiveChanges}.xml

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [X] Changed for changes in existing functionality.
- [X] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Fix the initial value for the warning attributes in the cli file and sfdx plugin file
Create custom sort to move 'CustomObject' type on top of the type list

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

fixes #74 

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

_(Write your answer here.)_

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

_(Write your answer here.)_

## Where has this been tested?

---

**Operating System:** Mac Mojave 10.14.6

**Yarn version:** 1.22.10

**Node version:** v15.2.1

**sgd version:** 4.0.3

**git version:** 2.29.2
