### PR TITLE
Fixed file and folder name on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Generate the sfdx content in source format and destructive change from two git c
 **SFDX-Git-Delta** (\*a.k.a. **SGD\***) helps Salesforce Architects and Developers accomplish 2 things with their source deployments:
 
 1. **Make deployments faster**, by identifying the metadata that has been changed since a reference commit.
-2. **Automate destructive deployments**, by listing the deleted (or renamed) metadata in a destructivePackage.xml
+2. **Automate destructive deployments**, by listing the deleted (or renamed) metadata in a destructiveChanges.xml
 
 ## Is SGD for you?
 
@@ -136,15 +136,15 @@ which means:
 
 The `sfdx sgd:source:delta` command produces 2 usefull artefacts:
 
-**1) A `package.xml` file, inside a `package` folder.** This package.xml file contains only the metadata that has been added and changed, and that needs to be deployed in the target org.
+**1) A `package.xml` file, inside a `package` folder.** This `package.xml` file contains only the metadata that has been added and changed, and that needs to be deployed in the target org.
 
 _Content of the `package.xml` file in our scenario:_
 ![package](/img/example_package.png)
 
-**2) A `destructivePackage.xml` file, inside a `destructivePackage` folder.** This destructivePackage.xml file contains only the metadata that has been removed or renamed, and that needs to be deleted from the target org. Note: the `destructivePackage` folder also contains a minimal package.xml file because deploying destructive changes requires a package.xml (even an empty one) in the payload.
+**2) A `destructiveChanges.xml` file, inside a `destructiveChanges` folder.** This `destructiveChanges.xml` file contains only the metadata that has been removed or renamed, and that needs to be deleted from the target org. Note: the `destructiveChanges` folder also contains a minimal package.xml file because deploying destructive changes requires a package.xml (even an empty one) in the payload.
 
-_Content of the `destructivePackage.xml` file in our scenario:_
-![destructivePackage](/img/example_destructiveChange.png)
+_Content of the `destructiveChanges.xml` file in our scenario:_
+![destructiveChange](/img/example_destructiveChange.png)
 
 In addition, we could also have generated a copy of the **force-app** folder with only the added and changed metadata, by using the `--generate-delta (-d)` option (more on that later).
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains? Explain your changes.

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

This is only a documentation update. This pull request doesn't change the functionality for this plugin.

The correct name of the XML file which contains the deleted metadata is `destructiveChanges.xml` and the correct name of folder which contains this XML file is `destructiveChanges`.

## Does this close any currently open issues?

---

No.

- [ ] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

N/A

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

N/A

## Where has this been tested?

---

**Operating System:** macOS Big Sur (11.0.1)

**Yarn version:** N/A

**Node version:** v12.14.0

**sgd version:** N/A

**git version:** 2.27.0
