### PR TITLE
feat: output folder will be created if it doesn't exist

### DIFF
--- a/__tests__/unit/lib/utils/cliHelper.test.js
+++ b/__tests__/unit/lib/utils/cliHelper.test.js
@@ -47,16 +47,6 @@ describe(`test if the appli`, () => {
     }).toThrow()
   })
 
-  test('throw errors when output folder does not exist', () => {
-    cliHelper = new CLIHelper({ ...testConfig, to: undefined })
-    expect(() => {
-      cliHelper.validateConfig({
-        ...testConfig,
-        output: 'not/exist/folder',
-      })
-    }).toThrow()
-  })
-
   test('throw errors when output is not a folder', () => {
     cliHelper = new CLIHelper({ ...testConfig, output: 'file' })
     expect(() => {

--- a/src/utils/cliHelper.js
+++ b/src/utils/cliHelper.js
@@ -23,9 +23,13 @@ class CLIHelper {
     if (isNaN(this.config.apiVersion)) {
       errors.push(`api-version ${this.config.apiVersion} is not a number`)
     }
-    ;[this.config.output, this.config.source]
-      .filter(dir => !dirExist(dir))
-      .forEach(dir => errors.push(`${dir} folder does not exist`))
+    if (!dirExist(this.config.source)) {
+      fs.mkdir(this.config.source, { recursive: true }, err => {
+        if (err) {
+          errors.push(`${this.config.source} folder could not be created`)
+        }
+      })
+    }
     ;[
       this.config.ignore,
       this.config.ignoreDestructive,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [x] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  If output folder doesn't exist, an attempt to create it will be made. An error will be thrown if folder can't be created.
-->

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #

- [ ] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  The value of the --output parameter will be tested to check if that folder exists. If not, an attempt to create it will be made. If this attempt fails, an error will be thrown.
-->

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

## Where has this been tested?
The old test for the requirement of the --output folder to exist was obsoleted as unnecessary.
---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** …

**yarn version:** …

**node version:** …

**git version:** …

**sfdx version:** …

**sgd plugin version:** …
