### PR TITLE
feat: add api version 51

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -27,7 +27,11 @@ const options = program
     '-D, --ignore-destructive [file]',
     'ignore file to use [./.forceignore]'
   )
-  .option('-a, --api-version [version]', 'salesforce API version [50]', '50')
+  .option(
+    '-a, --api-version [version]',
+    `salesforce API version [${pjson.sfdc.latestApiVersion}]`,
+    pjson.sfdc.latestApiVersion
+  )
   .option('-r, --repo [dir]', 'git repository location [.]', '.')
   .option('-d, --generate-delta', 'generate delta files in [./output] folder')
   .parse(process.argv)

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "prepare": "husky install",
     "release": "standard-version --no-verify",
     "release:github": "conventional-github-releaser -p angular",
-    "release:tags": "git push --follow-tags origin master -f --no-verify"
+    "release:tags": "git push --follow-tags origin master -f --no-verify",
+    "increment:apiversion": "jq '.sfdc.latestApiVersion = (.sfdc.latestApiVersion|tonumber + 1 |tostring)' package.json | sponge package.json && filename=`ls src/metadata/v*.json | tail -1` && version=${filename//[!0-9]/} && ((version++)) && targetname=\"src/metadata/v${version}.json\" && \\cp $filename $targetname"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.1",

--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "sfdc": {
+    "latestApiVersion": "50"
   }
 }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
     "access": "public"
   },
   "sfdc": {
-    "latestApiVersion": "50"
+    "latestApiVersion": "51"
   }
 }

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -3,6 +3,8 @@ import { Messages } from '@salesforce/core'
 import { AnyJson } from '@salesforce/ts-types'
 import * as sgd from '../../../main.js'
 
+const pjson = require('../../../../package.json')
+
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname)
 const COMMAND_NAME = 'delta'
