### PR TITLE
fix: document extension handling

### DIFF
--- a/__tests__/__utils__/testHandlerHelper.js
+++ b/__tests__/__utils__/testHandlerHelper.js
@@ -20,6 +20,10 @@ global.testHandlerHelper = testContext => {
             globalMetadata
           )
           handler.handle()
+          expect(testContext.work.diffs.package).toHaveProperty(
+            expectedType ?? type,
+            expected
+          )
         })
         test('deletion', () => {
           const handler = new testContext.handler(
@@ -44,6 +48,10 @@ global.testHandlerHelper = testContext => {
             globalMetadata
           )
           handler.handle()
+          expect(testContext.work.diffs.package).toHaveProperty(
+            expectedType ?? type,
+            expected
+          )
         })
       }
     )

--- a/__tests__/unit/lib/service/inFolderHandler.test.js
+++ b/__tests__/unit/lib/service/inFolderHandler.test.js
@@ -15,6 +15,21 @@ const testContext = {
       'force-app/main/default/reports/folder.reportFolder-meta.xml',
       new Set(['folder']),
     ],
+    [
+      'documents',
+      'force-app/main/default/documents/folder.documentFolder-meta.xml',
+      new Set(['folder']),
+    ],
+    [
+      'documents',
+      'force-app/main/default/documents/folder/document.ext',
+      new Set(['folder/document']),
+    ],
+    [
+      'documents',
+      'force-app/main/default/documents/folder/document.document-meta.xml',
+      new Set(['folder/document']),
+    ],
   ],
   work: {
     config: { output: '', repo: '.', generateDelta: true },

--- a/__tests__/unit/lib/service/inFolderHandler.test.js
+++ b/__tests__/unit/lib/service/inFolderHandler.test.js
@@ -22,13 +22,13 @@ const testContext = {
     ],
     [
       'documents',
-      'force-app/main/default/documents/folder/document.ext',
-      new Set(['folder/document']),
+      'force-app/main/default/documents/folder/document.test.ext',
+      new Set(['folder/document.test']),
     ],
     [
       'documents',
-      'force-app/main/default/documents/folder/document.document-meta.xml',
-      new Set(['folder/document']),
+      'force-app/main/default/documents/folder/document.test.document-meta.xml',
+      new Set(['folder/document.test']),
     ],
   ],
   work: {

--- a/src/metadata/a48.json
+++ b/src/metadata/a48.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/metadata/v46.json
+++ b/src/metadata/v46.json
@@ -259,6 +259,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {
@@ -569,7 +570,10 @@
     "xmlName": "ContentAsset"
   },
   {
-    "childXmlNames": ["SharingOwnerRule", "SharingCriteriaRule"],
+    "childXmlNames": [
+      "SharingOwnerRule",
+      "SharingCriteriaRule"
+    ],
     "directoryName": "sharingRules",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v47.json
+++ b/src/metadata/v47.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/metadata/v49.json
+++ b/src/metadata/v49.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -5,10 +5,6 @@ const path = require('path')
 
 const INFOLDER_SUFFIX_REGEX = new RegExp(`${mc.INFOLDER_SUFFIX}$`)
 class InFolderHandler extends StandardHandler {
-  handleDeletion() {
-    this._fillPackage(this.diffs.destructiveChanges)
-  }
-
   handleAddition() {
     super.handleAddition()
     if (!this.config.generateDelta) return

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -4,6 +4,7 @@ const mc = require('../utils/metadataConstants')
 const path = require('path')
 
 const INFOLDER_SUFFIX_REGEX = new RegExp(`${mc.INFOLDER_SUFFIX}$`)
+const EXTENSION_SUFFIX_REGEX = new RegExp(/\.[^/.]+$/)
 class InFolderHandler extends StandardHandler {
   handleAddition() {
     super.handleAddition()
@@ -41,7 +42,7 @@ class InFolderHandler extends StandardHandler {
       .join(path.sep)
       .replace(mc.META_REGEX, '')
       .replace(INFOLDER_SUFFIX_REGEX, '')
-      .replace(this.suffixRegex, '')
+      .replace(EXTENSION_SUFFIX_REGEX, '')
 
     packageObject[this.type].add(
       StandardHandler.cleanUpPackageMember(packageMember)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Improve regex creating the document metadata members
Let it deals with the volatility of the extension based on the type of the file hosting the change (it can be either the file extension or the meta file)

Improve test for inFolder element
Improve assertion in test handler helper

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #135 

- [X] Jest test to check the fix is applied are added.

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 18.7.0: Tue Jan 12 22:04:47 PST 2021; root:xnu-4903.278.56~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v14.16.0

**git version:** git version 2.31.1

**sfdx version:** sfdx-cli/7.98.0 darwin-x64 node-v14.16.0

**sgd plugin version:** sfdx-git-delta 4.4.0



