### PR TITLE
fix: issue when filtering same file name for different metadata

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,10 +1,7 @@
 {
     "*.js": [
-        "prettier --write",
-        "git add"
-    ],
-    ".js": [
         "yarn lint:fix",
-        "yarn lint"
+        "yarn lint",
+        "prettier --write"
     ]
 }

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -1,6 +1,6 @@
 'use strict'
 const os = require('os')
-const repoGitDiff = require('../../../../src/utils/repoGitDiff')
+const RepoGitDiff = require('../../../../src/utils/repoGitDiff')
 const child_process = require('child_process')
 jest.mock('child_process', () => ({ spawnSync: jest.fn() }))
 jest.mock('fs-extra')
@@ -13,11 +13,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: '',
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     expect(work).toStrictEqual(output)
   })
 
@@ -26,7 +27,7 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: '',
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       {
         output: '',
         repo: '',
@@ -36,6 +37,7 @@ describe(`test if repoGitDiff`, () => {
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     expect(work).toStrictEqual(output)
   })
 
@@ -46,11 +48,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     expect(work).toMatchObject(output)
   })
 
@@ -61,8 +64,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    // eslint-disable-next-line no-undef
-    const work = repoGitDiff({ output: '', repo: '' }, globalMetadata)
+    const repoGitDiff = new RepoGitDiff(
+      { output: '', repo: '' },
+      // eslint-disable-next-line no-undef
+      globalMetadata
+    )
+    const work = repoGitDiff.getDiff()
     expect(work).toStrictEqual(output)
   })
 
@@ -73,8 +80,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    // eslint-disable-next-line no-undef
-    const work = repoGitDiff({ output: '', repo: '' }, globalMetadata)
+    const repoGitDiff = new RepoGitDiff(
+      { output: '', repo: '' },
+      // eslint-disable-next-line no-undef
+      globalMetadata
+    )
+    const work = repoGitDiff.getDiff()
     expect(work).toStrictEqual(output)
   })
 
@@ -83,11 +94,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     //should be empty
     const expected = []
     expect(work).toStrictEqual(expected)
@@ -98,11 +110,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignoreDestructive: FORCEIGNORE_MOCK_PATH },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     //should be empty
     const expected = []
     expect(work).toStrictEqual(expected)
@@ -116,7 +129,7 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       {
         output: '',
         repo: '',
@@ -126,6 +139,7 @@ describe(`test if repoGitDiff`, () => {
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     //should be empty
     const expected = []
     expect(work).toStrictEqual(expected)
@@ -136,11 +150,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     //should be empty
     const expected = []
     expect(work).toStrictEqual(expected)
@@ -151,11 +166,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignoreDestructive: FORCEIGNORE_MOCK_PATH },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     expect(work).toStrictEqual(output)
   })
 
@@ -164,11 +180,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output[0],
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     //should be empty
     const expected = []
     expect(work).toStrictEqual(expected)
@@ -182,11 +199,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output.join(os.EOL),
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     const expected = [output[1]]
     expect(work).toStrictEqual(expected)
   })
@@ -199,11 +217,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output.join(os.EOL),
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     const expected = [output[1]]
     expect(work).toStrictEqual(expected)
   })
@@ -216,11 +235,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output.join(os.EOL),
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     expect(work).toStrictEqual(output)
   })
 
@@ -232,11 +252,12 @@ describe(`test if repoGitDiff`, () => {
     child_process.spawnSync.mockImplementation(() => ({
       stdout: output.join(os.EOL),
     }))
-    const work = repoGitDiff(
+    const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       // eslint-disable-next-line no-undef
       globalMetadata
     )
+    const work = repoGitDiff.getDiff()
     expect(work).toStrictEqual(output)
   })
 
@@ -246,7 +267,8 @@ describe(`test if repoGitDiff`, () => {
       throw expected
     })
     try {
-      repoGitDiff({ output: '', repo: '' })
+      const repoGitDiff = new RepoGitDiff({ output: '', repo: '' }, null)
+      repoGitDiff.getDiff()
     } catch (e) {
       expect(e).toBe(expected)
     }

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -224,6 +224,22 @@ describe(`test if repoGitDiff`, () => {
     expect(work).toStrictEqual(output)
   })
 
