### PR TITLE
fix: issue with path separator conversion in xml file and path portability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,3 +201,11 @@ To upgrade the API version, run the following command:
 ```
 yarn && yarn increment:apiversion
 ```
+## Testing the plugin from a pull request
+
+To test SGD as a Salesforce CLI plugin from a pending pull request:
+1. uninstall the previous version you may have `sfdx plugins:uninstall sfdx-git-delta`
+2. clone the repository
+3. checkout the branch to test
+3. run `sfdx plugins:link` from that local repository
+4. test the plugin!

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ OPTIONS
                                                                                     this command invocation
 ```
 
-_See code: [src/commands/sgd/source/delta.ts](https://github.com/scolladon/sfdx-git-delta/blob/v4.5.0/src/commands/sgd/source/delta.ts)_
+_See code: [src/commands/sgd/source/delta.ts](https://github.com/scolladon/sfdx-git-delta/blob/v4.6.0/src/commands/sgd/source/delta.ts)_
 <!-- commandsstop -->
 
 ### Important note for Windows users:

--- a/__tests__/integration/main.test.js
+++ b/__tests__/integration/main.test.js
@@ -43,6 +43,45 @@ describe(`test if the appli`, () => {
     ).toHaveProperty('warnings', [])
   })
 
+  test('can execute with posix  path', () => {
+    expect(
+      app({ output: './output', repo: '', to: 'test', apiVersion: '46' })
+    ).toHaveProperty('warnings', [])
+  })
+
+  test('can execute with posix relative path', () => {
+    expect(
+      app({
+        output: './output/../output',
+        repo: '',
+        to: 'test',
+        apiVersion: '46',
+      })
+    ).toHaveProperty('warnings', [])
+  })
+
+  test('can execute with windows path', () => {
+    expect(
+      app({
+        output: '.\\output',
+        repo: '',
+        to: 'test',
+        apiVersion: '46',
+      })
+    ).toHaveProperty('warnings', [])
+  })
+
+  test('can execute with windows relative path', () => {
+    expect(
+      app({
+        output: '.\\output\\..\\output',
+        repo: '',
+        to: 'test',
+        apiVersion: '46',
+      })
+    ).toHaveProperty('warnings', [])
+  })
+
   test('catch and reject big issues', () => {
     fsMocked.errorMode = true
     fseMocked.errorMode = true

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "postrelease": "npm run release:tags && npm run release:github",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "prepare": "husky install",
-    "release": "standard-version --no-verify",
+    "release": "standard-version --no-verify --commit-all",
     "release:github": "conventional-github-releaser -p angular",
     "release:tags": "git push --follow-tags origin master -f --no-verify",
     "increment:apiversion": "jq '.sfdc.latestApiVersion = (.sfdc.latestApiVersion|tonumber + 1 |tostring)' package.json | sponge package.json && filename=`ls src/metadata/v*.json | tail -1` && version=${filename//[!0-9]/} && ((version++)) && targetname=\"src/metadata/v${version}.json\" && \\cp $filename $targetname && yarn pack"
@@ -105,6 +105,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "standard-version": {
+    "scripts": {
+      "postbump": "yarn pack && git add README.md"
+    }
   },
   "sfdc": {
     "latestApiVersion": "52"

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 'use strict'
 const PackageConstructor = require('./utils/packageConstructor')
 const TypeHandlerFactory = require('./service/typeHandlerFactory')
+const { sanitizePath } = require('./utils/childProcessUtils')
 const metadataManager = require('./metadata/metadataManager')
 const repoSetup = require('./utils/repoSetup')
 const repoGitDiff = require('./utils/repoGitDiff')
@@ -36,13 +37,23 @@ const checkConfig = config => {
   return errors
 }
 
+const sanitizeConfig = config => {
+  config.apiVersion = parseInt(config.apiVersion)
+  repoSetup(config)
+  config.repo = config.repo ? sanitizePath(config.repo) : config.repo
+  config.output = config.output ? sanitizePath(config.output) : config.output
+  config.ignore = config.ignore ? sanitizePath(config.ignore) : config.ignore
+  config.ignoreDestructive = config.ignoreDestructive
+    ? sanitizePath(config.ignoreDestructive)
+    : config.ignoreDestructive
+}
+
 module.exports = config => {
+  sanitizeConfig(config)
   const inputError = checkConfig(config)
   if (inputError.length > 0) {
     throw new Error(inputError)
   }
-  config.apiVersion = parseInt(config.apiVersion)
-  repoSetup(config)
 
   const metadata = metadataManager.getDefinition(
     'directoryName',

--- a/src/utils/childProcessUtils.js
+++ b/src/utils/childProcessUtils.js
@@ -2,5 +2,7 @@
 const os = require('os')
 const path = require('path')
 
-module.exports.treatDataFromSpawn = data =>
-  data.replace(/[/\\]+/g, path.sep).replace(/\r?\n/g, os.EOL)
+const treatEOL = data => data.replace(/\r?\n/g, os.EOL)
+const treatPathSep = data => data.replace(/[/\\]+/g, path.sep)
+module.exports.treatDataFromSpawn = data => treatEOL(treatPathSep(data))
+module.exports.treatEOL = treatEOL

--- a/src/utils/childProcessUtils.js
+++ b/src/utils/childProcessUtils.js
@@ -4,5 +4,8 @@ const path = require('path')
 
 const treatEOL = data => data.replace(/\r?\n/g, os.EOL)
 const treatPathSep = data => data.replace(/[/\\]+/g, path.sep)
+const sanitizePath = data => path.normalize(treatPathSep(data))
+
 module.exports.treatDataFromSpawn = data => treatEOL(treatPathSep(data))
 module.exports.treatEOL = treatEOL
+module.exports.sanitizePath = sanitizePath

--- a/src/utils/fileGitDiff.js
+++ b/src/utils/fileGitDiff.js
@@ -12,5 +12,5 @@ module.exports = (filePath, config) => {
     { cwd: config.repo, encoding: gc.UTF8_ENCODING }
   )
 
-  return cpUtils.treatDataFromSpawn(diff)
+  return cpUtils.treatEOL(diff)
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [X] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Remove the path treatment for git diff file reader
Add path sanity treatment of config object

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #152

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->
Smoke test + Unit test

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

## Where has this been tested?

---

It has been tested on both mac and windows

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 18.7.0: Mon May  3 20:41:19 PDT 2021; root:xnu-4903.278.68~1/RELEASE_X86_64 and Windows 10

**yarn version:** 1.22.10

**node version:** v14.16.0

**git version:** 2.32.0

**sfdx version:** sfdx-cli/7.105.0 darwin-x64 node-v14.16.0

**sgd plugin version:** 4.6.0
