### PR TITLE
fix: use "/" for package member separator

### DIFF
--- a/__tests__/unit/lib/service/standardHandler.test.js
+++ b/__tests__/unit/lib/service/standardHandler.test.js
@@ -1,5 +1,6 @@
 'use strict'
 const StandardHandler = require('../../../../src/service/standardHandler')
+const mc = require('../../../../src/utils/metadataConstants')
 jest.mock('fs')
 
 const testContext = {
@@ -88,11 +89,19 @@ test('do not handle not ADM line', () => {
 
 test('do not handle treat meta file metadata non ending with meta suffix', () => {
   const handler = new testContext.handler(
-    `D       force-app/main/default/staticresources/test.resource${StandardHandler.METAFILE_SUFFIX}`,
+    `D       force-app/main/default/staticresources/test.resource${mc.METAFILE_SUFFIX}`,
     'staticresources',
     testContext.work,
     // eslint-disable-next-line no-undef
     globalMetadata
   )
   handler.handle()
+})
+
+test(`package member path delimiter is "${StandardHandler.PACKAGE_MEMBER_PATH_SEP}"`, () => {
+  expect(
+    StandardHandler.cleanUpPackageMember(`Package\\Member`).split(
+      StandardHandler.PACKAGE_MEMBER_PATH_SEP
+    ).length
+  ).toBe(2)
 })

--- a/src/service/inFileHandler.js
+++ b/src/service/inFileHandler.js
@@ -142,7 +142,9 @@ class InFileHandler extends StandardHandler {
     }`
 
     packageObject[subType] = packageObject[subType] ?? new Set()
-    packageObject[subType].add(elementFullName)
+    packageObject[subType].add(
+      StandardHandler.cleanUpPackageMember(elementFullName)
+    )
   }
 }
 

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -40,13 +40,15 @@ class InFolderHandler extends StandardHandler {
   _fillPackage(packageObject) {
     packageObject[this.type] = packageObject[this.type] ?? new Set()
 
+    const packageMember = this.splittedLine
+      .slice(this.splittedLine.indexOf(this.type) + 1)
+      .join(path.sep)
+      .replace(mc.META_REGEX, '')
+      .replace(INFOLDER_SUFFIX_REGEX, '')
+      .replace(this.suffixRegex, '')
+
     packageObject[this.type].add(
-      this.splittedLine
-        .slice(this.splittedLine.indexOf(this.type) + 1)
-        .join(path.sep)
-        .replace(mc.META_REGEX, '')
-        .replace(INFOLDER_SUFFIX_REGEX, '')
-        .replace(this.suffixRegex, '')
+      StandardHandler.cleanUpPackageMember(packageMember)
     )
   }
 }

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -55,7 +55,7 @@ class ResourceHandler extends StandardHandler {
 
   _getElementName() {
     const parsedPath = this._getParsedPath()
-    return parsedPath.name
+    return StandardHandler.cleanUpPackageMember(parsedPath.name)
   }
 
   _getParsedPath() {

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -5,6 +5,8 @@ const fse = require('fs-extra')
 const gc = require('../utils/gitConstants')
 const mc = require('../utils/metadataConstants')
 
+const PACKAGE_MEMBER_PATH_SEP = '/'
+
 const FSE_COPYSYNC_OPTION = {
   overwrite: true,
   errorOnExist: false,
@@ -83,7 +85,7 @@ class StandardHandler {
 
   _getElementName() {
     const parsedPath = this._getParsedPath()
-    return parsedPath.base
+    return StandardHandler.cleanUpPackageMember(parsedPath.base)
   }
 
   _fillPackage(packageObject) {
@@ -102,6 +104,11 @@ class StandardHandler {
       encoding: gc.UTF8_ENCODING,
     })
   }
+
+  static cleanUpPackageMember(packageMember) {
+    return `${packageMember}`.replace(/\\+/g, PACKAGE_MEMBER_PATH_SEP)
+  }
 }
 
+StandardHandler.PACKAGE_MEMBER_PATH_SEP = PACKAGE_MEMBER_PATH_SEP
 module.exports = StandardHandler


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains? Explain your changes.

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Add a method to treat package member
Make sure path separator for those member is "/" whatever the path separator is for the running architecture (POSIX or WIN)

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #127

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

The best is to do integration testing using Windows OS

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Should be included in the next minor/patch release

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 18.7.0: Tue Jan 12 22:04:47 PST 2021; root:xnu-4903.278.56~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v14.16.0

**git version:** git version 2.31.1

**sfdx version:** node-v14.16.0

**sgd plugin version:** sfdx-git-delta 4.3.1
