### PR TITLE
refactor: use Map instead of {}

### DIFF
--- a/__mocks__/fast-xml-parser.js
+++ b/__mocks__/fast-xml-parser.js
@@ -1,26 +1,26 @@
 'use strict'
 const fxp = jest.genMockFromModule('fast-xml-parser')
 
-let json2xml = {}
-let xml2json = {}
+let json2xml = new Map()
+let xml2json = new Map()
 fxp.__setMockContent = contents => {
-  json2xml = {}
-  xml2json = {}
+  json2xml = new Map()
+  xml2json = new Map()
   for (const content in contents) {
-    json2xml[contents[content]] = content
-    xml2json[content] = contents[content]
+    json2xml.set(contents[content], content)
+    xml2json.set(content, contents[content])
   }
 }
 
 fxp.XMLParser = function () {
   return {
-    parse: jest.fn(content => JSON.parse(xml2json[content])),
+    parse: jest.fn(content => JSON.parse(xml2json.get(content))),
   }
 }
 
 fxp.XMLBuilder = function () {
   return {
-    build: jest.fn(content => json2xml[content]),
+    build: jest.fn(content => json2xml.get(content)),
   }
 }
 

--- a/__tests__/__utils__/testHandlerHelper.js
+++ b/__tests__/__utils__/testHandlerHelper.js
@@ -12,7 +12,10 @@ global.testHandlerHelper = testContext => {
       (type, changePath, expected, expectedType) => {
         beforeEach(
           () =>
-            (testContext.work.diffs = { package: {}, destructiveChanges: {} })
+            (testContext.work.diffs = {
+              package: new Map(),
+              destructiveChanges: new Map(),
+            })
         )
         test('addition', async () => {
           const handler = new testContext.handler(
@@ -22,10 +25,9 @@ global.testHandlerHelper = testContext => {
             globalMetadata
           )
           await handler.handle()
-          expect(testContext.work.diffs.package).toHaveProperty(
-            expectedType ?? type,
-            expected
-          )
+          expect(
+            testContext.work.diffs.package.get(expectedType ?? type)
+          ).toEqual(expected)
         })
         test('deletion', async () => {
           const handler = new testContext.handler(
@@ -35,10 +37,9 @@ global.testHandlerHelper = testContext => {
             globalMetadata
           )
           await handler.handle()
-          expect(testContext.work.diffs.destructiveChanges).toHaveProperty(
-            expectedType ?? type,
-            expected
-          )
+          expect(
+            testContext.work.diffs.destructiveChanges.get(expectedType ?? type)
+          ).toEqual(expected)
         })
         test('modification', async () => {
           const handler = new testContext.handler(
@@ -48,10 +49,9 @@ global.testHandlerHelper = testContext => {
             globalMetadata
           )
           await handler.handle()
-          expect(testContext.work.diffs.package).toHaveProperty(
-            expectedType ?? type,
-            expected
-          )
+          expect(
+            testContext.work.diffs.package.get(expectedType ?? type)
+          ).toEqual(expected)
         })
       }
     )

--- a/__tests__/functional.test.js
+++ b/__tests__/functional.test.js
@@ -75,8 +75,8 @@ describe(`test if the appli`, () => {
       generateDelta: true,
     })
 
-    expect(work.diffs.package.fields).toContain('Account.changed')
-    expect(work.diffs.destructiveChanges.fields).not.toContain(
+    expect(work.diffs.package.get('fields')).toContain('Account.changed')
+    expect(work.diffs.destructiveChanges.get('fields')).not.toContain(
       'Account.changed'
     )
   })

--- a/__tests__/unit/lib/metadata/metadataManager.test.js
+++ b/__tests__/unit/lib/metadata/metadataManager.test.js
@@ -4,12 +4,13 @@ const metadataManager = require('../../../../src/metadata/metadataManager')
 describe(`test if metadata`, () => {
   test('when grouped per directoryName, have classes', async () => {
     const metadata = await metadataManager.getDefinition('directoryName')
-    expect(metadata).toHaveProperty('classes')
+    expect(metadata.get('classes')).toBeDefined()
   })
 
   test('when grouped per directoryName, do not have do not exist', async () => {
     let metadata = await metadataManager.getDefinition('directoryName', '48')
-    metadata = metadataManager.getDefinition('directoryName', '46')
-    expect(metadata).not.toHaveProperty('do not exist')
+    metadata = await metadataManager.getDefinition('directoryName', '46')
+    expect(metadata).toBeDefined()
+    expect(metadata.get('do not exist')).toBeFalsy()
   })
 })

--- a/__tests__/unit/lib/service/botHandler.test.js
+++ b/__tests__/unit/lib/service/botHandler.test.js
@@ -21,7 +21,7 @@ const testContext = {
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 }
 
@@ -50,9 +50,8 @@ describe('test BotHandler', () => {
         globalMetadata
       )
       handler.handle()
-      expect(testContext.work.diffs.package).toHaveProperty(
-        'Bot',
-        new Set(['TestBot'])
+      expect(testContext.work.diffs.package.get('Bot')).toEqual(
+        testContext.testData[0][2]
       )
     })
   })
