### PR TITLE
Fix/moved metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,11 +1,10 @@
 ---
 name: Enhancement request
 about: Use this template for tracking new features.
-title: "[FEATURE NAME]"
+title: '[FEATURE NAME]'
 labels: enhancement
 assignees: scolladon
 ---
-
 
 ### Is your proposal related to a problem?
 
@@ -16,8 +15,6 @@ assignees: scolladon
   For example, "I'm always frustrated when..."
 -->
 
-_(Write your answer here.)_
-
 ### Describe the solution you'd like
 
 ---
@@ -25,8 +22,6 @@ _(Write your answer here.)_
 <!--
   Provide a clear and concise description of what you want to happen.
 -->
-
-(Describe your proposed solution here.)
 
 ### Describe alternatives you've considered
 
@@ -36,8 +31,6 @@ _(Write your answer here.)_
   Let us know about other solutions you've tried or researched.
 -->
 
-_(Write your answer here.)_
-
 ### Additional context
 
 ---
@@ -46,5 +39,3 @@ _(Write your answer here.)_
   Is there anything else you can add about the proposal?
   You might want to link to related issues here, if you haven't already.
 -->
-
-_(Write your answer here.)_

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -18,16 +18,12 @@ Issue verification check :
   Provide a clear and concise description of what the problem is.
 -->
 
-_(Write your answer here.)_
-
 ### What is parameter and their value you used
 
 <!--
   Provide the command you used and the parameters
   Ex : $ sgd -r . -f HEAD^
 -->
-
-_(Write your answer here.)_
 
 ### What is the expected result
 
@@ -36,16 +32,12 @@ _(Write your answer here.)_
   Provide the expected content of the output folder
 -->
 
-_(Write your answer here.)_
-
 ### What is the actual result
 
 <!--
   Provide the actual output of the command
   Provide the actual content of the output folder
 -->
-
-_(Write your answer here.)_
 
 ## Steps to reproduce
 
@@ -59,8 +51,6 @@ _(Write your answer here.)_
   https://github.com/<gh-username>/<sgd-issue-reproducible-repo-name>
   sgd -d -r . -f HEAD^
 -->
-
-_(Write your answer here.)_
 
 ## Execution context
 
@@ -87,10 +77,8 @@ $ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
 ---
 
 <!--
-  Provide the output of those command line if allowed :
+  Provide the output of those command line :
   $ git diff --name-status --no-renames <from> <to>
   And for each SharingRule, WorkflowRule and CustomLabel files :
   $ git diff --no-prefix <from> <to> -- <file-path>
 -->
-
-_(Write your answer here.)_

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,8 +25,6 @@ Thanks for sending a pull request! Please make sure you click the link above to 
   Describe with your own words the content of the Pull Request
 -->
 
-_(Write your answer here.)_
-
 ## Does this close any currently open issues?
 
 ---
@@ -36,7 +34,7 @@ _(Write your answer here.)_
   EX : #<issue-number>
 -->
 
-_(Write your answer here.)_
+closes #
 
 - [ ] Jest test to check the fix is applied are added.
 
@@ -48,8 +46,6 @@ _(Write your answer here.)_
   Provide any new parameters or behaviour with current parameters
 -->
 
-_(Write your answer here.)_
-
 ## Any other comments?
 
 ---
@@ -60,8 +56,6 @@ _(Write your answer here.)_
   Target Release
   ...
 -->
-
-_(Write your answer here.)_
 
 ## Where has this been tested?
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ Windows is not tested.
 
 Git command line is required on the system where the command line is running.
 
-**Node v14.6.0 or above is required**. 
-To make sure that the Salesforce CLI is using the expected node version for SGD, run `sfdx --version` before attempting to install the SGD plugin: if you see a node version below v14.6.0 in the output, you'll need to fix it first. 
+**Node v14.6.0 or above is required**.
+To make sure that the Salesforce CLI is using the expected node version for SGD, run `sfdx --version` before attempting to install the SGD plugin: if you see a node version below v14.6.0 in the output, you'll need to fix it first.
 If you encounter this issue while having installed the correct version of node on your system, try to [install the Salesforce CLI via npm](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm#sfdx_setup_install_cli_npm) (`npm install sfdx-cli --global`) rather than with another installer.
 
 ## How to use it?
@@ -186,20 +186,72 @@ Here are 3 examples showing how you can compare the content of different branche
 
 **1) Comparing between commits in different branches**
 For example, if you have commit `fbc3ade6` in branch `develop` and commit `61f235b1` in branch `master`:
+
 ```
 sfdx sgd:source:delta --to fbc3ade6 --from 61f235b1 --output .
 ```
 
 **2) Comparing branches (all changes)**
