### PR TITLE
Update link to example Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ sfdx plugins:install sfdx-git-delta
 
 Because this plugin is not signed, you will get a warning saying that "This plugin is not digitally signed and its authenticity cannot be verified". This is expected, and you will have to answer `y` (yes) to proceed with the installation.
 
-If you run your CI/CD jobs inside a Docker image, you can add the plugin to your image, such as in this example: https://hub.docker.com/r/mehdisfdc/sfdx-cli-gitlab/dockerfile
+If you run your CI/CD jobs inside a Docker image, you can add the plugin to your image. Here is an example of a Dockerfile including the SGD plugin: https://github.com/mehdisfdc/sfdx-cli-gitlab
 
 To view the full list and description of the sgd options, run `sfdx sgd:source:delta --help`
 


### PR DESCRIPTION
Updating the readme to point to the repo with the following disclaimer (rather than pointing to the Dockerfile directly):

_"Please do not reference the mehdisfdc/sfdx-cli-gitlab image on your CI/CD pipeline, since this image may change at any time (which could break your pipeline).
If you are interested in using this image, please clone this repo and then create your own public image on https://hub.docker.com/ (it's free and easy, as of early 2021)."_