+  test('cannot filter same name file with different metadata', () => {
+    const output = [
+      'D      force-app/main/default/objects/Account/fields/CustomField__c.field-meta.xml',
+      'A      force-app/main/default/objects/Opportunity/fields/CustomField__c.field-meta.xml',
+    ]
+    child_process.spawnSync.mockImplementation(() => ({
+      stdout: output.join(os.EOL),
+    }))
+    const work = repoGitDiff(
+      { output: '', repo: '' },
+      // eslint-disable-next-line no-undef
+      globalMetadata
+    )
+    expect(work).toStrictEqual(output)
+  })
+
   test('can reject in case of error', () => {
     const expected = new Error('Test Error')
     child_process.spawnSync.mockImplementation(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ const PackageConstructor = require('./utils/packageConstructor')
 const TypeHandlerFactory = require('./service/typeHandlerFactory')
 const metadataManager = require('./metadata/metadataManager')
 const CLIHelper = require('./utils/cliHelper')
-const repoGitDiff = require('./utils/repoGitDiff')
+const RepoGitDiff = require('./utils/repoGitDiff')
 
 const fse = require('fs-extra')
 const path = require('path')
@@ -20,8 +20,9 @@ module.exports = config => {
     'directoryName',
     config.apiVersion
   )
+  const repoGitDiffHelper = new RepoGitDiff(config, metadata)
 
-  const lines = repoGitDiff(config, metadata)
+  const lines = repoGitDiffHelper.getDiff(config, metadata)
   const work = treatDiff(config, lines, metadata)
   treatPackages(work.diffs, config, metadata)
   return work

--- a/src/service/inTranslationHandler.js
+++ b/src/service/inTranslationHandler.js
@@ -16,6 +16,8 @@ class TranslationHandler extends ResourceHandler {
       path.normalize(path.join(this.config.output, objectTranslationName))
     )
   }
+
+  static OBJECT_TRANSLATION_TYPE = 'objectTranslations'
 }
 
 module.exports = TranslationHandler

--- a/src/service/subCustomObjectHandler.js
+++ b/src/service/subCustomObjectHandler.js
@@ -40,6 +40,20 @@ class SubCustomObjectHandler extends StandardHandler {
 
     packageObject[this.type].add(`${prefix}.${elementName}`)
   }
+
+  static SUB_OBJECT_TYPES = [
+    'businessProcesses',
+    'compactLayouts',
+    'fieldSets',
+    'fields',
+    'listViews',
+    'recordTypes',
+    'rules',
+    'sharingReasons',
+    'territories',
+    'validationRules',
+    'webLinks',
+  ]
 }
 
 module.exports = SubCustomObjectHandler

--- a/src/service/typeHandlerFactory.js
+++ b/src/service/typeHandlerFactory.js
@@ -8,7 +8,7 @@ const SubCustomObject = require('./subCustomObjectHandler')
 const InTranslation = require('./inTranslationHandler')
 const Wave = require('./waveHandler')
 
