### PR TITLE
fix: -d usage with -t different than HEAD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,5 +207,5 @@ To test SGD as a Salesforce CLI plugin from a pending pull request:
 1. uninstall the previous version you may have `sfdx plugins:uninstall sfdx-git-delta`
 2. clone the repository
 3. checkout the branch to test
-3. run `sfdx plugins:link` from that local repository
-4. test the plugin!
+4. run `yarn pack`, followed by `sfdx plugins:link`, from that local repository
+5. test the plugin!

--- a/README.md
+++ b/README.md
@@ -259,7 +259,18 @@ sfdx sgd:source:delta --to "HEAD" --from "HEAD^" --output changed-sources/ --gen
 In addition to the `package` and `destructiveChanges` folders, the `sfdx sgd:source:delta` command will also produce a copy of the added/changed files in the ouput folder.
 
 _Content of the output folder when using the --generate-delta option, with the same scenario as above:_
+
 ![delta-source](/img/example_generateDelta.png)
+
+> /!\ the `--generate-delta (-d)` can only be used when `--to (-t)` value is set to "HEAD" or to the "HEAD commit SHA".
+> If you need to use it with `--to (-t)` pointing to another commit than "HEAD", just checkout that commit first and then use `--generate-delta (-d)`. Exemple:
+>
+> ```sh
+> # move HEAD to past commit we are interested in
+> $ git checkout <not-HEAD-commit-sha>
+> # You can omit --to, it will take "HEAD" as default value
+> $ sfdx sgd:source:delta --from "HEAD^" --output changed-sources/ --generate-delta
+> ```
 
 ### Exclude some metadata only from destructiveChanges.xml:
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ _Content of the output folder when using the --generate-delta option, with the s
 
 ![delta-source](/img/example_generateDelta.png)
 