@@ -67,9 +66,8 @@ describe('test BotHandler', () => {
         globalMetadata
       )
       handler.handle()
-      expect(testContext.work.diffs.package).toHaveProperty(
-        'Bot',
-        new Set(['TestBot'])
+      expect(testContext.work.diffs.package.get('Bot')).toEqual(
+        testContext.testData[0][2]
       )
     })
   })

--- a/__tests__/unit/lib/service/customObjectHandler.test.js
+++ b/__tests__/unit/lib/service/customObjectHandler.test.js
@@ -27,7 +27,7 @@ const testContext = {
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 }
 
@@ -92,7 +92,9 @@ describe('customObjectHandler', () => {
         globalMetadata
       )
       await handler.handle()
-      expect(testContext.work.diffs.package).toHaveProperty('objects')
+      expect(testContext.work.diffs.package.get('objects')).toEqual(
+        testContext.testData[0][2]
+      )
     })
 
     test('addition and do not generate delta', async () => {
@@ -104,7 +106,9 @@ describe('customObjectHandler', () => {
         globalMetadata
       )
       await handler.handle()
-      expect(testContext.work.diffs.package).toHaveProperty('objects')
+      expect(testContext.work.diffs.package.get('objects')).toEqual(
+        testContext.testData[0][2]
+      )
     })
   })
 })

--- a/__tests__/unit/lib/service/inFolderHandler.test.js
+++ b/__tests__/unit/lib/service/inFolderHandler.test.js
@@ -34,7 +34,7 @@ testHandlerHelper({
   ],
   work: {
     config: { output: '', repo: '.', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 })
 
@@ -50,7 +50,7 @@ testHandlerHelper({
   ],
   work: {
     config: { output: '', repo: './repo', generateDelta: false },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
     warnings: [],
   },
 })

--- a/__tests__/unit/lib/service/inResourceHandler.test.js
+++ b/__tests__/unit/lib/service/inResourceHandler.test.js
@@ -52,7 +52,7 @@ const testContext = {
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 }
 
@@ -85,7 +85,7 @@ describe('test inResourceHandler', () => {
       globalMetadata
     )
     await handler.handle()
-    expect([...testContext.work.diffs.package[data[0]]]).toEqual(
+    expect([...testContext.work.diffs.package.get(data[0])]).toEqual(
       expect.arrayContaining([...data[2]])
     )
   })

--- a/__tests__/unit/lib/service/inTranslationHandler.test.js
+++ b/__tests__/unit/lib/service/inTranslationHandler.test.js
@@ -21,7 +21,7 @@ const testContext = {
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 }
 

--- a/__tests__/unit/lib/service/standardHandler.test.js
+++ b/__tests__/unit/lib/service/standardHandler.test.js
@@ -74,7 +74,7 @@ const testContext = {
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 }
 
