### PR TITLE
fix: handle xml parsing issues gracefully

### DIFF
--- a/__mocks__/fast-xml-parser.js
+++ b/__mocks__/fast-xml-parser.js
@@ -12,10 +12,6 @@ fxp.__setMockContent = contents => {
   }
 }
 
-fxp.validate = content => {
-  return Object.prototype.hasOwnProperty.call(xml2json, content)
-}
-
 fxp.parse = content => {
   return JSON.parse(xml2json[content])
 }

--- a/__mocks__/fast-xml-parser.js
+++ b/__mocks__/fast-xml-parser.js
@@ -12,6 +12,10 @@ fxp.__setMockContent = contents => {
   }
 }
 
+fxp.validate = content => {
+  return Object.prototype.hasOwnProperty.call(xml2json, content)
+}
+
 fxp.parse = content => {
   return JSON.parse(xml2json[content])
 }

--- a/__tests__/integration/main.test.js
+++ b/__tests__/integration/main.test.js
@@ -43,6 +43,19 @@ describe(`test if the appli`, () => {
     ).toHaveProperty('warnings', [])
   })
 
+  test('can execute with complex parameters and a Modification', () => {
+    expect(
+      app({
+        output: 'output',
+        repo: '',
+        to: 'test',
+        apiVersion: '46',
+        ignore: '.forceignore',
+        ignoreDestructive: '.forceignore',
+      })
+    ).toHaveProperty('warnings', [])
+  })
+
   test('can execute with posix  path', () => {
     expect(
       app({ output: './output', repo: '', to: 'test', apiVersion: '46' })

--- a/__tests__/unit/lib/service/customObjectHandler.test.js
+++ b/__tests__/unit/lib/service/customObjectHandler.test.js
@@ -29,16 +29,43 @@ const testContext = {
 }
 
 // eslint-disable-next-line no-undef
-describe('test CustomObjectHandler', () => {
+describe('test CustomObjectHandler with fields', () => {
   beforeAll(() => {
     require('fs').__setMockFiles({
       'force-app/main/default/objects/Account/Account.object-meta.xml': 'test',
+      'force-app/main/default/objects/Account/fields': '',
       'force-app/main/default/objects/Account/fields/test__c.field-meta.xml':
         SubCustomObjectHandler.MASTER_DETAIL_TAG,
       'force-app/main/default/objects/Test/Account/Account.object-meta.xml':
         'test',
       'force-app/main/default/objects/Test/Account/fields/test__c.field-meta.xml':
         SubCustomObjectHandler.MASTER_DETAIL_TAG,
+    })
+  })
+
+  // eslint-disable-next-line no-undef
+  testHandlerHelper(testContext)
+
+  test('addition', () => {
+    testContext.work.config.generateDelta = false
+    const handler = new testContext.handler(
+      'A       force-app/main/default/objects/Account/Account.object-meta.xml',
+      'objects',
+      testContext.work,
+      // eslint-disable-next-line no-undef
+      globalMetadata
+    )
+    handler.handle()
+  })
+})
+
+// eslint-disable-next-line no-undef
+describe('test CustomObjectHandler without fields', () => {
+  beforeAll(() => {
+    require('fs').__setMockFiles({
+      'force-app/main/default/objects/Account/Account.object-meta.xml': 'test',
+      'force-app/main/default/objects/Test/Account/Account.object-meta.xml':
+        'test',
     })
   })
 

--- a/__tests__/unit/lib/service/inFileHandler.test.js
+++ b/__tests__/unit/lib/service/inFileHandler.test.js
@@ -209,7 +209,7 @@ describe(`test if inFileHandler`, () => {
   describe('with bad xml', () => {
     const [expectedType, changePath, xmlContent, expectedResult] = [
       'labels',
-      'force-app/main/default/labels/CustomLabels.labels-meta.xml',
+      'force-app/main/error/labels/CustomLabels.labels-meta.xml',
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${os.EOL}<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">${os.EOL}<labels>${os.EOL}<fullName>TestLabel1</fullName>${os.EOL}</labels>${os.EOL}</labels>${os.EOL}<labels>${os.EOL}<fullName>TestLabel2</fullName>${os.EOL}</labels>${os.EOL}</CustomLabels>`,
       {},
     ]

--- a/__tests__/unit/lib/service/inFileHandler.test.js
+++ b/__tests__/unit/lib/service/inFileHandler.test.js
@@ -205,4 +205,31 @@ describe(`test if inFileHandler`, () => {
       })
     }
   )
+
+  describe('with bad xml', () => {
+    const [expectedType, changePath, xmlContent, expectedResult] = [
+      'labels',
+      'force-app/main/default/labels/CustomLabels.labels-meta.xml',
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>${os.EOL}<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">${os.EOL}<labels>${os.EOL}<fullName>TestLabel1</fullName>${os.EOL}</labels>${os.EOL}</labels>${os.EOL}<labels>${os.EOL}<fullName>TestLabel2</fullName>${os.EOL}</labels>${os.EOL}</CustomLabels>`,
+      {},
+    ]
+    test('generate proper warning', () => {
+      const handler = new testContext.handler(
+        `A       ${changePath}`,
+        expectedType,
+        work,
+        // eslint-disable-next-line no-undef
+        globalMetadata
+      )
+      child_process.spawnSync.mockImplementation(() => ({
+        stdout: xmlContent
+          .split(os.EOL)
+          .map(x => `${gc.PLUS} ${x}`)
+          .join(os.EOL),
+      }))
+      handler.handle()
+      expect(work.diffs.package).toMatchObject(expectedResult)
+      expect(work.warnings).toHaveLength(1)
+    })
+  })
 })

--- a/__tests__/unit/lib/service/inFolderHandler.test.js
+++ b/__tests__/unit/lib/service/inFolderHandler.test.js
@@ -2,7 +2,8 @@
 const InFolder = require('../../../../src/service/inFolderHandler')
 jest.mock('fs')
 
-const testContext = {
+// eslint-disable-next-line no-undef
+testHandlerHelper({
   handler: InFolder,
   testData: [
     [
@@ -35,7 +36,21 @@ const testContext = {
     config: { output: '', repo: '.', generateDelta: true },
     diffs: { package: {}, destructiveChanges: {} },
   },
-}
+})
 
 // eslint-disable-next-line no-undef
-testHandlerHelper(testContext)
+testHandlerHelper({
+  handler: InFolder,
+  testData: [
+    [
+      'dashboards',
+      'force-app/main/default/dashboards/folder/file.dashboard-meta.xml',
+      new Set(['folder/file']),
+    ],
+  ],
+  work: {
+    config: { output: '', repo: './repo', generateDelta: true },
+    diffs: { package: {}, destructiveChanges: {} },
+    warnings: [],
+  },
+})

--- a/src/main.js
+++ b/src/main.js
@@ -41,7 +41,7 @@ const sanitizeConfig = config => {
   config.apiVersion = parseInt(config.apiVersion)
   repoSetup(config)
   config.repo = config.repo ? sanitizePath(config.repo) : config.repo
-  config.output = config.output ? sanitizePath(config.output) : config.output
+  config.output = sanitizePath(config.output)
   config.ignore = config.ignore ? sanitizePath(config.ignore) : config.ignore
   config.ignoreDestructive = config.ignoreDestructive
     ? sanitizePath(config.ignoreDestructive)

--- a/src/service/inFileHandler.js
+++ b/src/service/inFileHandler.js
@@ -134,12 +134,7 @@ class InFileHandler extends StandardHandler {
   }
 
   _parseFile() {
-    const xmlContent = this._readFileSync()
-    const xmlValidation = fxp.validate(xmlContent)
-    if (xmlValidation !== true) {
-      throw new Error(xmlValidation?.err?.msg)
-    }
-    const result = fxp.parse(xmlContent, XML_PARSER_OPTION)
+    const result = fxp.parse(this._readFileSync(), XML_PARSER_OPTION, true)
 
     const authorizedKeys = Object.keys(Object.values(result)[0]).filter(tag =>
       Object.prototype.hasOwnProperty.call(

--- a/src/service/inFileHandler.js
+++ b/src/service/inFileHandler.js
@@ -134,7 +134,13 @@ class InFileHandler extends StandardHandler {
   }
 
   _parseFile() {
-    const result = fxp.parse(this._readFileSync(), XML_PARSER_OPTION)
+    const xmlContent = this._readFileSync()
+    const xmlValidation = fxp.validate(xmlContent)
+    if (xmlValidation !== true) {
+      throw new Error(xmlValidation?.err?.msg)
+    }
+    const result = fxp.parse(xmlContent, XML_PARSER_OPTION)
+
     const authorizedKeys = Object.keys(Object.values(result)[0]).filter(tag =>
       Object.prototype.hasOwnProperty.call(
         InFileHandler.xmlObjectToPackageType,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [X] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Use the xml library to detect malformed xml and then throw exception catched
Non blocking ! Output this in the warnings section.

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #155

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

You can test it using the reproduction playground dedicated [branch](https://github.com/scolladon/sfdx-git-delta-reproduction-playground/tree/issue/155)
Or locally using node:
```sh
$ git fetch
$ git checkout fix/xml-error-handling
$ node bin/run sgd:source:delta ...
```

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Can be included in the next release

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Thu May  6 00:48:39 PDT 2021; root:xnu-6153.141.33~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v14.16.0

**git version:** 2.32.0

**sfdx version:** sfdx-cli/7.107.0 darwin-x64 node-v14.16.0

**sgd plugin version:** 4.61
