### PR TITLE
fix: spawn buffer size

### DIFF
--- a/src/utils/fileGitDiff.js
+++ b/src/utils/fileGitDiff.js
@@ -19,7 +19,7 @@ module.exports = (filePath, config) => {
       '--',
       filePath,
     ],
-    { cwd: config.repo, encoding: gc.UTF8_ENCODING }
+    { cwd: config.repo, encoding: gc.UTF8_ENCODING, maxBuffer: 1024 * 10240 }
   )
 
   return cpUtils.treatEOL(diff)

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -28,13 +28,19 @@ class RepoGitDiff {
   constructor(config, metadata) {
     this.config = config
     this.metadata = metadata
+    this.spawnConfig = {
+      cwd: this.config.repo,
+      encoding: gc.UTF8_ENCODING,
+      maxBuffer: 1024 * 10240,
+    }
   }
 
   getIncludedFiles() {
-    const { stdout: ls } = childProcess.spawnSync('git', [...allFilesParams], {
-      cwd: this.config.repo,
-      encoding: gc.UTF8_ENCODING,
-    })
+    const { stdout: ls } = childProcess.spawnSync(
+      'git',
+      [...allFilesParams],
+      this.spawnConfig
+    )
     return this._addIncludes(cpUtils.treatDataFromSpawn(ls))
   }
 
@@ -51,7 +57,7 @@ class RepoGitDiff {
         this.config.to,
         this.config.source,
       ],
-      { cwd: this.config.repo, encoding: gc.UTF8_ENCODING }
+      this.spawnConfig
     )
     return this._treatResult(cpUtils.treatDataFromSpawn(diff))
   }

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -105,7 +105,7 @@ class RepoGitDiff {
               .readFileSync(obj.include)
               .toString()
               .split(os.EOL)
-              .filter(i => i)
+              .filter(Boolean)
           ).map(include => `${obj.prefix}      ${include}`)
         : []
     })


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

This fixes issue with very large code base that need to be parsed.
But it may fall into the buffer size issue which may not be enough on certain environment.
This should be [refactored to use stream, event, promise and async/await](https://github.com/scolladon/sfdx-git-delta/projects/1#card-75522144) to get rid of this buffer.

Change the buffer size for each call to `child_process.spawnSync`, set it to 10MB
The buffer is not set as a constant but each file defines the same value as each file may want to have a different value (`repoGitDiff` and `fileGitDiff`)


## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #192

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

Use a very large repository (>20k metadata element)

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Sun Nov 14 19:58:51 PST 2021; root:xnu-6153.141.50~1/RELEASE_X86_64

**yarn version:** 1.22.15

**node version:** v14.18.1

**git version:** 2.24.1

**sfdx version:** sfdx-cli/7.132.0 darwin-x64 node-v14.18.1

**sgd plugin version:** 4.12.0