-> /!\ the `--generate-delta (-d)` can only be used when `--to (-t)` value is set to "HEAD" or to the "HEAD commit SHA".
+> ⚠️ the `--generate-delta (-d)` can only be used when `--to (-t)` value is set to "HEAD" or to the "HEAD commit SHA".
 > If you need to use it with `--to (-t)` pointing to another commit than "HEAD", just checkout that commit first and then use `--generate-delta (-d)`. Exemple:
 >
 > ```sh

--- a/__tests__/integration/main.test.js
+++ b/__tests__/integration/main.test.js
@@ -1,6 +1,9 @@
 'use strict'
 const app = require('../../src/main')
-jest.mock('child_process')
+const gc = require('../../src/utils/gitConstants')
+
+const child_process = require('child_process')
+jest.mock('child_process', () => ({ spawnSync: jest.fn() }))
 jest.mock('fs-extra')
 jest.mock('fs')
 jest.mock('git-state')
@@ -17,6 +20,7 @@ describe(`test if the appli`, () => {
     fsMocked.__setMockFiles({
       output: '',
     })
+    child_process.spawnSync.mockImplementation(() => ({ stdout: '' }))
   })
 
   test('can execute with simple parameters and no diff', () => {
@@ -139,6 +143,26 @@ describe(`test if the appli`, () => {
         output: 'output',
         repo: 'not/git/folder',
         to: 'test',
+        apiVersion: '46',
+      })
+    }).toThrow()
+  })
+
+  test('throw errors when "-t" and "-d" are set', () => {
+    const notHeadSHA = 'test'
+    /*const child_process = require('child_process')
+    jest.mock('child_process', () => ({ spawnSync: jest.fn() }))*/
+    child_process.spawnSync
+      .mockReturnValueOnce({ stdout: Buffer.from('HEAD', gc.UTF8_ENCODING) })
+      .mockReturnValueOnce({
+        stdout: Buffer.from(notHeadSHA, gc.UTF8_ENCODING),
+      })
+    expect(() => {
+      app({
+        output: 'output',
+        repo: '',
+        to: notHeadSHA,
+        generateDelta: true,
         apiVersion: '46',
       })
     }).toThrow()

--- a/__tests__/unit/lib/utils/repoSetup.test.js
+++ b/__tests__/unit/lib/utils/repoSetup.test.js
@@ -1,5 +1,5 @@
 'use strict'
-const repoSetup = require('../../../../src/utils/repoSetup')
+const RepoSetup = require('../../../../src/utils/repoSetup')
 const child_process = require('child_process')
 jest.mock('child_process', () => ({ spawnSync: jest.fn() }))
 jest.mock('fs-extra')
@@ -11,15 +11,39 @@ describe(`test if repoSetup`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: '',
     }))
-    repoSetup(config)
-    expect(config.from).not.toBeUndefined()
+    const repoSetup = new RepoSetup(config)
+    const firsSha = repoSetup.getFirstSHA()
+
+    expect(firsSha).not.toBeUndefined()
+    expect(child_process.spawnSync).toHaveBeenCalled()
   })
   test('can set core.quotepath to off', () => {
     const config = { repo: '.', from: 'HEAD' }
     child_process.spawnSync.mockImplementation(() => ({
       stdout: '',
     }))
-    repoSetup(config)
-    expect(config.from).not.toBeUndefined()
+    const repoSetup = new RepoSetup(config)
+    repoSetup.repoConfiguration()
+    expect(child_process.spawnSync).toHaveBeenCalled()
+  })
+
+  test('can checkout to', () => {
+    const config = { repo: '.', from: 'HEAD' }
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: '',
+    }))
+    const repoSetup = new RepoSetup(config)
+    repoSetup.checkoutTo()
+    expect(child_process.spawnSync).toHaveBeenCalled()
+  })
+
+  test('can checkout back', () => {
+    const config = { repo: '.', from: 'HEAD' }
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: '',
+    }))
+    const repoSetup = new RepoSetup(config)
+    repoSetup.checkoutRef()
+    expect(child_process.spawnSync).toHaveBeenCalled()
   })
 })

--- a/__tests__/unit/lib/utils/repoSetup.test.js
+++ b/__tests__/unit/lib/utils/repoSetup.test.js
@@ -17,8 +17,21 @@ describe(`test if repoSetup`, () => {
     expect(firsSha).not.toBeUndefined()
     expect(child_process.spawnSync).toHaveBeenCalled()
   })
+
+  test('can set config.from if defined', () => {
+    const config = { repo: '.', from: 'HEAD~1' }
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: '',
+    }))
+    const repoSetup = new RepoSetup(config)
+    const firsSha = repoSetup.getFirstSHA()
+
+    expect(firsSha).toBeUndefined()
+    expect(child_process.spawnSync).not.toHaveBeenCalled()
+  })
+
   test('can set core.quotepath to off', () => {
-    const config = { repo: '.', from: 'HEAD' }
+    const config = { repo: '.', from: 'HEAD~1' }
     child_process.spawnSync.mockImplementation(() => ({
       stdout: '',
     }))
@@ -28,7 +41,7 @@ describe(`test if repoSetup`, () => {
   })
 
   test('can checkout to', () => {
-    const config = { repo: '.', from: 'HEAD' }
+    const config = { repo: '.', from: 'HEAD~1', to: 'sha' }
     child_process.spawnSync.mockImplementation(() => ({
       stdout: '',
     }))
@@ -37,13 +50,37 @@ describe(`test if repoSetup`, () => {
     expect(child_process.spawnSync).toHaveBeenCalled()
   })
 
+  test('cannot checkout to when to is default', () => {
+    const config = { repo: '.', from: 'HEAD~1', to: 'HEAD' }
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: '',
+    }))
+    const repoSetup = new RepoSetup(config)
+    repoSetup.repoConfiguration()
+    jest.clearAllMocks()
+    repoSetup.checkoutTo()
+    expect(child_process.spawnSync).not.toHaveBeenCalled()
+  })
+
   test('can checkout back', () => {
-    const config = { repo: '.', from: 'HEAD' }
+    const config = { repo: '.', from: 'HEAD~1', to: 'sha' }
     child_process.spawnSync.mockImplementation(() => ({
       stdout: '',
     }))
     const repoSetup = new RepoSetup(config)
     repoSetup.checkoutRef()
     expect(child_process.spawnSync).toHaveBeenCalled()
+  })
+
+  test('cannot checkout back when to is default', () => {
+    const config = { repo: '.', from: 'HEAD~1', to: 'HEAD' }
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: '',
+    }))
+    const repoSetup = new RepoSetup(config)
+    repoSetup.repoConfiguration()
+    jest.clearAllMocks()
+    repoSetup.checkoutRef()
+    expect(child_process.spawnSync).not.toHaveBeenCalled()
   })
 })

--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,7 @@ const checkConfig = (config, repoSetup) => {
 
   if (!repoSetup.isToEqualHead() && config.generateDelta) {
     errors.push(
-      `--generate-delta (-d) parameter cannot be set when --to (-t) parameter is not equivalent to HEAD`
+      `--generate-delta (-d) parameter cannot be used when --to (-t) parameter is not equivalent to HEAD`
     )
   }
 

--- a/src/utils/repoSetup.js
+++ b/src/utils/repoSetup.js
@@ -27,11 +27,14 @@ class RepoSetup {
     childProcess.spawnSync('git', gitConfig, {
       cwd: this.config.repo,
     })
-    this.referenceSHA = _bufToStr(
-      childProcess.spawnSync('git', revparseParams, {
-        cwd: this.config.repo,
-      }).stdout
-    )
+    this.referenceSHA =
+      this.config.to === HEAD
+        ? HEAD
+        : _bufToStr(
+            childProcess.spawnSync('git', revparseParams, {
+              cwd: this.config.repo,
+            }).stdout
+          )
   }
 
   getFirstSHA() {
@@ -47,12 +50,18 @@ class RepoSetup {
   }
 
   checkoutTo() {
+    if (this.referenceSHA === HEAD) {
+      return
+    }
     childProcess.spawnSync('git', [...checkout, this.config.to], {
       cwd: this.config.repo,
     })
   }
 
   checkoutRef() {
+    if (this.referenceSHA === HEAD) {
+      return
+    }
     childProcess.spawnSync('git', stashUntracked, {
       cwd: this.config.repo,
     }).stdout

--- a/src/utils/repoSetup.js
+++ b/src/utils/repoSetup.js
@@ -3,14 +3,8 @@ const childProcess = require('child_process')
 const gc = require('./gitConstants')
 
 const HEAD = 'HEAD'
-const STASH = 'stash'
-const CHECKOUT = 'checkout'
 
-const stashUntracked = [STASH, '-u']
-const stashDrop = [STASH, 'drop']
-const checkoutStash = ['stash', '--', '.']
 const revparseParams = ['rev-parse']
-const checkout = [CHECKOUT]
 const revlistParams = ['rev-list', '--max-parents=0', HEAD]
 const gitConfig = ['config', 'core.quotepath', 'off']
 
@@ -21,31 +15,37 @@ const _bufToStr = buf => {
 class RepoSetup {
   constructor(config) {
     this.config = config
+    this.config.generateDelta
   }
 
-  repoConfiguration() {
-    childProcess.spawnSync('git', gitConfig, {
-      cwd: this.config.repo,
-    })
-
+  isToEqualHead() {
+    if (this.config.to === HEAD) {
+      return true
+    }
     const headSHA = _bufToStr(
       childProcess.spawnSync('git', [...revparseParams, HEAD], {
         cwd: this.config.repo,
       }).stdout
     )
 
-    this.referenceSHA = _bufToStr(
+    const toSHA = _bufToStr(
       childProcess.spawnSync('git', [...revparseParams, this.config.to], {
         cwd: this.config.repo,
       }).stdout
     )
 
-    this.isToEqualHead = this.referenceSHA === headSHA
+    return toSHA === headSHA
   }
 
-  getFirstSHA() {
-    let firstCommitSHA
-    if (!this.config.from) {
+  repoConfiguration() {
+    childProcess.spawnSync('git', gitConfig, {
+      cwd: this.config.repo,
+    })
+  }
+
+  computeFromRef() {
+    let firstCommitSHA = this.config.from
+    if (!firstCommitSHA) {
       firstCommitSHA = _bufToStr(
         childProcess.spawnSync('git', revlistParams, {
           cwd: this.config.repo,
@@ -53,40 +53,6 @@ class RepoSetup {
       )
     }
     return firstCommitSHA
-  }
-
-  checkoutTo() {
-    if (this.isToEqualHead) {
-      return
-    }
-    childProcess.spawnSync('git', [...checkout, this.config.to], {
-      cwd: this.config.repo,
-    })
-  }
-
-  checkoutRef() {
-    if (this.isToEqualHead) {
-      return
-    }
-    childProcess.spawnSync('git', stashUntracked, {
-      cwd: this.config.repo,
-    }).stdout
-
-    childProcess.spawnSync('git', [...checkout, this.referenceSHA], {
-      cwd: this.config.repo,
-    }).stdout
-
-    childProcess.spawnSync(
-      'git',
-      [...checkout, ...checkoutStash, this.config.repo],
-      {
-        cwd: this.config.repo,
-      }
-    ).stdout
-
-    childProcess.spawnSync('git', stashDrop, {
-      cwd: this.config.repo,
-    }).stdout
   }
 }
 

--- a/src/utils/repoSetup.js
+++ b/src/utils/repoSetup.js
@@ -2,19 +2,77 @@
 const childProcess = require('child_process')
 const gc = require('./gitConstants')
 
-const revlistParams = ['rev-list', '--max-parents=0', 'HEAD']
+const HEAD = 'HEAD'
+const STASH = 'stash'
+const CHECKOUT = 'checkout'
+
+const stashUntracked = [STASH, '-u']
+const stashDrop = [STASH, 'drop']
+const checkoutStash = ['stash', '--', '.']
+const revparseParams = ['rev-parse', HEAD]
+const checkout = [CHECKOUT]
+const revlistParams = ['rev-list', '--max-parents=0', HEAD]
 const gitConfig = ['config', 'core.quotepath', 'off']
 
-module.exports = config => {
-  childProcess.spawnSync('git', gitConfig, {
-    cwd: config.repo,
-  }).stdout
-  if (!config.from) {
-    const firstCommitSHARaw = childProcess.spawnSync('git', revlistParams, {
-      cwd: config.repo,
-    }).stdout
-    const firstCommitSHA = Buffer.from(firstCommitSHARaw)
+const _bufToStr = buf => {
+  return Buffer.from(buf).toString(gc.UTF8_ENCODING).trim()
+}
 
-    config.from = firstCommitSHA.toString(gc.UTF8_ENCODING).trim()
+class RepoSetup {
+  constructor(config) {
+    this.config = config
+  }
+
+  repoConfiguration() {
+    childProcess.spawnSync('git', gitConfig, {
+      cwd: this.config.repo,
+    })
+    this.referenceSHA = _bufToStr(
+      childProcess.spawnSync('git', revparseParams, {
+        cwd: this.config.repo,
+      }).stdout
+    )
+  }
+
+  getFirstSHA() {
+    let firstCommitSHA
+    if (!this.config.from) {
+      firstCommitSHA = _bufToStr(
+        childProcess.spawnSync('git', revlistParams, {
+          cwd: this.config.repo,
+        }).stdout
+      )
+    }
+    return firstCommitSHA
+  }
+
+  checkoutTo() {
+    childProcess.spawnSync('git', [...checkout, this.config.to], {
+      cwd: this.config.repo,
+    })
+  }
+
+  checkoutRef() {
+    childProcess.spawnSync('git', stashUntracked, {
+      cwd: this.config.repo,
+    }).stdout
+
+    childProcess.spawnSync('git', [...checkout, this.referenceSHA], {
+      cwd: this.config.repo,
+    }).stdout
+
+    childProcess.spawnSync(
+      'git',
+      [...checkout, ...checkoutStash, this.config.repo],
+      {
+        cwd: this.config.repo,
+      }
+    ).stdout
+
+    childProcess.spawnSync('git', stashDrop, {
+      cwd: this.config.repo,
+    }).stdout
   }
 }
+
+module.exports = RepoSetup


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [x] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Move the current repository when config.to is different than HEAD
In order to have the file and the version of the file related to the commit wanted

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

Nop

- [x] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

Use jest and node

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Need to be roughly tested and also we need to look for other way to do it better

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Thu May  6 00:48:39 PDT 2021; root:xnu-6153.141.33~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v14.16.0

**git version:** 2.32.0

**sfdx version:** sfdx-cli/7.107.0 darwin-x64 node-v14.16.0

**sgd plugin version:** 4.61
