### PR TITLE
fix: git context to not exceed spawn sync buffer for very large inFile metadata

### DIFF
--- a/src/utils/fileGitDiff.js
+++ b/src/utils/fileGitDiff.js
@@ -3,7 +3,7 @@ const childProcess = require('child_process')
 const cpUtils = require('./childProcessUtils')
 const gc = require('./gitConstants')
 
-const unitDiffParams = ['--no-pager', 'diff', '--no-prefix', '-U10000000000']
+const unitDiffParams = ['--no-pager', 'diff', '--no-prefix', '-U200']
 
 module.exports = (filePath, config) => {
   const { stdout: diff } = childProcess.spawnSync(


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [X] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

git [context](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---unifiedltngt) is now set to 200 (instead of 10000000000).
It allows very large file to

- not exceed the spawnSync buffer
- keep default spawnSync buffer (1024*1024)
- keep working for every infile metadata kind (200 of context line seems to be enough during the [tests](https://github.com/scolladon/sfdx-git-delta-reproduction-playground/tree/issue/47-again))

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #47 (again)

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

Use yarn test
Use the [reproduction playground](https://github.com/scolladon/sfdx-git-delta-reproduction-playground/tree/issue/47-again)

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Can be included in the next release

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Thu May  6 00:48:39 PDT 2021; root:xnu-6153.141.33~1/RELEASE_X86_64

**yarn version:** 1.22.10

**node version:** v14.16.0

**git version:** 2.32.0

**sfdx version:** sfdx-cli/7.107.0 darwin-x64 node-v14.16.0

**sgd plugin version:** 4.61
