### PR TITLE
build: use `pull_request_target` for pull request ci

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [master]
 
 jobs:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

It contains a change of target for our pull request CI workflow in order to be able to run PR lint for Pull Request created from forked repository

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [X] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

It uses the `pull_request_target` on attribut instead of the `pull_request`.
Explanation [here](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target)