-Comparing all changes between the `develop` branch and the `master` branch: 
+Comparing all changes between the `develop` branch and the `master` branch:
+
 ```
 sfdx sgd:source:delta --to develop --from master --output .
 ```
 
 **3) Comparing branches (from a common ancestor)**
-Comparing changes performed in the `develop` branch since its common ancestor with the `master` branch (i.e. ignoring the changes performed in the `master` branch after `develop` was created): 
+Comparing changes performed in the `develop` branch since its common ancestor with the `master` branch (i.e. ignoring the changes performed in the `master` branch after `develop` was created):
+
 ```
 sfdx sgd:source:delta --to develop --from $(git merge-base develop master) --output .
+```
+
+### Renaming and Moving use cases
+
+Because the metadata is based on the name of the elements SGD will generate an entry for both package/package.xml and destructiveChanges/destructiveChanges.xml When renaming a metadata component.
+This will allow you to create the new component and delete the old one, avoiding duplicates at the same time. We leverage the `--no-renames` git parameters to treat those use cases atomically
+
+Ex : A force-app/main/default/AccountTest.cls -> D force-app/main/default/Account_Test.cls
+
+```xml
+<!-- package/package.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>AccountTest</members>
+        <name>ApexClass</name>
+    </types>
+    <version>50.0</version>
+</Package>
+
+<!-- destructiveChanges/destructiveChanges.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Account_Test</members>
+        <name>ApexClass</name>
+    </types>
+    <version>50.0</version>
+</Package>
+```
+
+Git deal with path changing like a renaming when using the `--no-renames` git parameters, even if the file content has been changed in the process.
+In order to deal with that, the plugin generates an entry only in the package.xml when detecting a path change.
+This allow to move files in different file structure, change them and detect delta using the plugin.
+The drawback is when a file is moved and not changed it will be putted in the package.xml anyway. For sharing rules and workflow it means the whole content will be redeployed.
+Currently there is no change detection in file to exclude unchanged files and address this drawback.
+
+Ex : A force-app/domain/Account/AccountTest.cls -> D force-app/main/default/AccountTest.cls
+
+```xml
+<!-- package/package.xml -->
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>AccountTest</members>
+        <name>ApexClass</name>
+    </types>
+    <version>50.0</version>
+</Package>
 ```
 
 ### Advanced use-case: Generating a folder containing only the added/modified sources
@@ -222,11 +274,10 @@ In addition to the `package` and `destructiveChanges` folders, the `sfdx sgd:sou
 _Content of the output folder when using the --generate-delta option, with the same scenario as above:_
 ![delta-source](/img/example_generateDelta.png)
 
-
 ## Javascript Module
 
 ```js
