### PR TITLE
fix: wrong type detection in subfolders

### DIFF
--- a/__tests__/unit/lib/service/typeHandlerFactory.test.js
+++ b/__tests__/unit/lib/service/typeHandlerFactory.test.js
@@ -45,4 +45,28 @@ describe('the type handler factory', () => {
       ).toBeInstanceOf(handler)
     })
   })
+
+  test('can handle SubCustomObject', () => {
+    expect(
+      typeHandlerFactory.getTypeHandler(
+        `Z       force-app/main/default/objects/Account/fields/Test__c`
+      )
+    ).toBeInstanceOf(SubCustomObject)
+  })
+
+  test('can handle sub folder with SubCustomObject', () => {
+    expect(
+      typeHandlerFactory.getTypeHandler(
+        `Z       force-app/main/default/objects/folder/Account/fields/Test__c`
+      )
+    ).toBeInstanceOf(SubCustomObject)
+  })
+
+  test('can handle sub folder with non SubCustomObject', () => {
+    expect(
+      typeHandlerFactory.getTypeHandler(
+        `Z       force-app/main/default/documents/classes/TestDocument`
+      )
+    ).toBeInstanceOf(InFolder)
+  })
 })

--- a/__tests__/unit/lib/service/typeHandlerFactory.test.js
+++ b/__tests__/unit/lib/service/typeHandlerFactory.test.js
@@ -35,7 +35,7 @@ describe('the type handler factory', () => {
     ],
     [InFolder, ['dashboards', 'documents', 'reports']],
     [InResource, ['staticresources', 'aura', 'lwc']],
-    [Standard, ['objects']],
+    [Standard, ['classes']],
   ])('give %p handler', (handler, types) => {
     test.each(types)('for %s folder', type => {
       expect(

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:clear:cache": "jest --clearCache",
     "test:coverage": "jest --coverage --runInBand",
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
+    "test:debug:break": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "postpack": "rm -f oclif.manifest.json",
     "postrelease": "npm run release:tags && npm run release:github",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",

--- a/src/service/customObjectHandler.js
+++ b/src/service/customObjectHandler.js
@@ -5,37 +5,41 @@ const mc = require('../utils/metadataConstants')
 const path = require('path')
 const fs = require('fs')
 
+const readFileSyncOptions = {
+  encoding: gc.UTF8_ENCODING,
+}
+
 class CustomObjectHandler extends StandardHandler {
   handleAddition() {
     super.handleAddition()
-    if (
-      !this.config.generateDelta ||
-      this.type !== CustomObjectHandler.OBJECT_TYPE
-    )
-      return
+    if (!this.config.generateDelta) return
+    this._handleMasterDetailException()
+  }
+
+  _handleMasterDetailException() {
+    if (this.type !== CustomObjectHandler.OBJECT_TYPE) return
+
     const fieldsFolder = path.resolve(
       this.config.repo,
       path.join(path.parse(this.line).dir, mc.FIELD_DIRECTORY_NAME)
     )
-    if (fs.existsSync(fieldsFolder)) {
-      fs.readdirSync(fieldsFolder)
-        .filter(fieldPath =>
-          fs
-            .readFileSync(
-              path.resolve(this.config.repo, fieldsFolder, fieldPath),
-              {
-                encoding: gc.UTF8_ENCODING,
-              }
-            )
-            .includes(mc.MASTER_DETAIL_TAG)
-        )
-        .forEach(field =>
-          this._copyFiles(
-            path.resolve(this.config.repo, fieldsFolder, field),
-            path.resolve(this.config.output, fieldsFolder, field)
+    if (!fs.existsSync(fieldsFolder)) return
+
+    fs.readdirSync(fieldsFolder)
+      .filter(fieldPath =>
+        fs
+          .readFileSync(
+            path.resolve(this.config.repo, fieldsFolder, fieldPath),
+            readFileSyncOptions
           )
+          .includes(mc.MASTER_DETAIL_TAG)
+      )
+      .forEach(field =>
+        this._copyFiles(
+          path.resolve(this.config.repo, fieldsFolder, field),
+          path.resolve(this.config.output, fieldsFolder, field)
         )
-    }
+      )
   }
 
   static OBJECT_TYPE = 'objects'

--- a/src/service/customObjectHandler.js
+++ b/src/service/customObjectHandler.js
@@ -5,12 +5,14 @@ const mc = require('../utils/metadataConstants')
 const path = require('path')
 const fs = require('fs')
 
-const OBJECT_TYPE = 'objects'
-
 class CustomObjectHandler extends StandardHandler {
   handleAddition() {
     super.handleAddition()
-    if (!this.config.generateDelta || this.type !== OBJECT_TYPE) return
+    if (
+      !this.config.generateDelta ||
+      this.type !== CustomObjectHandler.OBJECT_TYPE
+    )
+      return
     const fieldsFolder = path.resolve(
       this.config.repo,
       path.join(path.parse(this.line).dir, mc.FIELD_DIRECTORY_NAME)
@@ -35,6 +37,8 @@ class CustomObjectHandler extends StandardHandler {
         )
     }
   }
+
+  static OBJECT_TYPE = 'objects'
 }
 
 module.exports = CustomObjectHandler

--- a/src/service/typeHandlerFactory.js
+++ b/src/service/typeHandlerFactory.js
@@ -41,6 +41,8 @@ const classes = {
   workflows: InFile,
 }
 
+const haveSubTypes = [CustomObject.OBJECT_TYPE, '']
+
 module.exports = class HandlerFactory {
   constructor(work, metadata) {
     this.work = work
@@ -52,7 +54,8 @@ module.exports = class HandlerFactory {
       .split(path.sep)
       .reduce(
         (acc, value) =>
-          Object.prototype.hasOwnProperty.call(this.metadata, value)
+          Object.prototype.hasOwnProperty.call(this.metadata, value) &&
+          haveSubTypes.includes(acc)
             ? value
             : acc,
         ''

--- a/src/service/typeHandlerFactory.js
+++ b/src/service/typeHandlerFactory.js
@@ -41,7 +41,8 @@ const classes = {
   workflows: InFile,
 }
 
-const haveSubTypes = [CustomObject.OBJECT_TYPE, '']
+const EMPTY_STRING = ''
+const haveSubTypes = [CustomObject.OBJECT_TYPE, EMPTY_STRING]
 
 module.exports = class HandlerFactory {
   constructor(work, metadata) {
@@ -50,16 +51,13 @@ module.exports = class HandlerFactory {
   }
 
   getTypeHandler(line) {
-    const type = line
-      .split(path.sep)
-      .reduce(
-        (acc, value) =>
-          Object.prototype.hasOwnProperty.call(this.metadata, value) &&
-          haveSubTypes.includes(acc)
-            ? value
-            : acc,
-        ''
-      )
+    const type = line.split(path.sep).reduce((acc, value, _, arr) => {
+      acc = Object.prototype.hasOwnProperty.call(this.metadata, value)
+        ? value
+        : acc
+      if (!haveSubTypes.includes(acc)) arr.splice(1)
+      return acc
+    }, EMPTY_STRING)
 
     return classes[type]
       ? new classes[type](line, type, this.work, this.metadata)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Make sure the "first possible type" is returned as soon as it is encountered in the path.
Implements lookahead possibility for path with types which can contains other types (ie: objects can contain fields also)

=> Implements fast loop exit with possible lookahead

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #171 

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Tested locally with the sfdx git delta playground

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Thu May  6 00:48:39 PDT 2021; root:xnu-6153.141.33~1/RELEASE_X86_64

**yarn version:** 1.22.11

**node version:** v14.16.0

**git version:** git version 2.32.0

**sfdx version:** sfdx-cli/7.110.0 darwin-x64 node-v14.16.0

**sgd plugin version:** 4.7.1