### PR TITLE
feat: permissive git diff parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,22 +93,22 @@ If you encounter this issue while having installed the correct version of node o
 ## How to use it?
 
 <!-- commands -->
-* [`sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-P] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-sgdsourcedelta--f-string--t-string--r-filepath--i-filepath--d-filepath--s-filepath--p--o-filepath--a-number--d---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+* [`sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-W] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-sgdsourcedelta--f-string--t-string--r-filepath--i-filepath--d-filepath--s-filepath--w--o-filepath--a-number--d---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 
-## `sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-P] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-W] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
 Generate the sfdx content in source format and destructive change from two git commits
 
 ```
 USAGE
-  $ sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-P] 
+  $ sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-W] 
   [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel 
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
   -D, --ignore-destructive=ignore-destructive                                       ignore file to use
 
-  -P, --permissive-diff                                                             ignore git diff white char (space,
+  -W, --ignore-whitespace                                                           ignore git diff whitespace (space,
                                                                                     tab, eol) changes
 
   -a, --api-version=api-version                                                     [default: 52] salesforce API version

--- a/README.md
+++ b/README.md
@@ -93,20 +93,24 @@ If you encounter this issue while having installed the correct version of node o
 ## How to use it?
 
 <!-- commands -->
-* [`sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-sgdsourcedelta--f-string--t-string--r-filepath--i-filepath--d-filepath--s-filepath--o-filepath--a-number--d---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
+* [`sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-P] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`](#sfdx-sgdsourcedelta--f-string--t-string--r-filepath--i-filepath--d-filepath--s-filepath--p--o-filepath--a-number--d---json---loglevel-tracedebuginfowarnerrorfataltracedebuginfowarnerrorfatal)
 
-## `sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
+## `sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-P] [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
 Generate the sfdx content in source format and destructive change from two git commits
 
 ```
 USAGE
-  $ sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-o 
-  <filepath>] [-a <number>] [-d] [--json] [--loglevel 
+  $ sfdx sgd:source:delta -f <string> [-t <string>] [-r <filepath>] [-i <filepath>] [-D <filepath>] [-s <filepath>] [-P] 
+  [-o <filepath>] [-a <number>] [-d] [--json] [--loglevel 
   trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]
 
 OPTIONS
   -D, --ignore-destructive=ignore-destructive                                       ignore file to use
+
+  -P, --permissive-diff                                                             ignore git diff white char (space,
+                                                                                    tab, eol) changes
+
   -a, --api-version=api-version                                                     [default: 52] salesforce API version
 
   -d, --generate-delta                                                              generate delta files in [--output]

--- a/__tests__/unit/lib/utils/fileGitDiff.test.js
+++ b/__tests__/unit/lib/utils/fileGitDiff.test.js
@@ -46,7 +46,7 @@ describe(`test if fileGitDiff`, () => {
     const work = fileGitDiff(TEST_PATH, {
       output: '',
       repo: '',
-      permissiveDiff: true,
+      ignoreWhitespace: true,
     })
     expect(work).toStrictEqual(output)
   })

--- a/__tests__/unit/lib/utils/fileGitDiff.test.js
+++ b/__tests__/unit/lib/utils/fileGitDiff.test.js
@@ -37,7 +37,21 @@ describe(`test if fileGitDiff`, () => {
     expect(work).toStrictEqual(output)
   })
 
-  test('can parse git diff contexte line', () => {
+  test('can apply permissive git diff', () => {
+    const output = 'diff'
+
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: output,
+    }))
+    const work = fileGitDiff(TEST_PATH, {
+      output: '',
+      repo: '',
+      permissiveDiff: true,
+    })
+    expect(work).toStrictEqual(output)
+  })
+
+  test('can parse git diff context line', () => {
     const output = 'context line'
 
     child_process.spawnSync.mockImplementation(() => ({

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -31,7 +31,7 @@ describe(`test if repoGitDiff`, () => {
         output: '',
         repo: '',
         ignore: FORCEIGNORE_MOCK_PATH,
-        permissiveDiff: true,
+        ignoreWhitespace: true,
       },
       // eslint-disable-next-line no-undef
       globalMetadata

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -21,6 +21,24 @@ describe(`test if repoGitDiff`, () => {
     expect(work).toStrictEqual(output)
   })
 
+  test('can parse git permissively', () => {
+    const output = []
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: '',
+    }))
+    const work = repoGitDiff(
+      {
+        output: '',
+        repo: '',
+        ignore: FORCEIGNORE_MOCK_PATH,
+        permissiveDiff: true,
+      },
+      // eslint-disable-next-line no-undef
+      globalMetadata
+    )
+    expect(work).toStrictEqual(output)
+  })
+
   test('can resolve deletion', () => {
     const output = [
       'D      force-app/main/default/objects/Account/fields/awesome.field-meta.xml',

--- a/bin/cli
+++ b/bin/cli
@@ -22,6 +22,7 @@ const options = program
     messages.sourceFlag,
     CliHelper.SOURCE_DEFAULT_VALUE
   )
+  .option('-P, --permissive-diff', messages.permissiveDiffFlag)
   .option('-i, --ignore [file]', messages.ignoreFlag)
   .option('-D, --ignore-destructive [file]', messages.ignoreDestructiveFlag)
   .option(

--- a/bin/cli
+++ b/bin/cli
@@ -22,7 +22,7 @@ const options = program
     messages.sourceFlag,
     CliHelper.SOURCE_DEFAULT_VALUE
   )
-  .option('-P, --permissive-diff', messages.permissiveDiffFlag)
+  .option('-W, --ignore-whitespace', messages.ignoreWhitespaceFlag)
   .option('-i, --ignore [file]', messages.ignoreFlag)
   .option('-D, --ignore-destructive [file]', messages.ignoreDestructiveFlag)
   .option(

--- a/messages/delta.js
+++ b/messages/delta.js
@@ -11,6 +11,5 @@ module.exports = {
   ignoreDestructiveFlag: 'ignore file to use',
   apiVersionFlag: 'salesforce API version',
   deltaFlag: 'generate delta files in [--output] folder',
-  permissivediffFlag:
-    'allow spaces, blank lines and other indentation stuff to NOT be considered as diff',
+  permissiveDiffFlag: 'ignore git diff white char (space, tab, eol) changes',
 }

--- a/messages/delta.js
+++ b/messages/delta.js
@@ -11,4 +11,6 @@ module.exports = {
   ignoreDestructiveFlag: 'ignore file to use',
   apiVersionFlag: 'salesforce API version',
   deltaFlag: 'generate delta files in [--output] folder',
+  permissivediffFlag:
+    'allow spaces, blank lines and other indentation stuff to NOT be considered as diff',
 }

--- a/messages/delta.js
+++ b/messages/delta.js
@@ -11,5 +11,5 @@ module.exports = {
   ignoreDestructiveFlag: 'ignore file to use',
   apiVersionFlag: 'salesforce API version',
   deltaFlag: 'generate delta files in [--output] folder',
-  permissiveDiffFlag: 'ignore git diff white char (space, tab, eol) changes',
+  ignoreWhitespaceFlag: 'ignore git diff whitespace (space, tab, eol) changes',
 }

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -45,6 +45,11 @@ export default class SourceDeltaGenerate extends SfdxCommand {
       description: messages.getMessage('sourceFlag'),
       default: CliHelper.SOURCE_DEFAULT_VALUE,
     }),
+    permissivediff: flags.boolean({
+      char: 'P',
+      description: messages.getMessage('permissivediffFlag'),
+      default: false,
+    }),
     output: flags.filepath({
       char: 'o',
       description: messages.getMessage('outputFlag'),
@@ -78,6 +83,7 @@ export default class SourceDeltaGenerate extends SfdxCommand {
         ignoreDestructive: this.flags['ignore-destructive'],
         apiVersion: this.flags['api-version'],
         repo: this.flags.repo,
+        permissivediff: this.flags.permissivediff,
         generateDelta: this.flags['generate-delta'],
       })
       output.warnings = jobResult?.warnings?.map(warning => warning.message)

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -45,9 +45,9 @@ export default class SourceDeltaGenerate extends SfdxCommand {
       description: messages.getMessage('sourceFlag'),
       default: CliHelper.SOURCE_DEFAULT_VALUE,
     }),
-    permissivediff: flags.boolean({
+    'permissive-diff': flags.boolean({
       char: 'P',
-      description: messages.getMessage('permissivediffFlag'),
+      description: messages.getMessage('permissiveDiffFlag'),
       default: false,
     }),
     output: flags.filepath({
@@ -83,7 +83,7 @@ export default class SourceDeltaGenerate extends SfdxCommand {
         ignoreDestructive: this.flags['ignore-destructive'],
         apiVersion: this.flags['api-version'],
         repo: this.flags.repo,
-        permissivediff: this.flags.permissivediff,
+        permissiveDiff: this.flags['permissive-diff'],
         generateDelta: this.flags['generate-delta'],
       })
       output.warnings = jobResult?.warnings?.map(warning => warning.message)

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -82,7 +82,7 @@ export default class SourceDeltaGenerate extends SfdxCommand {
         ignoreDestructive: this.flags['ignore-destructive'],
         apiVersion: this.flags['api-version'],
         repo: this.flags.repo,
-        ignoreWhitespace: this.flags['--ignore-whitespace'],
+        ignoreWhitespace: this.flags['ignore-whitespace'],
         generateDelta: this.flags['generate-delta'],
       })
       output.warnings = jobResult?.warnings?.map(warning => warning.message)

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -45,10 +45,9 @@ export default class SourceDeltaGenerate extends SfdxCommand {
       description: messages.getMessage('sourceFlag'),
       default: CliHelper.SOURCE_DEFAULT_VALUE,
     }),
-    'permissive-diff': flags.boolean({
-      char: 'P',
-      description: messages.getMessage('permissiveDiffFlag'),
-      default: false,
+    'ignore-whitespace': flags.boolean({
+      char: 'W',
+      description: messages.getMessage('ignoreWhitespaceFlag'),
     }),
     output: flags.filepath({
       char: 'o',
@@ -83,7 +82,7 @@ export default class SourceDeltaGenerate extends SfdxCommand {
         ignoreDestructive: this.flags['ignore-destructive'],
         apiVersion: this.flags['api-version'],
         repo: this.flags.repo,
-        permissiveDiff: this.flags['permissive-diff'],
+        ignoreWhitespace: this.flags['--ignore-whitespace'],
         generateDelta: this.flags['generate-delta'],
       })
       output.warnings = jobResult?.warnings?.map(warning => warning.message)

--- a/src/utils/fileGitDiff.js
+++ b/src/utils/fileGitDiff.js
@@ -6,9 +6,19 @@ const gc = require('./gitConstants')
 const unitDiffParams = ['--no-pager', 'diff', '--no-prefix', '-U200']
 
 module.exports = (filePath, config) => {
+  const permissiveDiffParams = config.permissiveDiff
+    ? gc.PERMISSIVE_DIFF_PARAMS
+    : []
   const { stdout: diff } = childProcess.spawnSync(
     'git',
-    [...unitDiffParams, config.from, config.to, '--', filePath],
+    [
+      ...unitDiffParams,
+      ...permissiveDiffParams,
+      config.from,
+      config.to,
+      '--',
+      filePath,
+    ],
     { cwd: config.repo, encoding: gc.UTF8_ENCODING }
   )
 

--- a/src/utils/fileGitDiff.js
+++ b/src/utils/fileGitDiff.js
@@ -6,14 +6,14 @@ const gc = require('./gitConstants')
 const unitDiffParams = ['--no-pager', 'diff', '--no-prefix', '-U200']
 
 module.exports = (filePath, config) => {
-  const permissiveDiffParams = config.permissiveDiff
-    ? gc.PERMISSIVE_DIFF_PARAMS
+  const ignoreWhitespaceParams = config.ignoreWhitespace
+    ? gc.IGNORE_WHITESPACE_PARAMS
     : []
   const { stdout: diff } = childProcess.spawnSync(
     'git',
     [
       ...unitDiffParams,
-      ...permissiveDiffParams,
+      ...ignoreWhitespaceParams,
       config.from,
       config.to,
       '--',

--- a/src/utils/gitConstants.js
+++ b/src/utils/gitConstants.js
@@ -3,7 +3,7 @@ module.exports.ADDITION = 'A'
 module.exports.DELETION = 'D'
 module.exports.GIT_DIFF_TYPE_REGEX = /^.\s+/u
 module.exports.MINUS = '-'
-module.exports.PERMISSIVE_DIFF_PARAMS = [
+module.exports.IGNORE_WHITESPACE_PARAMS = [
   '--ignore-all-space',
   '--ignore-blank-lines',
   '--ignore-cr-at-eol',

--- a/src/utils/gitConstants.js
+++ b/src/utils/gitConstants.js
@@ -3,5 +3,11 @@ module.exports.ADDITION = 'A'
 module.exports.DELETION = 'D'
 module.exports.GIT_DIFF_TYPE_REGEX = /^.\s+/u
 module.exports.MINUS = '-'
+module.exports.PERMISSIVE_DIFF_PARAMS = [
+  '--ignore-all-space',
+  '--ignore-blank-lines',
+  '--ignore-cr-at-eol',
+  '--word-diff-regex',
+]
 module.exports.PLUS = '+'
 module.exports.UTF8_ENCODING = 'utf8'

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -13,21 +13,18 @@ const lcSensitivity = {
 }
 
 module.exports = (config, metadata) => {
-  // If --permissivediff argument, allow spaces, blank lines and other indentation stuff to NOT be considered as diff
-  if (config.permissivediff === true) {
-    fullDiffParams.push(
-      ...[
-        '--ignore-all-space',
-        '--ignore-blank-lines',
-        '--ignore-cr-at-eol',
-        '--word-diff-regex',
-      ]
-    )
-  }
-  // Call git diff
+  const permissiveDiffParams = config.permissiveDiff
+    ? gc.PERMISSIVE_DIFF_PARAMS
+    : []
   const { stdout: diff } = childProcess.spawnSync(
     'git',
-    [...fullDiffParams, config.from, config.to, config.source],
+    [
+      ...fullDiffParams,
+      ...permissiveDiffParams,
+      config.from,
+      config.to,
+      config.source,
+    ],
     { cwd: config.repo, encoding: gc.UTF8_ENCODING }
   )
 

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -13,6 +13,18 @@ const lcSensitivity = {
 }
 
 module.exports = (config, metadata) => {
+  // If --permissivediff argument, allow spaces, blank lines and other indentation stuff to NOT be considered as diff
+  if (config.permissivediff === true) {
+    fullDiffParams.push(
+      ...[
+        '--ignore-all-space',
+        '--ignore-blank-lines',
+        '--ignore-cr-at-eol',
+        '--word-diff-regex',
+      ]
+    )
+  }
+  // Call git diff
   const { stdout: diff } = childProcess.spawnSync(
     'git',
     [...fullDiffParams, config.from, config.to, config.source],

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -13,14 +13,14 @@ const lcSensitivity = {
 }
 
 module.exports = (config, metadata) => {
-  const permissiveDiffParams = config.permissiveDiff
-    ? gc.PERMISSIVE_DIFF_PARAMS
+  const ignoreWhitespaceParams = config.ignoreWhitespace
+    ? gc.IGNORE_WHITESPACE_PARAMS
     : []
   const { stdout: diff } = childProcess.spawnSync(
     'git',
     [
       ...fullDiffParams,
-      ...permissiveDiffParams,
+      ...ignoreWhitespaceParams,
       config.from,
       config.to,
       config.source,


### PR DESCRIPTION
Manage a new argument --permissivediff to add the following parameters to git diff call

```javascript
[
    '--ignore-all-space',
    '--ignore-blank-lines',
    '--ignore-cr-at-eol',
    '--word-diff-regex',
]
```

It allows to avoid detecting as a difference the indentation/spaces stuff

Fixes #184