-const path = require('path')
+const typeUtils = require('../utils/typeUtils')
 
 const classes = {
   aura: InResource,
@@ -41,9 +41,6 @@ const classes = {
   workflows: InFile,
 }
 
-const EMPTY_STRING = ''
-const haveSubTypes = [CustomObject.OBJECT_TYPE, EMPTY_STRING]
-
 module.exports = class HandlerFactory {
   constructor(work, metadata) {
     this.work = work
@@ -51,13 +48,7 @@ module.exports = class HandlerFactory {
   }
 
   getTypeHandler(line) {
-    const type = line.split(path.sep).reduce((acc, value, _, arr) => {
-      acc = Object.prototype.hasOwnProperty.call(this.metadata, value)
-        ? value
-        : acc
-      if (!haveSubTypes.includes(acc)) arr.splice(1)
-      return acc
-    }, EMPTY_STRING)
+    const type = typeUtils.getType(line, this.metadata)
 
     return classes[type]
       ? new classes[type](line, type, this.work, this.metadata)

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -1,5 +1,9 @@
 'use strict'
 const cpUtils = require('./childProcessUtils')
+const CustomObject = require('../service/customObjectHandler')
+const InTranslation = require('../service/inTranslationHandler')
+const SubCustomObject = require('../service/subCustomObjectHandler')
+const typeUtils = require('../utils/typeUtils')
 const gc = require('./gitConstants')
 const childProcess = require('child_process')
 const fs = require('fs')
@@ -12,68 +16,101 @@ const lcSensitivity = {
   sensitivity: 'accent',
 }
 
-module.exports = (config, metadata) => {
-  const ignoreWhitespaceParams = config.ignoreWhitespace
-    ? gc.IGNORE_WHITESPACE_PARAMS
-    : []
-  const { stdout: diff } = childProcess.spawnSync(
-    'git',
-    [
-      ...fullDiffParams,
-      ...ignoreWhitespaceParams,
-      config.from,
-      config.to,
-      config.source,
-    ],
-    { cwd: config.repo, encoding: gc.UTF8_ENCODING }
-  )
+const pathType = [
+  CustomObject.OBJECT_TYPE,
+  InTranslation.OBJECT_TRANSLATION_TYPE,
+  ...SubCustomObject.SUB_OBJECT_TYPES,
+]
+class RepoGitDiff {
+  constructor(config, metadata) {
+    this.config = config
+    this.metadata = metadata
+  }
 
-  return treatResult(cpUtils.treatDataFromSpawn(diff), metadata, config)
-}
-
-const treatResult = (repoDiffResult, metadata, config) => {
-  const lines = repoDiffResult.split(os.EOL)
-  const linesPerDiffType = lines.reduce(
-    (acc, line) => (acc[line.charAt(0)]?.push(line), acc),
-    { [gc.ADDITION]: [], [gc.DELETION]: [] }
-  )
-  const AfileNames = linesPerDiffType[gc.ADDITION].map(
-    line => path.parse(line.replace(gc.GIT_DIFF_TYPE_REGEX, '')).base
-  )
-  const deletedRenamed = linesPerDiffType[gc.DELETION].filter(line => {
-    const dEl = path.parse(line.replace(gc.GIT_DIFF_TYPE_REGEX, '')).base
-    return AfileNames.some(
-      aEl => !aEl.localeCompare(dEl, undefined, lcSensitivity)
+  getDiff() {
+    const ignoreWhitespaceParams = this.config.ignoreWhitespace
+      ? gc.IGNORE_WHITESPACE_PARAMS
+      : []
+    const { stdout: diff } = childProcess.spawnSync(
+      'git',
+      [
+        ...fullDiffParams,
+        ...ignoreWhitespaceParams,
+        this.config.from,
+        this.config.to,
+        this.config.source,
+      ],
+      { cwd: this.config.repo, encoding: gc.UTF8_ENCODING }
     )
-  })
+    return this._treatResult(cpUtils.treatDataFromSpawn(diff))
+  }
 
-  return lines
-    .filter(
-      line =>
-        !!line &&
-        !deletedRenamed.includes(line) &&
-        line
-          .split(path.sep)
-          .some(part => Object.prototype.hasOwnProperty.call(metadata, part))
+  _treatResult(repoDiffResult) {
+    const lines = repoDiffResult.split(os.EOL)
+    const linesPerDiffType = lines.reduce(
+      (acc, line) => (acc[line.charAt(0)]?.push(line), acc),
+      { [gc.ADDITION]: [], [gc.DELETION]: [] }
     )
-    .filter(filterIgnore(config))
-}
+    const AfileNames = linesPerDiffType[gc.ADDITION].map(line =>
+      this._extractComparisonName(line)
+    )
+    const deletedRenamed = linesPerDiffType[gc.DELETION].filter(line => {
+      const dEl = this._extractComparisonName(line)
+      return AfileNames.some(
+        aEl => !aEl.localeCompare(dEl, undefined, lcSensitivity)
+      )
+    })
 
-const filterIgnore = config => line => {
-  const ig = ignore()
-  const dig = ignore()
-  ;[
-    { ignore: config.ignore, helper: ig },
-    { ignore: config.ignoreDestructive, helper: dig },
-  ].forEach(
-    ign =>
-      ign.ignore &&
-      fs.existsSync(ign.ignore) &&
-      ign.helper.add(fs.readFileSync(ign.ignore).toString())
-  )
-  return config.ignoreDestructive
-    ? line.startsWith(gc.DELETION)
-      ? !dig.ignores(line.replace(gc.GIT_DIFF_TYPE_REGEX, ''))
+    return lines
+      .filter(
+        line =>
+          !!line &&
+          !deletedRenamed.includes(line) &&
+          line
+            .split(path.sep)
+            .some(part =>
+              Object.prototype.hasOwnProperty.call(this.metadata, part)
+            )
+      )
+      .filter(line => this._filterIgnore(line))
+  }
+
+  _filterIgnore(line) {
+    const ig = ignore()
+    const dig = ignore()
+    ;[
+      { ignore: this.config.ignore, helper: ig },
+      { ignore: this.config.ignoreDestructive, helper: dig },
+    ].forEach(
+      ign =>
+        ign.ignore &&
+        fs.existsSync(ign.ignore) &&
+        ign.helper.add(fs.readFileSync(ign.ignore).toString())
+    )
+    return this.config.ignoreDestructive
+      ? line.startsWith(gc.DELETION)
+        ? !dig.ignores(line.replace(gc.GIT_DIFF_TYPE_REGEX, ''))
+        : !ig.ignores(line.replace(gc.GIT_DIFF_TYPE_REGEX, ''))
       : !ig.ignores(line.replace(gc.GIT_DIFF_TYPE_REGEX, ''))
-    : !ig.ignores(line.replace(gc.GIT_DIFF_TYPE_REGEX, ''))
+  }
+
+  _extractComparisonName(line) {
+    const type = typeUtils.getType(line, this.metadata)
+    const el = path.parse(line.replace(gc.GIT_DIFF_TYPE_REGEX, ''))
+    let comparisonName = el.base
+    if (pathType.includes(type)) {
+      comparisonName = line
+        .split(path.sep)
+        .reduce(
+          (acc, value) =>
+            acc || Object.prototype.hasOwnProperty.call(this.metadata, value)
+              ? acc + value
+              : acc,
+          ''
+        )
+    }
+    return comparisonName
+  }
 }
+
+module.exports = RepoGitDiff

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -62,17 +62,18 @@ class RepoGitDiff {
     })
 
     return lines
-      .filter(
-        line =>
-          !!line &&
-          !deletedRenamed.includes(line) &&
-          line
-            .split(path.sep)
-            .some(part =>
-              Object.prototype.hasOwnProperty.call(this.metadata, part)
-            )
-      )
+      .filter(line => this._filterInternal(line, deletedRenamed))
       .filter(line => this._filterIgnore(line))
+  }
+
+  _filterInternal(line, deletedRenamed) {
+    return (
+      !!line &&
+      !deletedRenamed.includes(line) &&
+      line
+        .split(path.sep)
+        .some(part => Object.prototype.hasOwnProperty.call(this.metadata, part))
+    )
   }
 
   _filterIgnore(line) {

--- a/src/utils/typeUtils.js
+++ b/src/utils/typeUtils.js
@@ -1,0 +1,11 @@
+const CustomObject = require('../service/customObjectHandler')
+const path = require('path')
+
+const haveSubTypes = [CustomObject.OBJECT_TYPE, '']
+
+module.exports.getType = (line, metadata) =>
+  line.split(path.sep).reduce((acc, value, _, arr) => {
+    acc = Object.prototype.hasOwnProperty.call(metadata, value) ? value : acc
+    if (!haveSubTypes.includes(acc)) arr.splice(1)
+    return acc
+  }, '')


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

It builds a more complete base of comparison to detect which file is deleted, renamed, added, moved by taking part of the path containing available metadata type.
For exemple :
`force-app/main/default/objects/Account/fields/CustomField__c.field-meta.xml`
before the algorithm was taking `CustomField__c.field-meta.xml` as comparison element
now it takes `objects/Account/fields/CustomField__c.field-meta.xml`
which allow to have the same field for another object being manipulated by the plugin



## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #193

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

You can use the sgd reproduction playground branch [issue/193](https://github.com/scolladon/sfdx-git-delta-reproduction-playground/tree/issue/193) to test current version of sgd (4.9.0) against the one in this PR

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Next release can be considered to ship this

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Thu Sep 16 20:58:47 PDT 2021; root:xnu-6153.141.40.1~1/RELEASE_X86_64

**yarn version:** 1.22.11

**node version:** v16.10.0

**git version:** 2.33.0

**sfdx version:** sfdx-cli/7.120.0 darwin-x64 node-v16.10.0

**sgd plugin version:** 4.9.0