-var sgd = require('sfdx-git-delta')
+const sgd = require('sfdx-git-delta')
 
 const work = sgd({
   to: '', // commit sha to where the diff is done. Default : HEAD
@@ -257,7 +308,7 @@ console.log(JSON.stringify(work))
 
 [SemVer](http://semver.org/) is used for versioning.
 
-## Authors [![Join the chat at https://gitter.im/scolladon/sfdx-git-delta](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/dwyl/?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+## Authors [![Join the chat at https://gitter.im/sfdx-git-delta/community](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sfdx-git-delta/community)
 
 - **Sebastien Colladon** - Developer - [scolladon](https://github.com/scolladon)
 - **Mehdi Cherfaoui** - Tester - [mehdisfdc](https://github.com/mehdisfdc)

--- a/README.md
+++ b/README.md
@@ -205,55 +205,6 @@ Comparing changes performed in the `develop` branch since its common ancestor wi
 sfdx sgd:source:delta --to develop --from $(git merge-base develop master) --output .
 ```
 
-### Renaming and Moving use cases
-
-Because the metadata is based on the name of the elements SGD will generate an entry for both package/package.xml and destructiveChanges/destructiveChanges.xml When renaming a metadata component.
-This will allow you to create the new component and delete the old one, avoiding duplicates at the same time. We leverage the `--no-renames` git parameters to treat those use cases atomically
-
-Ex : A force-app/main/default/AccountTest.cls -> D force-app/main/default/Account_Test.cls
-
-```xml
-<!-- package/package.xml -->
-<?xml version="1.0" encoding="UTF-8"?>
-<Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <types>
-        <members>AccountTest</members>
-        <name>ApexClass</name>
-    </types>
-    <version>50.0</version>
-</Package>
-
-<!-- destructiveChanges/destructiveChanges.xml -->
-<?xml version="1.0" encoding="UTF-8"?>
-<Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <types>
-        <members>Account_Test</members>
-        <name>ApexClass</name>
-    </types>
-    <version>50.0</version>
-</Package>
-```
-
-Git deal with path changing like a renaming when using the `--no-renames` git parameters, even if the file content has been changed in the process.
-In order to deal with that, the plugin generates an entry only in the package.xml when detecting a path change.
-This allow to move files in different file structure, change them and detect delta using the plugin.
-The drawback is when a file is moved and not changed it will be putted in the package.xml anyway. For sharing rules and workflow it means the whole content will be redeployed.
-Currently there is no change detection in file to exclude unchanged files and address this drawback.
-
-Ex : A force-app/domain/Account/AccountTest.cls -> D force-app/main/default/AccountTest.cls
-
-```xml
-<!-- package/package.xml -->
-<?xml version="1.0" encoding="UTF-8"?>
-<Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <types>
-        <members>AccountTest</members>
-        <name>ApexClass</name>
-    </types>
-    <version>50.0</version>
-</Package>
-```
-
 ### Advanced use-case: Generating a folder containing only the added/modified sources
 
 Using a package.xml file to deploy a subset of the metadata is propably the simpliest approach to delta deployments. But there are some situations where you may want to have the actual source files related to all the components that have been changed recently.

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -1,4 +1,5 @@
 'use strict'
+const os = require('os')
 const repoGitDiff = require('../../../../src/utils/repoGitDiff')
 const child_process = require('child_process')
 jest.mock('child_process', () => ({ spawnSync: jest.fn() }))
@@ -86,6 +87,24 @@ describe(`test if repoGitDiff`, () => {
     )
     //should be empty
     const expected = []
+    expect(work).toStrictEqual(expected)
+  })
+
+  test('can filter moved files', () => {
+    const output = [
+      'D      force-app/main/default/pages/Account.page',
+      'A      force-app/account/domain/pages/Account.page',
+    ]
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: output.join(os.EOL),
+    }))
+    const work = repoGitDiff(
+      { output: '', repo: '' },
+      // eslint-disable-next-line no-undef
+      globalMetadata
+    )
+    //should be empty
+    const expected = [output[1]]
     expect(work).toStrictEqual(expected)
   })
 

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -92,8 +92,8 @@ describe(`test if repoGitDiff`, () => {
 
   test('can filter moved files', () => {
     const output = [
-      'D      force-app/main/default/pages/Account.page',
-      'A      force-app/account/domain/pages/Account.page',
+      'D      force-app/main/default/classes/Account.cls',
+      'A      force-app/account/domain/classes/Account.cls',
     ]
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output.join(os.EOL),
@@ -103,9 +103,24 @@ describe(`test if repoGitDiff`, () => {
       // eslint-disable-next-line no-undef
       globalMetadata
     )
-    //should be empty
     const expected = [output[1]]
     expect(work).toStrictEqual(expected)
+  })
+
+  test('cannot filter renamed files', () => {
+    const output = [
+      'D      force-app/main/default/classes/Account.cls',
+      'A      force-app/main/default/classes/RenamedAccount.cls',
+    ]
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: output.join(os.EOL),
+    }))
+    const work = repoGitDiff(
+      { output: '', repo: '' },
+      // eslint-disable-next-line no-undef
+      globalMetadata
+    )
+    expect(work).toStrictEqual(output)
   })
 
   test('can reject in case of error', () => {

--- a/src/service/inFileHandler.js
+++ b/src/service/inFileHandler.js
@@ -3,7 +3,6 @@ const fileGitDiff = require('../utils/fileGitDiff')
 const gc = require('../utils/gitConstants')
 const mc = require('../utils/metadataConstants')
 const StandardHandler = require('./standardHandler')
-const fs = require('fs')
 const fse = require('fs-extra')
 const os = require('os')
 const path = require('path')
@@ -123,10 +122,7 @@ class InFileHandler extends StandardHandler {
   }
 
   _parseFile() {
-    const xmlData = fs.readFileSync(path.join(this.config.repo, this.line), {
-      encoding: gc.UTF8_ENCODING,
-    })
-    const result = fxp.parse(xmlData, XML_PARSER_OPTION)
+    const result = fxp.parse(this._readFileSync(), XML_PARSER_OPTION)
     const authorizedKeys = Object.keys(Object.values(result)[0]).filter(x =>
       Object.prototype.hasOwnProperty.call(this.xmlObjectToPackageType, x)
     )

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -1,4 +1,5 @@
 'use strict'
+const fs = require('fs')
 const path = require('path')
 const fse = require('fs-extra')
 const gc = require('../utils/gitConstants')
@@ -94,6 +95,12 @@ class StandardHandler {
     if (fse.pathExistsSync(src)) {
       fse.copySync(src, dst, FSE_COPYSYNC_OPTION)
     }
+  }
+
+  _readFileSync() {
+    return fs.readFileSync(path.join(this.config.repo, this.line), {
+      encoding: gc.UTF8_ENCODING,
+    })
   }
 }
 

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -1,6 +1,7 @@
 'use strict'
 const path = require('path')
 const fse = require('fs-extra')
+const gc = require('../utils/gitConstants')
 const mc = require('../utils/metadataConstants')
 
 const FSE_COPYSYNC_OPTION = {
@@ -13,7 +14,7 @@ const FSE_COPYSYNC_OPTION = {
 class StandardHandler {
   constructor(line, type, work, metadata) {
     ;[this.changeType] = line
-    this.line = line.replace(/^.\s+/u, '')
+    this.line = line.replace(gc.GIT_DIFF_TYPE_REGEX, '')
     this.type = type
     this.diffs = work.diffs
     this.config = work.config

--- a/src/service/subCustomObjectHandler.js
+++ b/src/service/subCustomObjectHandler.js
@@ -1,9 +1,7 @@
 'use strict'
 const StandardHandler = require('./standardHandler')
-const gc = require('../utils/gitConstants')
 const mc = require('../utils/metadataConstants')
 const path = require('path')
-const fs = require('fs')
 
 class SubCustomObjectHandler extends StandardHandler {
   handleDeletion() {
@@ -14,9 +12,7 @@ class SubCustomObjectHandler extends StandardHandler {
     super.handleAddition()
     if (!this.config.generateDelta) return
 
-    const data = fs.readFileSync(path.join(this.config.repo, this.line), {
-      encoding: gc.UTF8_ENCODING,
-    })
+    const data = this._readFileSync()
     if (data?.includes(mc.MASTER_DETAIL_TAG)) {
       const customObjectDirPath = this.splittedLine
         .slice(0, [this.splittedLine.indexOf(this.type)])

--- a/src/utils/gitConstants.js
+++ b/src/utils/gitConstants.js
@@ -1,4 +1,7 @@
 'use strict'
-module.exports.UTF8_ENCODING = 'utf8'
-module.exports.PLUS = '+'
+module.exports.ADDITION = 'A'
+module.exports.DELETION = 'D'
+module.exports.GIT_DIFF_TYPE_REGEX = /^.\s+/u
 module.exports.MINUS = '-'
+module.exports.PLUS = '+'
+module.exports.UTF8_ENCODING = 'utf8'


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains? Explain your changes.

---

<!--
  Check all that apply
-->

- [X] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Because the metadata is based on the name of the elements SGD will generate an entry for both package/package.xml and destructiveChanges/destructiveChanges.xml When renaming a metadata component.
This will allow you to create the new component and delete the old one, avoiding duplicates at the same time. We leverage the `--no-renames` git parameters to treat those use cases atomically

Ex : A force-app/main/default/AccountTest.cls -> D force-app/main/default/Account_Test.cls

```xml
<!-- package/package.xml -->
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <types>
        <members>AccountTest</members>
        <name>ApexClass</name>
    </types>
    <version>50.0</version>
</Package>

<!-- destructiveChanges/destructiveChanges.xml -->
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <types>
        <members>Account_Test</members>
        <name>ApexClass</name>
    </types>
    <version>50.0</version>
</Package>
```

Git deal with path changing like a renaming when using the `--no-renames` git parameters, even if the file content has been changed in the process.
In order to deal with that, the plugin generates an entry only in the package.xml when detecting a path change.
This allow to move files in different file structure, change them and detect delta using the plugin.
The drawback is when a file is moved and not changed it will be putted in the package.xml anyway. For sharing rules and workflow it means the whole content will be redeployed.
Currently there is no change detection in file to exclude unchanged files and address this drawback.

Ex : A force-app/domain/Account/AccountTest.cls -> D force-app/main/default/AccountTest.cls

```xml
<!-- package/package.xml -->
<?xml version="1.0" encoding="UTF-8"?>
<Package xmlns="http://soap.sforce.com/2006/04/metadata">
    <types>
        <members>AccountTest</members>
        <name>ApexClass</name>
    </types>
    <version>50.0</version>
</Package>
```

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #107 
- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

Rename a metadata component
Move a metadata component
Run the plugin and see the package.xml and destructiveChanges.xml files


## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 18.7.0: Tue Jan 12 22:04:47 PST 2021; root:xnu-4903.278.56~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v15.10.0

**git version:** 2.30.1

**sfdx version:** sfdx-cli/7.89.2 darwin-x64 node-v15.10.0

**sgd plugin version:** sfdx-git-delta 4.2.1
