### PR TITLE
Make sure destructiveChanges.xml does not contains package.xml element

### DIFF
--- a/__tests__/functional.test.js
+++ b/__tests__/functional.test.js
@@ -27,6 +27,7 @@ const lines = [
   'D      force-app/main/default/staticressources/Added/deleted.png',
   'A      force-app/main/default/documents/Added/doc.document',
   'A      force-app/main/default/lwc/Added/component.js`',
+  'D      force-app/main/sample/objects/Account/fields/changed.field-meta.xml',
 ]
 
 describe(`test if the appli`, () => {
@@ -64,5 +65,23 @@ describe(`test if the appli`, () => {
         generateDelta: true,
       }).warnings
     ).not.toHaveLength(0)
+  })
+
+  test('do not generate destructiveChanges.xml and package.xml with same element', () => {
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: lines.join(os.EOL),
+    }))
+    const work = app({
+      output: 'output',
+      repo: '',
+      to: 'test',
+      apiVersion: '46',
+      generateDelta: true,
+    })
+
+    expect(work.diffs.package.fields).toContain('Account.changed')
+    expect(work.diffs.destructiveChanges.fields).not.toContain(
+      'Account.changed'
+    )
   })
 })

--- a/src/main.js
+++ b/src/main.js
@@ -69,6 +69,7 @@ const treatDiff = (config, lines, metadata) => {
 }
 
 const treatPackages = (dcJson, config, metadata) => {
+  cleanPackages(dcJson)
   const pc = new PackageConstructor(config, metadata)
   ;[
     {
@@ -90,4 +91,17 @@ const treatPackages = (dcJson, config, metadata) => {
     const location = path.join(config.output, op.folder, op.filename)
     fse.outputFileSync(location, op.xmlContent)
   })
+}
+
+const cleanPackages = dcJson => {
+  const additive = dcJson[PACKAGE_FILE_NAME]
+  const destructive = dcJson[DESTRUCTIVE_CHANGES_FILE_NAME]
+  Object.keys(additive)
+    .filter(type => Object.prototype.hasOwnProperty.call(destructive, type))
+    .forEach(
+      type =>
+        (destructive[type] = new Set(
+          [...destructive[type]].filter(element => !additive[type].has(element))
+        ))
+    )
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains? Explain your changes.

---

<!--
  Check all that apply
-->

- [X] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Implement a post processing filtering to exclude element in
destructiveChanges.xml also present in package.xml

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #111

- [X] Jest test to check the fix is applied are added.

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 18.7.0: Tue Jan 12 22:04:47 PST 2021; root:xnu-4903.278.56~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v15.12.0

**git version:** 2.31.0

**sfdx version:** sfdx-cli/7.93.1 darwin-x64 node-v15.12.0

**sgd plugin version:** sfdx-git-delta 4.2.3
