### PR TITLE
fix: inResource file identification

### DIFF
--- a/__tests__/unit/lib/service/inResourceHandler.test.js
+++ b/__tests__/unit/lib/service/inResourceHandler.test.js
@@ -36,6 +36,16 @@ const testContext = {
       'force-app/main/default/aura/component/component.cmp-meta.xml',
       new Set(['component']),
     ],
+    [
+      'experiences',
+      'force-app/main/default/experiences/component/subfolder/file.json',
+      new Set(['component']),
+    ],
+    [
+      'experiences',
+      'force-app/main/default/experiences/component-meta.xml',
+      new Set(['component']),
+    ],
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -4,7 +4,6 @@ const path = require('path')
 const fs = require('fs')
 const mc = require('../utils/metadataConstants')
 
-const STATIC_RESOURCE_TYPE = 'staticresources'
 const elementSrc = {}
 
 class ResourceHandler extends StandardHandler {
@@ -28,11 +27,7 @@ class ResourceHandler extends StandardHandler {
     }
 
     elementSrc[srcPath]
-      .filter(src =>
-        this.type === STATIC_RESOURCE_TYPE
-          ? src.startsWith(parsedElementName.name)
-          : src === parsedElementName.name
-      )
+      .filter(src => path.parse(src).name === parsedElementName.name)
       .forEach(src =>
         this._copyFiles(
           path.normalize(path.join(srcPath, src)),

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -4,24 +4,17 @@ const path = require('path')
 const fs = require('fs')
 const mc = require('../utils/metadataConstants')
 
+const STATIC_RESOURCE_TYPE = 'staticresources'
 const elementSrc = {}
 
 class ResourceHandler extends StandardHandler {
   constructor(line, type, work, metadata) {
     super(line, type, work, metadata)
-    this.elementRegex = new RegExp(
-      `(?<path>.*[/\\\\]${
-        StandardHandler.metadata[this.type].directoryName
-      })[/\\\\](?<name>[^/\\\\]*)+`,
-      'u'
-    )
   }
   handleAddition() {
     super.handleAddition()
     if (!this.config.generateDelta) return
-    const [, srcPath, elementName] = path
-      .join(this.config.repo, this.line)
-      .match(this.elementRegex)
+    const [, srcPath, elementName] = this._parseLine()
     const [targetPath] = `${path.join(this.config.output, this.line)}`.match(
       new RegExp(
         `.*[/\\\\]${StandardHandler.metadata[this.type].directoryName}`,
@@ -30,12 +23,16 @@ class ResourceHandler extends StandardHandler {
     )
 
     const parsedElementName = path.parse(elementName)
-
     if (!Object.prototype.hasOwnProperty.call(elementSrc, srcPath)) {
       elementSrc[srcPath] = fs.readdirSync(srcPath)
     }
+
     elementSrc[srcPath]
-      .filter(src => src.indexOf(parsedElementName.name) !== -1)
+      .filter(src =>
+        this.type === STATIC_RESOURCE_TYPE
+          ? src.startsWith(parsedElementName.name)
+          : src === parsedElementName.name
+      )
       .forEach(src =>
         this._copyFiles(
           path.normalize(path.join(srcPath, src)),
@@ -45,15 +42,25 @@ class ResourceHandler extends StandardHandler {
   }
 
   handleDeletion() {
-    const [, srcPath, elementName] = path
-      .join(this.config.repo, this.line)
-      .match(this.elementRegex)
-
+    const [, srcPath, elementName] = this._parseLine()
     if (fs.existsSync(path.join(srcPath, elementName))) {
       this.handleModification(this)
     } else {
       super.handleDeletion()
     }
+  }
+
+  _parseLine() {
+    return path
+      .join(this.config.repo, this.line)
+      .match(
+        new RegExp(
+          `(?<path>.*[/\\\\]${
+            StandardHandler.metadata[this.type].directoryName
+          })[/\\\\](?<name>[^/\\\\]*)+`,
+          'u'
+        )
+      )
   }
 
   _getElementName() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

fix the way we identify files contained in Resource metadata kind (staticresource, lwc, aura, experiences, waveTemplate) to be copied

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #176 

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Available for the next release

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Tue Jun 22 19:49:55 PDT 2021; root:xnu-6153.141.35~1/RELEASE_X86_64

**yarn version:** 1.22.11

**node version:** v14.16.0

**git version:** 2.32.0

**sfdx version:** sfdx-cli/7.110.0 darwin-x64 node-v14.16.0

**sgd plugin version:** 4.7.2
