### PR TITLE
fix: path resolution for master detail fields

### DIFF
--- a/__mocks__/fs-extra.js
+++ b/__mocks__/fs-extra.js
@@ -5,12 +5,16 @@ fse.errorMode = false
 fse.outputFileError = false
 fse.pathShouldExist = true
 
-fse.pathExists = () => Promise.resolve(fse.pathShouldExist)
-fse.copy = () => (fse.errorMode ? Promise.reject() : Promise.resolve())
-fse.copySync = () => {
+fse.pathExists = jest.fn(() => Promise.resolve(fse.pathShouldExist))
+fse.copy = jest.fn(() => {
+  if (fse.errorMode) return Promise.reject()
+  return Promise.resolve()
+})
+fse.copySync = jest.fn(() => {
   if (fse.errorMode) throw new Error()
-}
-fse.outputFile = () =>
+})
+fse.outputFile = jest.fn(() =>
   fse.outputFileError ? Promise.reject() : Promise.resolve()
+)
 
 module.exports = fse

--- a/__tests__/unit/lib/service/customObjectHandler.test.js
+++ b/__tests__/unit/lib/service/customObjectHandler.test.js
@@ -1,8 +1,10 @@
 'use strict'
 const CustomObjectHandler = require('../../../../src/service/customObjectHandler')
-const SubCustomObjectHandler = require('../../../../src/service/subCustomObjectHandler')
 const metadataManager = require('../../../../src/metadata/metadataManager')
+const { MASTER_DETAIL_TAG } = require('../../../../src/utils/metadataConstants')
+const { copy } = require('fs-extra')
 jest.mock('fs')
+jest.mock('fs-extra')
 
 const testContext = {
   handler: CustomObjectHandler,
@@ -32,58 +34,46 @@ const testContext = {
 // eslint-disable-next-line no-undef
 describe('test CustomObjectHandler with fields', () => {
   let globalMetadata
-  beforeAll(async () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
     require('fs').__setMockFiles({
       'force-app/main/default/objects/Account/Account.object-meta.xml': 'test',
       'force-app/main/default/objects/Account/fields': '',
       'force-app/main/default/objects/Account/fields/test__c.field-meta.xml':
-        SubCustomObjectHandler.MASTER_DETAIL_TAG,
+        MASTER_DETAIL_TAG,
       'force-app/main/default/objects/Test/Account/Account.object-meta.xml':
         'test',
-      'force-app/main/default/objects/Test/Account/fields/test__c.field-meta.xml':
-        SubCustomObjectHandler.MASTER_DETAIL_TAG,
+      'force-app/main/default/objects/Test/Account/fields/no':
+        MASTER_DETAIL_TAG,
     })
     globalMetadata = await metadataManager.getDefinition('directoryName', 50)
   })
 
-  // eslint-disable-next-line no-undef
-  testHandlerHelper(testContext)
-
-  test('addition', () => {
-    testContext.work.config.generateDelta = false
+  test('addition and masterdetail fields', async () => {
     const handler = new testContext.handler(
       'A       force-app/main/default/objects/Account/Account.object-meta.xml',
       'objects',
       testContext.work,
       globalMetadata
     )
-    handler.handle()
+    await handler.handle()
+    expect(copy).toBeCalled()
   })
+
+  // eslint-disable-next-line no-undef
+  testHandlerHelper(testContext)
 })
 
 // eslint-disable-next-line no-undef
 describe('test CustomObjectHandler without fields', () => {
-  let globalMetadata
   beforeAll(async () => {
     require('fs').__setMockFiles({
       'force-app/main/default/objects/Account/Account.object-meta.xml': 'test',
       'force-app/main/default/objects/Test/Account/Account.object-meta.xml':
         'test',
     })
-    globalMetadata = await metadataManager.getDefinition('directoryName', 50)
   })
 
   // eslint-disable-next-line no-undef
   testHandlerHelper(testContext)
-
-  test('addition', () => {
-    testContext.work.config.generateDelta = false
-    const handler = new testContext.handler(
-      'A       force-app/main/default/objects/Account/Account.object-meta.xml',
-      'objects',
-      testContext.work,
-      globalMetadata
-    )
-    handler.handle()
-  })
 })

--- a/src/service/botHandler.js
+++ b/src/service/botHandler.js
@@ -15,7 +15,7 @@ class BotHandler extends WaveHandler {
     return [...elementName].join('.')
   }
   async handleAddition() {
-    super.handleAddition()
+    await super.handleAddition()
 
     const botName = this._getParsedPath().dir.split(sep).pop()
     this._fillPackageWithParameter({

--- a/src/service/customObjectHandler.js
+++ b/src/service/customObjectHandler.js
@@ -16,7 +16,7 @@ const readFileOptions = {
 
 class CustomObjectHandler extends StandardHandler {
   async handleAddition() {
-    super.handleAddition()
+    await super.handleAddition()
     if (!this.config.generateDelta) return
     await this._handleMasterDetailException()
   }
@@ -24,7 +24,7 @@ class CustomObjectHandler extends StandardHandler {
   async _handleMasterDetailException() {
     if (this.type !== CustomObjectHandler.OBJECT_TYPE) return
 
-    const fieldsFolder = resolve(
+    const fieldsFolder = join(
       this.config.repo,
       join(parse(this.line).dir, FIELD_DIRECTORY_NAME)
     )

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -10,8 +10,8 @@ const { join, normalize, sep } = require('path')
 const INFOLDER_SUFFIX_REGEX = new RegExp(`${INFOLDER_SUFFIX}$`)
 const EXTENSION_SUFFIX_REGEX = new RegExp(/\.[^/.]+$/)
 class InFolderHandler extends StandardHandler {
-  handleAddition() {
-    super.handleAddition()
+  async handleAddition() {
+    await super.handleAddition()
     if (!this.config.generateDelta) return
 
     const regexRepo = this.config.repo !== '.' ? this.config.repo : ''

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -13,7 +13,7 @@ class ResourceHandler extends StandardHandler {
     super(line, type, work, metadata)
   }
   async handleAddition() {
-    super.handleAddition()
+    await super.handleAddition()
     if (!this.config.generateDelta) return
     const [, srcPath, elementName] = this._parseLine()
     const [targetPath] = `${join(this.config.output, this.line)}`.match(

--- a/src/service/subCustomObjectHandler.js
+++ b/src/service/subCustomObjectHandler.js
@@ -12,7 +12,7 @@ class SubCustomObjectHandler extends StandardHandler {
   }
 
   async handleAddition() {
-    super.handleAddition()
+    await super.handleAddition()
     if (!this.config.generateDelta) return
 
     const data = await this._readFile()


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Fix the path resolution when copying master detail fields for custom object part of the delta generated sources
Now, when a custom object is should be deployed and is copied in the output folder, master detail fields of this object will also be copied

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #263

- [X] Jest test to check the fix is applied are added.

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

You can test with the [playground](https://github.com/scolladon/sfdx-git-delta-reproduction-playground/tree/issue/263)
Or run the jest test

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 19.6.0: Thu Jan 13 01:26:33 PST 2022; root:xnu-6153.141.51~3/RELEASE_X86_64

**yarn version:** 1.22.15

**node version:** v14.19.0

**git version:** 2.35.1

**sfdx version:** sfdx-cli/7.142.1 darwin-x64 node-v14.19.0

**sgd plugin version:** 5.0.0