@@ -100,7 +100,9 @@ describe(`standardHandler`, () => {
       globalMetadata
     )
     await handler.handle()
-    expect(testContext.work.diffs.package).toHaveProperty('classes')
+    expect(testContext.work.diffs.package.get('classes')).toEqual(
+      testContext.testData[5][2]
+    )
   })
 
   test('do not handle not ADM line', async () => {

--- a/__tests__/unit/lib/service/subCustomObjectHandler.test.js
+++ b/__tests__/unit/lib/service/subCustomObjectHandler.test.js
@@ -39,7 +39,7 @@ const testContext = {
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 }
 
@@ -61,7 +61,9 @@ test('field is not a master detail', async () => {
   require('fs').__setMockFiles({ [testContext.testData[0][1]]: '' })
 
   await handler.handle()
-  expect(testContext.work.diffs.package).toHaveProperty('fields')
+  expect(testContext.work.diffs.package.get('fields')).toEqual(
+    testContext.testData[0][2]
+  )
 })
 
 test('field does not generate delta', async () => {
@@ -80,5 +82,7 @@ test('field does not generate delta', async () => {
   require('fs').__setMockFiles({ [testContext.testData[0][1]]: '' })
 
   await handler.handle()
-  expect(testContext.work.diffs.package).toHaveProperty('fields')
+  expect(testContext.work.diffs.package.get('fields')).toEqual(
+    testContext.testData[0][2]
+  )
 })

--- a/__tests__/unit/lib/service/typeHandlerFactory.test.js
+++ b/__tests__/unit/lib/service/typeHandlerFactory.test.js
@@ -17,7 +17,7 @@ describe('the type handler factory', () => {
     typeHandlerFactory = new TypeHandlerFactory(
       {
         config: { apiVersion: '46' },
-        diffs: { package: {}, destructiveChanges: {} },
+        diffs: { package: new Map(), destructiveChanges: new Map() },
         promises: [],
       }, // eslint-disable-next-line no-undef
       globalMetadata

--- a/__tests__/unit/lib/service/waveHandler.test.js
+++ b/__tests__/unit/lib/service/waveHandler.test.js
@@ -128,7 +128,7 @@ const testContext = {
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
   },
 }
 

--- a/__tests__/unit/lib/utils/packageConstructor.test.js
+++ b/__tests__/unit/lib/utils/packageConstructor.test.js
@@ -6,7 +6,7 @@ const options = { apiVersion: '46' }
 const tests = [
   [
     'Object',
-    { objects: ['Object', 'OtherObject'] },
+    new Map(Object.entries({ objects: new Set(['Object', 'OtherObject']) })),
     `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
@@ -19,7 +19,7 @@ const tests = [
   ],
   [
     'empty',
-    {},
+    new Map(),
     `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <version>${options.apiVersion}.0</version>
@@ -27,13 +27,15 @@ const tests = [
   ],
   [
     'full',
-    {
-      dashboards: ['Dashboard'],
-      documents: ['Document'],
-      fields: ['Field'],
-      lwc: ['Component'],
-      objects: ['Object', 'OtherObject'],
-    },
+    new Map(
+      Object.entries({
+        dashboards: new Set(['Dashboard']),
+        documents: new Set(['Document']),
+        fields: new Set(['Field']),
+        lwc: new Set(['Component']),
+        objects: new Set(['Object', 'OtherObject']),
+      })
+    ),
     `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>
@@ -62,7 +64,7 @@ const tests = [
   ],
   [
     'WaveApplication',
-    { WaveApplication: ['aWaveApp'] },
+    new Map([['WaveApplication', new Set(['aWaveApp'])]]),
     `<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <types>

--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,7 @@ module.exports = async config => {
 const treatDiff = async (config, lines, metadata) => {
   const work = {
     config: config,
-    diffs: { package: {}, destructiveChanges: {} },
+    diffs: { package: new Map(), destructiveChanges: new Map() },
     warnings: [],
   }
 
@@ -61,7 +61,7 @@ const treatPackages = async (dcJson, config, metadata) => {
       {
         filename: `${PACKAGE_FILE_NAME}.${XML_FILE_EXTENSION}`,
         folder: DESTRUCTIVE_CHANGES_FILE_NAME,
-        xmlContent: pc.constructPackage({}),
+        xmlContent: pc.constructPackage(new Map()),
       },
     ].map(async op => {
       const location = join(config.output, op.folder, op.filename)
@@ -73,12 +73,14 @@ const treatPackages = async (dcJson, config, metadata) => {
 const cleanPackages = dcJson => {
   const additive = dcJson[PACKAGE_FILE_NAME]
   const destructive = dcJson[DESTRUCTIVE_CHANGES_FILE_NAME]
-  Object.keys(additive)
-    .filter(type => Object.prototype.hasOwnProperty.call(destructive, type))
-    .forEach(
-      type =>
-        (destructive[type] = new Set(
-          [...destructive[type]].filter(element => !additive[type].has(element))
-        ))
-    )
+  for (const [type, members] of additive) {
+    if (destructive.has(type)) {
+      destructive.set(
+        type,
+        new Set(
+          [...destructive.get(type)].filter(element => !members.has(element))
+        )
+      )
+    }
+  }
 }

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -19,13 +19,13 @@ class InFolderHandler extends StandardHandler {
     let [, , folderPath, folderName] = join(this.config.repo, this.line).match(
       new RegExp(
         `(${RegExpEscape(regexRepo)})(?<path>.*[/\\\\]${RegExpEscape(
-          StandardHandler.metadata[this.type].directoryName
+          StandardHandler.metadata.get(this.type).directoryName
         )})[/\\\\](?<name>[^/\\\\]*)+`,
         'u'
       )
     )
     folderName = `${folderName}.${
-      StandardHandler.metadata[this.type].xmlName.toLowerCase() +
+      StandardHandler.metadata.get(this.type).xmlName.toLowerCase() +
       INFOLDER_SUFFIX +
       METAFILE_SUFFIX
     }`
@@ -37,7 +37,9 @@ class InFolderHandler extends StandardHandler {
   }
 
   _fillPackage(packageObject) {
-    packageObject[this.type] = packageObject[this.type] ?? new Set()
+    if (!packageObject.has(this.type)) {
+      packageObject.set(this.type, new Set())
+    }
 
     const packageMember = this.splittedLine
       .slice(this.splittedLine.indexOf(this.type) + 1)
@@ -46,9 +48,9 @@ class InFolderHandler extends StandardHandler {
       .replace(INFOLDER_SUFFIX_REGEX, '')
       .replace(EXTENSION_SUFFIX_REGEX, '')
 
-    packageObject[this.type].add(
-      StandardHandler.cleanUpPackageMember(packageMember)
-    )
+    packageObject
+      .get(this.type)
+      .add(StandardHandler.cleanUpPackageMember(packageMember))
   }
 }
 

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -37,12 +37,12 @@ class StandardHandler {
     this.splittedLine = this.line.split(sep)
     this.warnings = work.warnings
 
-    if (StandardHandler.metadata[this.type].metaFile === true) {
+    if (StandardHandler.metadata.get(this.type).metaFile === true) {
       this.line = this.line.replace(METAFILE_SUFFIX, '')
     }
 
     this.suffixRegex = new RegExp(
-      `\\.${StandardHandler.metadata[this.type].suffix}$`
+      `\\.${StandardHandler.metadata.get(this.type).suffix}$`
     )
 
     this.handlerMap = {
@@ -108,13 +108,15 @@ class StandardHandler {
   }
 
   _fillPackageWithParameter(params) {
-    params.package[params.type] = params.package[params.type] ?? new Set()
-    params.package[params.type].add(params.elementName)
+    if (!params.package.has(params.type)) {
+      params.package.set(params.type, new Set())
+    }
+    params.package.get(params.type).add(params.elementName)
   }
 
   async _copyWithMetaFile(src, dst) {
     const file = this._copyFiles(src, dst)
-    if (StandardHandler.metadata[this.type].metaFile === true) {
+    if (StandardHandler.metadata.get(this.type).metaFile === true) {
       await this._copyFiles(src + METAFILE_SUFFIX, dst + METAFILE_SUFFIX)
     }
     await file

--- a/src/service/subCustomObjectHandler.js
+++ b/src/service/subCustomObjectHandler.js
@@ -36,12 +36,14 @@ class SubCustomObjectHandler extends StandardHandler {
   }
 
   _fillPackage(packageObject) {
-    packageObject[this.type] = packageObject[this.type] ?? new Set()
-    const prefix = this.splittedLine[this.splittedLine.indexOf(this.type) - 1]
+    if (!packageObject.has(this.type)) {
+      packageObject.set(this.type, new Set())
+    }
 
+    const prefix = this.splittedLine[this.splittedLine.indexOf(this.type) - 1]
     const elementName = this._getElementName()
 
-    packageObject[this.type].add(`${prefix}.${elementName}`)
+    packageObject.get(this.type).add(`${prefix}.${elementName}`)
   }
 
   static SUB_OBJECT_TYPES = [

--- a/src/service/waveHandler.js
+++ b/src/service/waveHandler.js
@@ -2,24 +2,28 @@
 const StandardHandler = require('./standardHandler')
 const { parse } = require('path')
 
-const WAVE_SUBTYPE = {}
+const WAVE_SUBTYPE = new Map()
 
 class WaveHandler extends StandardHandler {
   constructor(line, type, work, metadata) {
     super(line, type, work, metadata)
 
-    StandardHandler.metadata[this.type].content.reduce((acc, val) => {
-      acc[val.suffix] = val.xmlName
-      return acc
-    }, WAVE_SUBTYPE)
+    StandardHandler.metadata
+      .get(this.type)
+      .content.reduce(
+        (acc, val) => acc.set(val.suffix, val.xmlName),
+        WAVE_SUBTYPE
+      )
     this.ext = parse(this.line).ext.substring(1)
     this.suffixRegex = new RegExp(`\\.${this.ext}$`)
   }
 
   _fillPackage(packageObject) {
-    const type = WAVE_SUBTYPE[this.ext]
-    packageObject[type] = packageObject[type] ?? new Set()
-    packageObject[type].add(this._getElementName())
+    const type = WAVE_SUBTYPE.get(this.ext)
+    if (!packageObject.has(type)) {
+      packageObject.set(type, new Set())
+    }
+    packageObject.get(type).add(this._getElementName())
   }
 }
 

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -133,9 +133,7 @@ class RepoGitDiff {
   _filterInternal(line, deletedRenamed) {
     return (
       !deletedRenamed.includes(line) &&
-      line
-        .split(path.sep)
-        .some(part => Object.prototype.hasOwnProperty.call(this.metadata, part))
+      line.split(path.sep).some(part => this.metadata.has(part))
     )
   }
 
@@ -198,10 +196,7 @@ class RepoGitDiff {
       comparisonName = line
         .split(path.sep)
         .reduce(
-          (acc, value) =>
-            acc || Object.prototype.hasOwnProperty.call(this.metadata, value)
-              ? acc + value
-              : acc,
+          (acc, value) => (acc || this.metadata.has(value) ? acc + value : acc),
           ''
         )
     }

--- a/src/utils/typeUtils.js
+++ b/src/utils/typeUtils.js
@@ -6,7 +6,7 @@ const haveSubTypes = [CustomObject.OBJECT_TYPE, '']
 
 module.exports.getType = (line, metadata) =>
   line.split(sep).reduce((acc, value, _, arr) => {
-    acc = Object.prototype.hasOwnProperty.call(metadata, value) ? value : acc
+    acc = metadata.has(value) ? value : acc
     if (!haveSubTypes.includes(acc)) arr.splice(1)
     return acc
   }, '')


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [x] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [ ] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Refactor the code to use Map instead of {} to benefit from [everything Map](https://medium.com/front-end-weekly/es6-map-vs-object-what-and-when-b80621932373) comes with