@@ -46,7 +48,7 @@ export default class SourceDeltaGenerate extends SfdxCommand {
     'api-version': flags.number({
       char: 'a',
       description: messages.getMessage('apiVersionFlag'),
-      default: 50.0,
+      default: parseFloat(pjson.sfdc.latestApiVersion),
     }),
     'generate-delta': flags.boolean({
       char: 'd',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,0 @@
-export default {};

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1,0 +1,1272 @@
+[
+  {
+    "directoryName": "installedPackages",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "installedPackage",
+    "xmlName": "InstalledPackage"
+  },
+  {
+    "childXmlNames": "CustomLabel",
+    "directoryName": "labels",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "labels",
+    "xmlName": "CustomLabels"
+  },
+  {
+    "directoryName": "staticresources",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "resource",
+    "xmlName": "StaticResource"
+  },
+  {
+    "directoryName": "scontrols",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "scf",
+    "xmlName": "Scontrol"
+  },
+  {
+    "directoryName": "certs",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "crt",
+    "xmlName": "Certificate"
+  },
+  {
+    "directoryName": "messageChannels",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "messageChannel",
+    "xmlName": "LightningMessageChannel"
+  },
+  {
+    "directoryName": "aura",
+    "inFolder": false,
+    "metaFile": false,
+    "xmlName": "AuraDefinitionBundle"
+  },
+  {
+    "directoryName": "lwc",
+    "inFolder": false,
+    "metaFile": false,
+    "xmlName": "LightningComponentBundle"
+  },
+  {
+    "directoryName": "components",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "component",
+    "xmlName": "ApexComponent"
+  },
+  {
+    "directoryName": "pages",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "page",
+    "xmlName": "ApexPage"
+  },
+  {
+    "directoryName": "queues",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "queue",
+    "xmlName": "Queue"
+  },
+  {
+    "directoryName": "CaseSubjectParticles",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "CaseSubjectParticle",
+    "xmlName": "CaseSubjectParticle"
+  },
+  {
+    "directoryName": "dataSources",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "dataSource",
+    "xmlName": "ExternalDataSource"
+  },
+  {
+    "directoryName": "namedCredentials",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "namedCredential",
+    "xmlName": "NamedCredential"
+  },
+  {
+    "directoryName": "externalServiceRegistrations",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "externalServiceRegistration",
+    "xmlName": "ExternalServiceRegistration"
+  },
+  {
+    "directoryName": "roles",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "role",
+    "xmlName": "Role"
+  },
+  {
+    "directoryName": "groups",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "group",
+    "xmlName": "Group"
+  },
+  {
+    "directoryName": "globalValueSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "globalValueSet",
+    "xmlName": "GlobalValueSet"
+  },
+  {
+    "directoryName": "standardValueSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "standardValueSet",
+    "xmlName": "StandardValueSet"
+  },
+  {
+    "directoryName": "customPermissions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "customPermission",
+    "xmlName": "CustomPermission"
+  },
+  {
+    "childXmlNames": [
+      "CustomField",
+      "Index",
+      "BusinessProcess",
+      "RecordType",
+      "CompactLayout",
+      "WebLink",
+      "ValidationRule",
+      "SharingReason",
+      "ListView",
+      "FieldSet"
+    ],
+    "directoryName": "objects",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "object",
+    "xmlName": "CustomObject"
+  },
+  {
+    "directoryName": "businessProcesses",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "businessProcess",
+    "xmlName": "BusinessProcess"
+  },
+  {
+    "directoryName": "compactLayouts",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "compactLayout",
+    "xmlName": "CompactLayout"
+  },
+  {
+    "directoryName": "fields",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "field",
+    "xmlName": "CustomField"
+  },
+  {
+    "directoryName": "fieldSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "fieldSet",
+    "xmlName": "FieldSet"
+  },
+  {
+    "directoryName": "listViews",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "listView",
+    "xmlName": "ListView"
+  },
+  {
+    "directoryName": "recordTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "recordType",
+    "xmlName": "RecordType"
+  },
+  {
+    "directoryName": "sharingReasons",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sharingReason",
+    "xmlName": "SharingReason"
+  },
+  {
+    "directoryName": "validationRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "validationRule",
+    "xmlName": "ValidationRule"
+  },
+  {
+    "directoryName": "webLinks",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "webLink",
+    "xmlName": "WebLink"
+  },
+  {
+    "directoryName": "reportTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "reportType",
+    "xmlName": "ReportType"
+  },
+  {
+    "directoryName": "reports",
+    "inFolder": true,
+    "metaFile": false,
+    "suffix": "report",
+    "xmlName": "Report"
+  },
+  {
+    "directoryName": "dashboards",
+    "inFolder": true,
+    "metaFile": false,
+    "suffix": "dashboard",
+    "xmlName": "Dashboard"
+  },
+  {
+    "directoryName": "analyticSnapshots",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "snapshot",
+    "xmlName": "AnalyticSnapshot"
+  },
+  {
+    "directoryName": "feedFilters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "feedFilter",
+    "xmlName": "CustomFeedFilter"
+  },
+  {
+    "directoryName": "layouts",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "layout",
+    "xmlName": "Layout"
+  },
+  {
+    "directoryName": "documents",
+    "inFolder": true,
+    "metaFile": true,
+    "xmlName": "Document"
+  },
+  {
+    "directoryName": "weblinks",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "weblink",
+    "xmlName": "CustomPageWebLink"
+  },
+  {
+    "directoryName": "letterhead",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "letter",
+    "xmlName": "Letterhead"
+  },
+  {
+    "directoryName": "email",
+    "inFolder": true,
+    "metaFile": true,
+    "suffix": "email",
+    "xmlName": "EmailTemplate"
+  },
+  {
+    "directoryName": "quickActions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "quickAction",
+    "xmlName": "QuickAction"
+  },
+  {
+    "directoryName": "flexipages",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "flexipage",
+    "xmlName": "FlexiPage"
+  },
+  {
+    "directoryName": "tabs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "tab",
+    "xmlName": "CustomTab"
+  },
+  {
+    "directoryName": "customApplicationComponents",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "customApplicationComponent",
+    "xmlName": "CustomApplicationComponent"
+  },
+  {
+    "directoryName": "applications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "app",
+    "xmlName": "CustomApplication"
+  },
+  {
+    "directoryName": "portals",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "portal",
+    "xmlName": "Portal"
+  },
+  {
+    "directoryName": "customMetadata",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "md",
+    "xmlName": "CustomMetadata"
+  },
+  {
+    "directoryName": "flows",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "flow",
+    "xmlName": "Flow"
+  },
+  {
+    "directoryName": "flowDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "flowDefinition",
+    "xmlName": "FlowDefinition"
+  },
+  {
+    "childXmlNames": [
+      "WorkflowFieldUpdate",
+      "WorkflowKnowledgePublish",
+      "WorkflowTask",
+      "WorkflowAlert",
+      "WorkflowSend",
+      "WorkflowOutboundMessage",
+      "WorkflowFlowAction",
+      "WorkflowRule"
+    ],
+    "directoryName": "workflows",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "workflow",
+    "xmlName": "Workflow"
+  },
+  {
+    "childXmlNames": "AssignmentRule",
+    "directoryName": "assignmentRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "assignmentRules",
+    "xmlName": "AssignmentRules"
+  },
+  {
+    "childXmlNames": "AutoResponseRule",
+    "directoryName": "autoResponseRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "autoResponseRules",
+    "xmlName": "AutoResponseRules"
+  },
+  {
+    "childXmlNames": "EscalationRule",
+    "directoryName": "escalationRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "escalationRules",
+    "xmlName": "EscalationRules"
+  },
+  {
+    "directoryName": "postTemplates",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "postTemplate",
+    "xmlName": "PostTemplate"
+  },
+  {
+    "directoryName": "approvalProcesses",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "approvalProcess",
+    "xmlName": "ApprovalProcess"
+  },
+  {
+    "directoryName": "homePageComponents",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "homePageComponent",
+    "xmlName": "HomePageComponent"
+  },
+  {
+    "directoryName": "homePageLayouts",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "homePageLayout",
+    "xmlName": "HomePageLayout"
+  },
+  {
+    "directoryName": "objectTranslations",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "objectTranslation",
+    "xmlName": "CustomObjectTranslation"
+  },
+  {
+    "directoryName": "translations",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "translation",
+    "xmlName": "Translations"
+  },
+  {
+    "directoryName": "globalValueSetTranslations",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "globalValueSetTranslation",
+    "xmlName": "GlobalValueSetTranslation"
+  },
+  {
+    "directoryName": "standardValueSetTranslations",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "standardValueSetTranslation",
+    "xmlName": "StandardValueSetTranslation"
+  },
+  {
+    "directoryName": "classes",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "cls",
+    "xmlName": "ApexClass"
+  },
+  {
+    "directoryName": "triggers",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "trigger",
+    "xmlName": "ApexTrigger"
+  },
+  {
+    "directoryName": "testSuites",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "testSuite",
+    "xmlName": "ApexTestSuite"
+  },
+  {
+    "directoryName": "profiles",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "profile",
+    "xmlName": "Profile"
+  },
+  {
+    "directoryName": "permissionsets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "permissionset",
+    "xmlName": "PermissionSet"
+  },
+  {
+    "directoryName": "mutingpermissionsets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mutingpermissionset",
+    "xmlName": "MutingPermissionSet"
+  },
+  {
+    "directoryName": "permissionsetgroups",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "permissionsetgroup",
+    "xmlName": "PermissionSetGroup"
+  },
+  {
+    "directoryName": "profilePasswordPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "profilePasswordPolicy",
+    "xmlName": "ProfilePasswordPolicy"
+  },
+  {
+    "directoryName": "profileSessionSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "profileSessionSetting",
+    "xmlName": "ProfileSessionSetting"
+  },
+  {
+    "directoryName": "myDomainDiscoverableLogins",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "myDomainDiscoverableLogin",
+    "xmlName": "MyDomainDiscoverableLogin"
+  },
+  {
+    "directoryName": "oauthcustomscopes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "oauthcustomscope",
+    "xmlName": "OauthCustomScope"
+  },
+  {
+    "directoryName": "datacategorygroups",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "datacategorygroup",
+    "xmlName": "DataCategoryGroup"
+  },
+  {
+    "directoryName": "remoteSiteSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "remoteSite",
+    "xmlName": "RemoteSiteSetting"
+  },
+  {
+    "directoryName": "cspTrustedSites",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "cspTrustedSite",
+    "xmlName": "CspTrustedSite"
+  },
+  {
+    "directoryName": "redirectWhitelistUrls",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "redirectWhitelistUrl",
+    "xmlName": "RedirectWhitelistUrl"
+  },
+  {
+    "childXmlNames": "MatchingRule",
+    "directoryName": "matchingRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "matchingRule",
+    "xmlName": "MatchingRules"
+  },
+  {
+    "directoryName": "duplicateRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "duplicateRule",
+    "xmlName": "DuplicateRule"
+  },
+  {
+    "directoryName": "cleanDataServices",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "cleanDataService",
+    "xmlName": "CleanDataService"
+  },
+  {
+    "directoryName": "skills",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "skill",
+    "xmlName": "Skill"
+  },
+  {
+    "directoryName": "serviceChannels",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "serviceChannel",
+    "xmlName": "ServiceChannel"
+  },
+  {
+    "directoryName": "queueRoutingConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "queueRoutingConfig",
+    "xmlName": "QueueRoutingConfig"
+  },
+  {
+    "directoryName": "servicePresenceStatuses",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "servicePresenceStatus",
+    "xmlName": "ServicePresenceStatus"
+  },
+  {
+    "directoryName": "presenceDeclineReasons",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "presenceDeclineReason",
+    "xmlName": "PresenceDeclineReason"
+  },
+  {
+    "directoryName": "presenceUserConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "presenceUserConfig",
+    "xmlName": "PresenceUserConfig"
+  },
+  {
+    "directoryName": "workSkillRoutings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "workSkillRouting",
+    "xmlName": "WorkSkillRouting"
+  },
+  {
+    "directoryName": "authproviders",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "authprovider",
+    "xmlName": "AuthProvider"
+  },
+  {
+    "directoryName": "eclair",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "geodata",
+    "xmlName": "EclairGeoData"
+  },
+  {
+    "directoryName": "channelLayouts",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "channelLayout",
+    "xmlName": "ChannelLayout"
+  },
+  {
+    "directoryName": "contentassets",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "asset",
+    "xmlName": "ContentAsset"
+  },
+  {
+    "directoryName": "sites",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "site",
+    "xmlName": "CustomSite"
+  },
+  {
+    "childXmlNames": [
+      "SharingOwnerRule",
+      "SharingCriteriaRule",
+      "SharingGuestRule"
+    ],
+    "directoryName": "sharingRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sharingRules",
+    "xmlName": "SharingRules"
+  },
+  {
+    "directoryName": "sharingSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sharingSet",
+    "xmlName": "SharingSet"
+  },
+  {
+    "directoryName": "iframeWhiteListUrlSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "iframeWhiteListUrlSettings",
+    "xmlName": "IframeWhiteListUrlSettings"
+  },
+  {
+    "directoryName": "communities",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "community",
+    "xmlName": "Community"
+  },
+  {
+    "directoryName": "ChatterExtensions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ChatterExtension",
+    "xmlName": "ChatterExtension"
+  },
+  {
+    "directoryName": "platformEventChannels",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "platformEventChannel",
+    "xmlName": "PlatformEventChannel"
+  },
+  {
+    "directoryName": "platformEventChannelMembers",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "platformEventChannelMember",
+    "xmlName": "PlatformEventChannelMember"
+  },
+  {
+    "directoryName": "callCenters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "callCenter",
+    "xmlName": "CallCenter"
+  },
+  {
+    "directoryName": "milestoneTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "milestoneType",
+    "xmlName": "MilestoneType"
+  },
+  {
+    "directoryName": "entitlementProcesses",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "entitlementProcess",
+    "xmlName": "EntitlementProcess"
+  },
+  {
+    "directoryName": "entitlementTemplates",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "entitlementTemplate",
+    "xmlName": "EntitlementTemplate"
+  },
+  {
+    "directoryName": "timeSheetTemplates",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "timeSheetTemplate",
+    "xmlName": "TimeSheetTemplate"
+  },
+  {
+    "directoryName": "appointmentSchedulingPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "policy",
+    "xmlName": "AppointmentSchedulingPolicy"
+  },
+  {
+    "directoryName": "Canvases",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "Canvas",
+    "xmlName": "CanvasMetadata"
+  },
+  {
+    "directoryName": "MobileApplicationDetails",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "MobileApplicationDetail",
+    "xmlName": "MobileApplicationDetail"
+  },
+  {
+    "directoryName": "notificationtypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "notiftype",
+    "xmlName": "CustomNotificationType"
+  },
+  {
+    "directoryName": "connectedApps",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "connectedApp",
+    "xmlName": "ConnectedApp"
+  },
+  {
+    "directoryName": "appMenus",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "appMenu",
+    "xmlName": "AppMenu"
+  },
+  {
+    "directoryName": "notificationTypeConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "config",
+    "xmlName": "NotificationTypeConfig"
+  },
+  {
+    "directoryName": "delegateGroups",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "delegateGroup",
+    "xmlName": "DelegateGroup"
+  },
+  {
+    "directoryName": "siteDotComSites",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "site",
+    "xmlName": "SiteDotCom"
+  },
+  {
+    "directoryName": "experiences",
+    "inFolder": false,
+    "metaFile": true,
+    "xmlName": "ExperienceBundle"
+  },
+  {
+    "directoryName": "networks",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "network",
+    "xmlName": "Network"
+  },
+  {
+    "directoryName": "networkBranding",
+    "inFolder": false,
+    "metaFile": true,
+    "suffix": "networkBranding",
+    "xmlName": "NetworkBranding"
+  },
+  {
+    "directoryName": "brandingSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "brandingSet",
+    "xmlName": "BrandingSet"
+  },
+  {
+    "directoryName": "communityThemeDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "communityThemeDefinition",
+    "xmlName": "CommunityThemeDefinition"
+  },
+  {
+    "directoryName": "communityTemplateDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "communityTemplateDefinition",
+    "xmlName": "CommunityTemplateDefinition"
+  },
+  {
+    "directoryName": "navigationMenus",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "navigationMenu",
+    "xmlName": "NavigationMenu"
+  },
+  {
+    "directoryName": "audience",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "audience",
+    "xmlName": "Audience"
+  },
+  {
+    "directoryName": "flowCategories",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "flowCategory",
+    "xmlName": "FlowCategory"
+  },
+  {
+    "directoryName": "lightningBolts",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "lightningBolt",
+    "xmlName": "LightningBolt"
+  },
+  {
+    "directoryName": "lightningExperienceThemes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "lightningExperienceTheme",
+    "xmlName": "LightningExperienceTheme"
+  },
+  {
+    "directoryName": "lightningOnboardingConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "lightningOnboardingConfig",
+    "xmlName": "LightningOnboardingConfig"
+  },
+  {
+    "directoryName": "customHelpMenuSections",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "customHelpMenuSection",
+    "xmlName": "CustomHelpMenuSection"
+  },
+  {
+    "directoryName": "prompts",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "prompt",
+    "xmlName": "Prompt"
+  },
+  {
+    "childXmlNames": "ManagedTopic",
+    "directoryName": "managedTopics",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "managedTopics",
+    "xmlName": "ManagedTopics"
+  },
+  {
+    "directoryName": "moderation",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "keywords",
+    "xmlName": "KeywordList"
+  },
+  {
+    "directoryName": "userCriteria",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "userCriteria",
+    "xmlName": "UserCriteria"
+  },
+  {
+    "directoryName": "moderation",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "rule",
+    "xmlName": "ModerationRule"
+  },
+  {
+    "directoryName": "cmsConnectSource",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "cmsConnectSource",
+    "xmlName": "CMSConnectSource"
+  },
+  {
+    "directoryName": "managedContentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "managedContentType",
+    "xmlName": "ManagedContentType"
+  },
+  {
+    "directoryName": "territory2Types",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "territory2Type",
+    "xmlName": "Territory2Type"
+  },
+  {
+    "directoryName": "territory2Models",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "territory2Model",
+    "xmlName": "Territory2Model"
+  },
+  {
+    "directoryName": "rules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "territory2Rule",
+    "xmlName": "Territory2Rule"
+  },
+  {
+    "directoryName": "territories",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "territory2",
+    "xmlName": "Territory2"
+  },
+  {
+    "directoryName": "campaignInfluenceModels",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "campaignInfluenceModel",
+    "xmlName": "CampaignInfluenceModel"
+  },
+  {
+    "directoryName": "samlssoconfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "samlssoconfig",
+    "xmlName": "SamlSsoConfig"
+  },
+  {
+    "directoryName": "corsWhitelistOrigins",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "corsWhitelistOrigin",
+    "xmlName": "CorsWhitelistOrigin"
+  },
+  {
+    "directoryName": "actionLinkGroupTemplates",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "actionLinkGroupTemplate",
+    "xmlName": "ActionLinkGroupTemplate"
+  },
+  {
+    "directoryName": "transactionSecurityPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "transactionSecurityPolicy",
+    "xmlName": "TransactionSecurityPolicy"
+  },
+  {
+    "directoryName": "liveChatDeployments",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "liveChatDeployment",
+    "xmlName": "LiveChatDeployment"
+  },
+  {
+    "directoryName": "liveChatButtons",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "liveChatButton",
+    "xmlName": "LiveChatButton"
+  },
+  {
+    "directoryName": "liveChatAgentConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "liveChatAgentConfig",
+    "xmlName": "LiveChatAgentConfig"
+  },
+  {
+    "directoryName": "synonymDictionaries",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "synonymDictionary",
+    "xmlName": "SynonymDictionary"
+  },
+  {
+    "directoryName": "pathAssistants",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "pathAssistant",
+    "xmlName": "PathAssistant"
+  },
+  {
+    "directoryName": "animationRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "animationRule",
+    "xmlName": "AnimationRule"
+  },
+  {
+    "directoryName": "LeadConvertSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "LeadConvertSetting",
+    "xmlName": "LeadConvertSettings"
+  },
+  {
+    "directoryName": "liveChatSensitiveDataRule",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "liveChatSensitiveDataRule",
+    "xmlName": "LiveChatSensitiveDataRule"
+  },
+  {
+    "directoryName": "cachePartitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "cachePartition",
+    "xmlName": "PlatformCachePartition"
+  },
+  {
+    "directoryName": "topicsForObjects",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "topicsForObjects",
+    "xmlName": "TopicsForObjects"
+  },
+  {
+    "directoryName": "recommendationStrategies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "recommendationStrategy",
+    "xmlName": "RecommendationStrategy"
+  },
+  {
+    "directoryName": "emailservices",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "xml",
+    "xmlName": "EmailServicesFunction"
+  },
+  {
+    "directoryName": "recordActionDeployments",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "deployment",
+    "xmlName": "RecordActionDeployment"
+  },
+  {
+    "directoryName": "EmbeddedServiceConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "EmbeddedServiceConfig",
+    "xmlName": "EmbeddedServiceConfig"
+  },
+  {
+    "directoryName": "EmbeddedServiceLiveAgent",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "EmbeddedServiceLiveAgent",
+    "xmlName": "EmbeddedServiceLiveAgent"
+  },
+  {
+    "directoryName": "EmbeddedServiceBranding",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "EmbeddedServiceBranding",
+    "xmlName": "EmbeddedServiceBranding"
+  },
+  {
+    "directoryName": "EmbeddedServiceFlowConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "EmbeddedServiceFlowConfig",
+    "xmlName": "EmbeddedServiceFlowConfig"
+  },
+  {
+    "directoryName": "EmbeddedServiceMenuSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "EmbeddedServiceMenuSettings",
+    "xmlName": "EmbeddedServiceMenuSettings"
+  },
+  {
+    "directoryName": "settings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "settings",
+    "xmlName": "Settings"
+  },
+  {
+    "directoryName": "wave",
+    "inFolder": false,
+    "metaFile": true,
+    "content": [
+      {
+        "suffix": "wapp",
+        "xmlName": "WaveApplication"
+      },
+      {
+        "suffix": "wdf",
+        "xmlName": "WaveDataflow"
+      },
+      {
+        "suffix": "wdash",
+        "xmlName": "WaveDashboard"
+      },
+      {
+        "suffix": "wds",
+        "xmlName": "WaveDataset"
+      },
+      {
+        "suffix": "wlens",
+        "xmlName": "WaveLens"
+      },
+      {
+        "suffix": "wdpr",
+        "xmlName": "WaveRecipe"
+      },
+      {
+        "suffix": "xmd",
+        "xmlName": "WaveXmd"
+      }
+    ]
+  },
+  {
+    "directoryName": "waveTemplates",
+    "inFolder": true,
+    "metaFile": false,
+    "xmlName": "WaveTemplateBundle"
+  },
+  {
+    "directoryName": "workflows.alerts",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Workflow",
+    "xmlName": "WorkflowAlert",
+    "xmlTag": "alerts"
+  },
+  {
+    "directoryName": "workflows.fieldUpdates",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Workflow",
+    "xmlName": "WorkflowFieldUpdate",
+    "xmlTag": "fieldUpdates"
+  },
+  {
+    "directoryName": "labels.labels",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "CustomLabels",
+    "xmlName": "CustomLabel",
+    "xmlTag": "labels"
+  },
+  {
+    "directoryName": "workflows.outboundMessages",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Workflow",
+    "xmlName": "WorkflowOutboundMessage",
+    "xmlTag": "outboundMessages"
+  },
+  {
+    "directoryName": "workflows.rules",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Workflow",
+    "xmlName": "WorkflowRule",
+    "xmlTag": "rules"
+  },
+  {
+    "directoryName": "sharingRules.sharingCriteriaRules",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "SharingRules",
+    "xmlName": "SharingCriteriaRule",
+    "xmlTag": "sharingCriteriaRules"
+  },
+  {
+    "directoryName": "sharingRules.sharingGuestRules",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "SharingRules",
+    "xmlName": "SharingGuestRule",
+    "xmlTag": "sharingGuestRules"
+  },
+  {
+    "directoryName": "sharingRules.sharingOwnerRules",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "SharingRules",
+    "xmlName": "SharingOwnerRule",
+    "xmlTag": "sharingOwnerRules"
+  },
+  {
+    "directoryName": "sharingRules.sharingTerritoryRules",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "SharingRules",
+    "xmlName": "SharingTerritoryRule",
+    "xmlTag": "sharingTerritoryRules"
+  },
+  {
+    "directoryName": "workflows.tasks",
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Workflow",
+    "xmlName": "WorkflowTask",
+    "xmlTag": "tasks"
+  }
+]


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [X] Added for new features.
- [X] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->
Add API version 51 metadata file support
Add a script to upgrade API version metadata
Add an attribute in the package.json to store the latest current API
Bind this attribute in the code for API default value usage

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

Use the new script in the package.json.
It requires `jq` and `sponge` installed

```sh
$ yarn increment:apiversion
```

It will increment the attribute sfdc.latestApiVersion in the `package.json`
And create a new file in `src/metadata` for the new API version
It works in unix like environment

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

> If you need to do something twice, then you should automate it instead of doing it
> -- <cite>Smart Lazy guy</cite>

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 18.7.0: Tue Jan 12 22:04:47 PST 2021; root:xnu-4903.278.56~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v14.16.0

**git version:** git version 2.31.1

**sfdx version:** sfdx-cli/7.98.0 darwin-x64 node-v14.16.0

**sgd plugin version:** sfdx-git-delta 4.4.0
