### PR TITLE
fix: rollback to hasOwnProperty

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -36,7 +36,7 @@ fs.promises.readFile = path =>
   new Promise((res, rej) => {
     if (fs.errorMode) rej(new Error())
     else {
-      const result = Object.hasOwn(mockContent, path)
+      const result = Object.prototype.hasOwnProperty.call(mockContent, path)
         ? mockContent[path]
         : MASTER_DETAIL_TAG
       res(result)

--- a/src/main.js
+++ b/src/main.js
@@ -74,7 +74,7 @@ const cleanPackages = dcJson => {
   const additive = dcJson[PACKAGE_FILE_NAME]
   const destructive = dcJson[DESTRUCTIVE_CHANGES_FILE_NAME]
   Object.keys(additive)
-    .filter(type => Object.hasOwn(destructive, type))
+    .filter(type => Object.prototype.hasOwnProperty.call(destructive, type))
     .forEach(
       type =>
         (destructive[type] = new Set(

--- a/src/metadata/metadataManager.js
+++ b/src/metadata/metadataManager.js
@@ -27,7 +27,7 @@ module.exports = {
     if (!describeMetadata[apiVersion]) {
       const apiMap = await getApiMap()
       const apiFile =
-        !!apiVersion && Object.hasOwn(apiMap, apiVersion)
+        !!apiVersion && Object.prototype.hasOwnProperty.call(apiMap, apiVersion)
           ? apiMap[apiVersion]
           : apiMap.latest
       describeMetadata[apiVersion] = require(resolve(__dirname, apiFile))

--- a/src/service/inFileHandler.js
+++ b/src/service/inFileHandler.js
@@ -152,7 +152,10 @@ class InFileHandler extends StandardHandler {
     const result = XML_HEADER + xmlParser.parse(file)
 
     const authorizedKeys = Object.keys(Object.values(result)[0]).filter(tag =>
-      Object.hasOwn(InFileHandler.xmlObjectToPackageType, tag)
+      Object.prototype.hasOwnProperty.call(
+        InFileHandler.xmlObjectToPackageType,
+        tag
+      )
     )
     return {
       authorizedKeys: authorizedKeys,
@@ -182,7 +185,10 @@ class InFileHandler extends StandardHandler {
     return (
       !!matchResult &&
       !!matchResult[1] &&
-      Object.hasOwn(InFileHandler.xmlObjectToPackageType, matchResult[1])
+      Object.prototype.hasOwnProperty.call(
+        InFileHandler.xmlObjectToPackageType,
+        matchResult[1]
+      )
     )
   }
 }

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -90,7 +90,7 @@ class ResourceHandler extends StandardHandler {
   }
 
   async _buildElementMap(srcPath) {
-    if (!Object.hasOwn(elementSrc, srcPath)) {
+    if (!Object.prototype.hasOwnProperty.call(elementSrc, srcPath)) {
       elementSrc[srcPath] = await readdir(srcPath)
     }
   }

--- a/src/utils/packageConstructor.js
+++ b/src/utils/packageConstructor.js
@@ -23,7 +23,7 @@ module.exports = class PackageConstructor {
     Object.keys(strucDiffPerType)
       .filter(
         type =>
-          Object.hasOwn(this.metadata, type) ||
+          Object.prototype.hasOwnProperty.call(this.metadata, type) ||
           this.looseMetadata.includes(type)
       )
       .sort(sortTypes)

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -114,7 +114,9 @@ class RepoGitDiff {
   _filterInternal(line, deletedRenamed) {
     return (
       !deletedRenamed.includes(line) &&
-      line.split(path.sep).some(part => Object.hasOwn(this.metadata, part))
+      line
+        .split(path.sep)
+        .some(part => Object.prototype.hasOwnProperty.call(this.metadata, part))
     )
   }
 
@@ -178,7 +180,9 @@ class RepoGitDiff {
         .split(path.sep)
         .reduce(
           (acc, value) =>
-            acc || Object.hasOwn(this.metadata, value) ? acc + value : acc,
+            acc || Object.prototype.hasOwnProperty.call(this.metadata, value)
+              ? acc + value
+              : acc,
           ''
         )
     }

--- a/src/utils/typeUtils.js
+++ b/src/utils/typeUtils.js
@@ -6,7 +6,7 @@ const haveSubTypes = [CustomObject.OBJECT_TYPE, '']
 
 module.exports.getType = (line, metadata) =>
   line.split(sep).reduce((acc, value, _, arr) => {
-    acc = Object.hasOwn(metadata, value) ? value : acc
+    acc = Object.prototype.hasOwnProperty.call(metadata, value) ? value : acc
     if (!haveSubTypes.includes(acc)) arr.splice(1)
     return acc
   }, '')


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---
Fix about `Object.hasOwn`  issue on main test


<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [x] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->
Fix about `Object.hasOwn` because it is not available on node 14
Rollback to use `Object.prototype.hasOwnProperty.call`

