### PR TITLE
fix: binary filtering for git diff --numstat parsing and document meta type file regression

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,5 +216,6 @@ To test SGD as a Salesforce CLI plugin from a pending pull request:
 1. uninstall the previous version you may have `sfdx plugins:uninstall sfdx-git-delta`
 2. clone the repository
 3. checkout the branch to test
-4. run `yarn pack`, followed by `sfdx plugins:link`, from that local repository
-5. test the plugin!
+4. install the dependencies `yarn install`
+5. run `yarn pack`, followed by `sfdx plugins:link`, from that local repository
+6. test the plugin!

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -1,11 +1,18 @@
 'use strict'
 const RepoGitDiff = require('../../../../src/utils/repoGitDiff')
 const metadataManager = require('../../../../src/metadata/metadataManager')
+const {
+  ADDITION,
+  DELETION,
+  MODIFICATION,
+} = require('../../../../src/utils/gitConstants')
 jest.mock('child_process')
 const child_process = require('child_process')
 
 const FORCEIGNORE_MOCK_PATH = '__mocks__/.forceignore'
 const FORCEINCLUDE_MOCK_PATH = '__mocks__/.forceinclude'
+
+const TAB = '\t'
 
 describe(`test if repoGitDiff`, () => {
   let globalMetadata
@@ -44,48 +51,87 @@ describe(`test if repoGitDiff`, () => {
     expect(work).toStrictEqual(output)
   })
 
-  test('can resolve deletion', async () => {
+  test('can resolve file deletion', async () => {
     const output = [
-      'D      force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
+      'force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
     ]
-    child_process.__setOutput([output])
+    child_process.__setOutput([[], output.map(x => `1${TAB}1${TAB}${x}`), []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    expect(work).toMatchObject(output)
+    expect(work).toStrictEqual(output.map(x => `${DELETION}${TAB}${x}`))
+  })
+
+  test('can resolve binary file deletion', async () => {
+    const output = [
+      'force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
+    ]
+    child_process.__setOutput([[], output.map(x => `1${TAB}1${TAB}${x}`), []])
+    const repoGitDiff = new RepoGitDiff(
+      { output: '', repo: '' },
+      globalMetadata
+    )
+    const work = await repoGitDiff.getLines()
+    expect(work).toMatchObject(output.map(x => `${DELETION}${TAB}${x}`))
   })
 
   test('can resolve file copy when new file is added', async () => {
     const output = [
-      'A      force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
+      'force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
     ]
-    child_process.__setOutput([output])
+    child_process.__setOutput([[], [], output.map(x => `1${TAB}1${TAB}${x}`)])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    expect(work).toStrictEqual(output)
+    expect(work).toMatchObject(output.map(x => `${ADDITION}${TAB}${x}`))
+  })
+
+  test('can resolve file copy when new binary file is added', async () => {
+    const output = [
+      'force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
+    ]
+    child_process.__setOutput([[], [], output.map(x => `-${TAB}-${TAB}${x}`)])
+    const repoGitDiff = new RepoGitDiff(
+      { output: '', repo: '' },
+      globalMetadata
+    )
+    const work = await repoGitDiff.getLines()
+    expect(work).toMatchObject(output.map(x => `${ADDITION}${TAB}${x}`))
   })
 
   test('can resolve file copy when file is modified', async () => {
     const output = [
-      'M      force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
+      'force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
     ]
-    child_process.__setOutput([output])
+    child_process.__setOutput([output.map(x => `-${TAB}-${TAB}${x}`), [], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    expect(work).toStrictEqual(output)
+    expect(work).toMatchObject(output.map(x => `${MODIFICATION}${TAB}${x}`))
+  })
+
+  test('can resolve file copy when binary file is modified', async () => {
+    const output = [
+      'force-app/main/default/objects/Account/fields/awesome.field-meta.xml',
+    ]
+    child_process.__setOutput([output.map(x => `-${TAB}-${TAB}${x}`), [], []])
+    const repoGitDiff = new RepoGitDiff(
+      { output: '', repo: '' },
+      globalMetadata
+    )
+    const work = await repoGitDiff.getLines()
+    expect(work).toMatchObject(output.map(x => `${MODIFICATION}${TAB}${x}`))
   })
 
   test('can filter ignored files', async () => {
-    const output = ['M      force-app/main/default/lwc/jsconfig.json']
-    child_process.__setOutput([output])
+    const output = 'force-app/main/default/lwc/jsconfig.json'
+    child_process.__setOutput([[`1${TAB}1${TAB}${output}`], [], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       globalMetadata
@@ -97,8 +143,8 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('can filter ignored destructive files', async () => {
-    const output = ['D      force-app/main/default/lwc/jsconfig.json']
-    child_process.__setOutput([output])
+    const output = 'force-app/main/default/lwc/jsconfig.json'
+    child_process.__setOutput([[], [`1${TAB}1${TAB}${output}`], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignoreDestructive: FORCEIGNORE_MOCK_PATH },
       globalMetadata
@@ -110,11 +156,12 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('can filter ignored and ignored destructive files', async () => {
-    const output = [
-      'M      force-app/main/default/lwc/jsconfig.json',
-      'D      force-app/main/default/lwc/jsconfig.json',
-    ]
-    child_process.__setOutput([output])
+    const output = 'force-app/main/default/lwc/jsconfig.json'
+    child_process.__setOutput([
+      [],
+      [`1${TAB}1${TAB}${output}`],
+      [`1${TAB}1${TAB}${output}`],
+    ])
     const repoGitDiff = new RepoGitDiff(
       {
         output: '',
@@ -131,8 +178,8 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('can filter deletion if only ignored is specified files', async () => {
-    const output = ['D      force-app/main/default/lwc/jsconfig.json']
-    child_process.__setOutput([output])
+    const output = 'force-app/main/default/lwc/jsconfig.json'
+    child_process.__setOutput([[], [`1${TAB}1${TAB}${output}`], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       globalMetadata
@@ -144,19 +191,20 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('cannot filter non deletion if only ignored destructive is specified files', async () => {
-    const output = ['A      force-app/main/default/lwc/jsconfig.json']
-    child_process.__setOutput([output])
+    const output = 'force-app/main/default/lwc/jsconfig.json'
+    child_process.__setOutput([[], [], [`1${TAB}1${TAB}${output}`]])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignoreDestructive: FORCEIGNORE_MOCK_PATH },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    expect(work).toStrictEqual(output)
+    const expected = [`${ADDITION}${TAB}${output}`]
+    expect(work).toStrictEqual(expected)
   })
 
   test('can filter sub folders', async () => {
-    const output = ['M      force-app/main/default/pages/Account.page']
-    child_process.__setOutput([output])
+    const output = 'force-app/main/default/lwc/jsconfig.json'
+    child_process.__setOutput([[`1${TAB}1${TAB}${output}`], [], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
       globalMetadata
@@ -169,60 +217,84 @@ describe(`test if repoGitDiff`, () => {
 
   test('can filter moved files', async () => {
     const output = [
-      'D      force-app/main/default/classes/Account.cls',
-      'A      force-app/account/domain/classes/Account.cls',
+      'force-app/main/default/classes/Account.cls',
+      'force-app/account/domain/classes/Account.cls',
     ]
-    child_process.__setOutput([output])
+    child_process.__setOutput([
+      [],
+      [`1${TAB}1${TAB}${output[0]}`],
+      [`1${TAB}1${TAB}${output[1]}`],
+    ])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    const expected = [output[1]]
+    const expected = [`${ADDITION}${TAB}${output[1]}`]
     expect(work).toStrictEqual(expected)
   })
 
   test('can filter case changed files', async () => {
     const output = [
-      'D      force-app/main/default/objects/Account/fields/TEST__c.field-meta.xml',
-      'A      force-app/main/default/objects/Account/fields/Test__c.field-meta.xml',
+      'force-app/main/default/objects/Account/fields/TEST__c.field-meta.xml',
+      'force-app/main/default/objects/Account/fields/Test__c.field-meta.xml',
     ]
-    child_process.__setOutput([output])
+    child_process.__setOutput([
+      [],
+      [`1${TAB}1${TAB}${output[0]}`],
+      [`1${TAB}1${TAB}${output[1]}`],
+    ])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    const expected = [output[1]]
+    const expected = [`${ADDITION}${TAB}${output[1]}`]
     expect(work).toStrictEqual(expected)
   })
 
   test('cannot filter renamed files', async () => {
     const output = [
-      'D      force-app/main/default/classes/Account.cls',
-      'A      force-app/main/default/classes/RenamedAccount.cls',
+      'force-app/main/default/classes/Account.cls',
+      'force-app/main/default/classes/RenamedAccount.cls',
     ]
-    child_process.__setOutput([output])
+    child_process.__setOutput([
+      [],
+      [`1${TAB}1${TAB}${output[0]}`],
+      [`1${TAB}1${TAB}${output[1]}`],
+    ])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    expect(work).toStrictEqual(output)
+    const expected = [
+      `${ADDITION}${TAB}${output[1]}`,
+      `${DELETION}${TAB}${output[0]}`,
+    ]
+    expect(work).toStrictEqual(expected)
   })
 
   test('cannot filter same name file with different metadata', async () => {
     const output = [
-      'D      force-app/main/default/objects/Account/fields/CustomField__c.field-meta.xml',
-      'A      force-app/main/default/objects/Opportunity/fields/CustomField__c.field-meta.xml',
+      'force-app/main/default/classes/Account.cls',
+      'force-app/main/default/classes/RenamedAccount.cls',
     ]
-    child_process.__setOutput([output])
+    child_process.__setOutput([
+      [],
+      [`1${TAB}1${TAB}${output[0]}`],
+      [`1${TAB}1${TAB}${output[1]}`],
+    ])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '' },
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    expect(work).toStrictEqual(output)
+    const expected = [
+      `${ADDITION}${TAB}${output[1]}`,
+      `${DELETION}${TAB}${output[0]}`,
+    ]
+    expect(work).toStrictEqual(expected)
   })
 
   test('can explicitly include files', async () => {
@@ -237,7 +309,6 @@ describe(`test if repoGitDiff`, () => {
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    //should be empty
     const expected = ['A      force-app/main/default/lwc/jsconfig.json']
     expect(work).toStrictEqual(expected)
   })
@@ -254,7 +325,6 @@ describe(`test if repoGitDiff`, () => {
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    //should be empty
     const expected = ['D      force-app/main/default/lwc/jsconfig.json']
     expect(work).toStrictEqual(expected)
   })
@@ -297,9 +367,8 @@ describe(`test if repoGitDiff`, () => {
       globalMetadata
     )
     const work = await repoGitDiff.getLines()
-    //should be empty
     const expected = [
-      'D      force-app/main/default/lwc/jsconfig.json',
+      `D      force-app/main/default/lwc/jsconfig.json`,
       'D      force-app/main/default/staticresources/jsconfig.json',
     ]
     expect(work).toStrictEqual(expected)

--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -277,8 +277,8 @@ describe(`test if repoGitDiff`, () => {
 
   test('cannot filter same name file with different metadata', async () => {
     const output = [
-      'force-app/main/default/classes/Account.cls',
-      'force-app/main/default/classes/RenamedAccount.cls',
+      'force-app/main/default/objects/Account/fields/CustomField__c.field-meta.xml',
+      'force-app/main/default/objects/Opportunity/fields/CustomField__c.field-meta.xml',
     ]
     child_process.__setOutput([
       [],

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:debug": "node --inspect node_modules/.bin/jest",
     "test:debug:break": "node --inspect-brk node_modules/.bin/jest",
     "postpack": "rm -f oclif.manifest.json ; prettier --write README.md",
-    "postrelease": "npm run release:tags && npm run release:github",
+    "postrelease": "yarn release:tags && yarn  release:github",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "prepare": "husky install",
     "release": "standard-version --no-verify --commit-all",

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -266,6 +266,7 @@
     "directoryName": "documents",
     "inFolder": true,
     "metaFile": true,
+    "suffix": "document",
     "xmlName": "Document"
   },
   {

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -14,19 +14,7 @@ class InFolderHandler extends StandardHandler {
     await super.handleAddition()
     if (!this.config.generateDelta) return
 
-    const regexRepo = this.config.repo !== '.' ? this.config.repo : ''
-
-    const [, , folderPath, folderName] = join(
-      this.config.repo,
-      this.line
-    ).match(
-      new RegExp(
-        `(${RegExpEscape(regexRepo)})(?<path>.*[/\\\\]${RegExpEscape(
-          StandardHandler.metadata.get(this.type).directoryName
-        )})[/\\\\](?<name>[^/\\\\]*)+`,
-        'u'
-      )
-    )
+    const [, , folderPath, folderName] = this._parseLine()
 
     const folderFileName = `${folderName}.${
       StandardHandler.metadata.get(this.type).xmlName.toLowerCase() +
@@ -59,5 +47,3 @@ class InFolderHandler extends StandardHandler {
 }
 
 module.exports = InFolderHandler
-
-const RegExpEscape = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -16,7 +16,10 @@ class InFolderHandler extends StandardHandler {
 
     const regexRepo = this.config.repo !== '.' ? this.config.repo : ''
 
-    let [, , folderPath, folderName] = join(this.config.repo, this.line).match(
+    const [, , folderPath, folderName] = join(
+      this.config.repo,
+      this.line
+    ).match(
       new RegExp(
         `(${RegExpEscape(regexRepo)})(?<path>.*[/\\\\]${RegExpEscape(
           StandardHandler.metadata.get(this.type).directoryName
@@ -24,15 +27,16 @@ class InFolderHandler extends StandardHandler {
         'u'
       )
     )
-    folderName = `${folderName}.${
+
+    const folderFileName = `${folderName}.${
       StandardHandler.metadata.get(this.type).xmlName.toLowerCase() +
       INFOLDER_SUFFIX +
       METAFILE_SUFFIX
     }`
 
     this._copyFiles(
-      normalize(join(this.config.repo, folderPath, folderName)),
-      normalize(join(this.config.output, folderPath, folderName))
+      normalize(join(this.config.repo, folderPath, folderFileName)),
+      normalize(join(this.config.output, folderPath, folderFileName))
     )
   }
 

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -15,7 +15,7 @@ class ResourceHandler extends StandardHandler {
   async handleAddition() {
     await super.handleAddition()
     if (!this.config.generateDelta) return
-    const [, srcPath, elementName] = this._parseLine()
+    const [, , srcPath, elementName] = this._parseLine()
     const [targetPath] = `${join(this.config.output, this.line)}`.match(
       new RegExp(
         `.*[/\\\\]${StandardHandler.metadata.get(this.type).directoryName}`,
@@ -51,17 +51,6 @@ class ResourceHandler extends StandardHandler {
     } else {
       super.handleDeletion()
     }
-  }
-
-  _parseLine() {
-    return join(this.config.repo, this.line).match(
-      new RegExp(
-        `(?<path>.*[/\\\\]${
-          StandardHandler.metadata.get(this.type).directoryName
-        })[/\\\\](?<name>[^/\\\\]*)+`,
-        'u'
-      )
-    )
   }
 
   _getElementName() {

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -24,6 +24,8 @@ const FSE_COPYSYNC_OPTION = {
 
 const copiedFiles = new Set()
 
+const RegExpEscape = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
 class StandardHandler {
   static metadata
 
@@ -161,6 +163,18 @@ class StandardHandler {
       encoding: UTF8_ENCODING,
     })
     return file
+  }
+
+  _parseLine() {
+    const regexRepo = this.config.repo !== '.' ? this.config.repo : ''
+    return join(this.config.repo, this.line).match(
+      new RegExp(
+        `(${RegExpEscape(regexRepo)})(?<path>.*[/\\\\]${RegExpEscape(
+          StandardHandler.metadata.get(this.type).directoryName
+        )})[/\\\\](?<name>[^/\\\\]*)+`,
+        'u'
+      )
+    )
   }
 
   static cleanUpPackageMember(packageMember) {

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -117,26 +117,24 @@ class StandardHandler {
   async _copyWithMetaFile(src, dst) {
     const file = this._copyFiles(src, dst)
     if (StandardHandler.metadata.get(this.type).metaFile === true) {
-      const parsedSrc = parse(src)
-      const parsedDst = parse(dst)
       const metaFile = this._copyFiles(
-        join(
-          parsedSrc.dir,
-          `${parsedSrc.name}.${
-            StandardHandler.metadata.get(this.type).suffix
-          }${METAFILE_SUFFIX}`
-        ),
-        join(
-          parsedDst.dir,
-          `${parsedDst.name}.${
-            StandardHandler.metadata.get(this.type).suffix
-          }${METAFILE_SUFFIX}`
-        )
+        this._getMetaTypeFilePath(src),
+        this._getMetaTypeFilePath(dst)
       )
       await this._copyFiles(src + METAFILE_SUFFIX, dst + METAFILE_SUFFIX)
       await metaFile
     }
     await file
+  }
+
+  _getMetaTypeFilePath(path) {
+    const parsedPath = parse(path)
+    return join(
+      parsedPath.dir,
+      `${parsedPath.name}.${
+        StandardHandler.metadata.get(this.type).suffix
+      }${METAFILE_SUFFIX}`
+    )
   }
 
   async _copyFiles(src, dst) {

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -117,7 +117,24 @@ class StandardHandler {
   async _copyWithMetaFile(src, dst) {
     const file = this._copyFiles(src, dst)
     if (StandardHandler.metadata.get(this.type).metaFile === true) {
+      const parsedSrc = parse(src)
+      const parsedDst = parse(dst)
+      const metaFile = this._copyFiles(
+        join(
+          parsedSrc.dir,
+          `${parsedSrc.name}.${
+            StandardHandler.metadata.get(this.type).suffix
+          }${METAFILE_SUFFIX}`
+        ),
+        join(
+          parsedDst.dir,
+          `${parsedDst.name}.${
+            StandardHandler.metadata.get(this.type).suffix
+          }${METAFILE_SUFFIX}`
+        )
+      )
       await this._copyFiles(src + METAFILE_SUFFIX, dst + METAFILE_SUFFIX)
+      await metaFile
     }
     await file
   }

--- a/src/utils/metadataConstants.js
+++ b/src/utils/metadataConstants.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const METAFILE_SUFFIX = '-meta.xml'
 const META_REGEX = new RegExp(`${METAFILE_SUFFIX}$`)
 const OBJECT_META_XML_SUFFIX = `object${METAFILE_SUFFIX}`

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -26,7 +26,7 @@ const filterDeleted = [`${DIFF_FILTER}=${DELETION}`]
 const filterAdded = [`${DIFF_FILTER}=${ADDITION}`]
 const filterModification = [`${DIFF_FILTER}=${MODIFICATION}`]
 const TAB = '\t'
-const NUM_STAT_REGEX = /^\d+\t\d+\t/
+const NUM_STAT_REGEX = /^((-|\d+)\t){2}/
 const allFilesParams = ['ls-files']
 const lcSensitivity = {
   sensitivity: 'accent',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,9 +1265,9 @@
   integrity sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==
 
 "@types/node@*", "@types/node@>=12", "@types/node@^17.0.0":
-  version "17.0.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
-  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+  version "17.0.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.22.tgz#38b6c4b9b2f3ed9f2e376cce42a298fb2375251e"
+  integrity sha512-8FwbVoG4fy+ykY86XCAclKZDORttqE5/s7dyWZKLXTdv3vRy5HozBEinG5IqhvPXXzIZEcTVbuHlQEI6iuwcmw==
 
 "@types/node@^12.19.9":
   version "12.20.47"
@@ -1324,13 +1324,13 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.7.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz#c28ef7f2e688066db0b6a9d95fb74185c114fb9a"
-  integrity sha512-u6Db5JfF0Esn3tiAKELvoU5TpXVSkOpZ78cEGn/wXtT2RVqs2vkt4ge6N8cRCyw7YVKhmmLDbwI2pg92mlv7cA==
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.16.0.tgz#78f246dd8d1b528fc5bfca99a8a64d4023a3d86d"
+  integrity sha512-SJoba1edXvQRMmNI505Uo4XmGbxCK9ARQpkvOd00anxzri9RNQk0DDCxD+LIl+jYhkzOJiOMMKYEHnHEODjdCw==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.15.0"
-    "@typescript-eslint/type-utils" "5.15.0"
-    "@typescript-eslint/utils" "5.15.0"
+    "@typescript-eslint/scope-manager" "5.16.0"
+    "@typescript-eslint/type-utils" "5.16.0"
+    "@typescript-eslint/utils" "5.16.0"
     debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
@@ -1361,29 +1361,29 @@
     eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/parser@^5.7.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.15.0.tgz#95f603f8fe6eca7952a99bfeef9b85992972e728"
-  integrity sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.16.0.tgz#e4de1bde4b4dad5b6124d3da227347616ed55508"
+  integrity sha512-fkDq86F0zl8FicnJtdXakFs4lnuebH6ZADDw6CYQv0UZeIjHvmEw87m9/29nk2Dv5Lmdp0zQ3zDQhiMWQf/GbA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.15.0"
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/typescript-estree" "5.15.0"
+    "@typescript-eslint/scope-manager" "5.16.0"
+    "@typescript-eslint/types" "5.16.0"
+    "@typescript-eslint/typescript-estree" "5.16.0"
     debug "^4.3.2"
 
-"@typescript-eslint/scope-manager@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.15.0.tgz#d97afab5e0abf4018d1289bd711be21676cdd0ee"
-  integrity sha512-EFiZcSKrHh4kWk0pZaa+YNJosvKE50EnmN4IfgjkA3bTHElPtYcd2U37QQkNTqwMCS7LXeDeZzEqnsOH8chjSg==
+"@typescript-eslint/scope-manager@5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.16.0.tgz#7e7909d64bd0c4d8aef629cdc764b9d3e1d3a69a"
+  integrity sha512-P+Yab2Hovg8NekLIR/mOElCDPyGgFZKhGoZA901Yax6WR6HVeGLbsqJkZ+Cvk5nts/dAlFKm8PfL43UZnWdpIQ==
   dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/visitor-keys" "5.15.0"
+    "@typescript-eslint/types" "5.16.0"
+    "@typescript-eslint/visitor-keys" "5.16.0"
 
-"@typescript-eslint/type-utils@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.15.0.tgz#d2c02eb2bdf54d0a645ba3a173ceda78346cf248"
-  integrity sha512-KGeDoEQ7gHieLydujGEFLyLofipe9PIzfvA/41urz4hv+xVxPEbmMQonKSynZ0Ks2xDhJQ4VYjB3DnRiywvKDA==
+"@typescript-eslint/type-utils@5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.16.0.tgz#b482bdde1d7d7c0c7080f7f2f67ea9580b9e0692"
+  integrity sha512-SKygICv54CCRl1Vq5ewwQUJV/8padIWvPgCxlWPGO/OgQLCijY9G7lDu6H+mqfQtbzDNlVjzVWQmeqbLMBLEwQ==
   dependencies:
-    "@typescript-eslint/utils" "5.15.0"
+    "@typescript-eslint/utils" "5.16.0"
     debug "^4.3.2"
     tsutils "^3.21.0"
 
@@ -1392,10 +1392,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-3.10.1.tgz#1d7463fa7c32d8a23ab508a803ca2fe26e758727"
   integrity sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==
 
-"@typescript-eslint/types@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.15.0.tgz#c7bdd103843b1abae97b5518219d3e2a0d79a501"
-  integrity sha512-yEiTN4MDy23vvsIksrShjNwQl2vl6kJeG9YkVJXjXZnkJElzVK8nfPsWKYxcsGWG8GhurYXP4/KGj3aZAxbeOA==
+"@typescript-eslint/types@5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.16.0.tgz#5827b011982950ed350f075eaecb7f47d3c643ee"
+  integrity sha512-oUorOwLj/3/3p/HFwrp6m/J2VfbLC8gjW5X3awpQJ/bSG+YRGFS4dpsvtQ8T2VNveV+LflQHjlLvB6v0R87z4g==
 
 "@typescript-eslint/typescript-estree@3.10.1":
   version "3.10.1"
@@ -1411,28 +1411,28 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/typescript-estree@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.15.0.tgz#81513a742a9c657587ad1ddbca88e76c6efb0aac"
-  integrity sha512-Hb0e3dGc35b75xLzixM3cSbG1sSbrTBQDfIScqdyvrfJZVEi4XWAT+UL/HMxEdrJNB8Yk28SKxPLtAhfCbBInA==
+"@typescript-eslint/typescript-estree@5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.16.0.tgz#32259459ec62f5feddca66adc695342f30101f61"
+  integrity sha512-SE4VfbLWUZl9MR+ngLSARptUv2E8brY0luCdgmUevU6arZRY/KxYoLI/3V/yxaURR8tLRN7bmZtJdgmzLHI6pQ==
   dependencies:
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/visitor-keys" "5.15.0"
+    "@typescript-eslint/types" "5.16.0"
+    "@typescript-eslint/visitor-keys" "5.16.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.15.0.tgz#468510a0974d3ced8342f37e6c662778c277f136"
-  integrity sha512-081rWu2IPKOgTOhHUk/QfxuFog8m4wxW43sXNOMSCdh578tGJ1PAaWPsj42LOa7pguh173tNlMigsbrHvh/mtA==
+"@typescript-eslint/utils@5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.16.0.tgz#42218b459d6d66418a4eb199a382bdc261650679"
+  integrity sha512-iYej2ER6AwmejLWMWzJIHy3nPJeGDuCqf8Jnb+jAQVoPpmWzwQOfa9hWVB8GIQE5gsCv/rfN4T+AYb/V06WseQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.15.0"
-    "@typescript-eslint/types" "5.15.0"
-    "@typescript-eslint/typescript-estree" "5.15.0"
+    "@typescript-eslint/scope-manager" "5.16.0"
+    "@typescript-eslint/types" "5.16.0"
+    "@typescript-eslint/typescript-estree" "5.16.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -1443,12 +1443,12 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/visitor-keys@5.15.0":
-  version "5.15.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.15.0.tgz#5669739fbf516df060f978be6a6dce75855a8027"
-  integrity sha512-+vX5FKtgvyHbmIJdxMJ2jKm9z2BIlXJiuewI8dsDYMp5LzPUcuTT78Ya5iwvQg3VqSVdmxyM8Anj1Jeq7733ZQ==
+"@typescript-eslint/visitor-keys@5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.16.0.tgz#f27dc3b943e6317264c7492e390c6844cd4efbbb"
+  integrity sha512-jqxO8msp5vZDhikTwq9ubyMHqZ67UIvawohr4qF3KhlpL7gzSjOd+8471H3nh5LyABkaI85laEKKU8SnGUK5/g==
   dependencies:
-    "@typescript-eslint/types" "5.15.0"
+    "@typescript-eslint/types" "5.16.0"
     eslint-visitor-keys "^3.0.0"
 
 JSONStream@^1.0.4:
@@ -3033,9 +3033,9 @@ ejs@^3.1.6:
     jake "^10.6.1"
 
 electron-to-chromium@^1.4.84:
-  version "1.4.88"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.88.tgz#ebe6a2573b563680c7a7bf3a51b9e465c9c501db"
-  integrity sha512-oA7mzccefkvTNi9u7DXmT0LqvhnOiN2BhSrKerta7HeUC1cLoIwtbf2wL+Ah2ozh5KQd3/1njrGrwDBXx6d14Q==
+  version "1.4.89"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.89.tgz#33c06592812a17a7131873f4596579084ce33ff8"
+  integrity sha512-z1Axg0Fu54fse8wN4fd+GAINdU5mJmLtcl6bqIcYyzNVGONcfHAeeJi88KYMQVKalhXlYuVPzKkFIU5VD0raUw==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -5280,11 +5280,9 @@ json5@^1.0.1:
     minimist "^1.2.0"
 
 json5@^2.1.2:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contains

---

<!--
  Check all that apply
-->

- [ ] Added for new features.
- [ ] Changed for changes in existing functionality.
- [ ] Deprecated for soon-to-be removed features.
- [ ] Removed for now removed features.
- [X] Fixed for any bug fixes.
- [ ] Security in case of vulnerabilities.

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Fix `--numstat` binary interpretation support when parsing git diff lines
Fix `document` meta file copy issue

## Does this close any currently open issues?

---

<!--
  Provide the issue link or remove this section
  EX : #<issue-number>
-->

closes #270 

- [X] Jest test to check the fix is applied are added.

There is still an issue when changing an in Folder meta file, the corresponding file is not copied when the file extension is different

## Any particular element to being able to test locally

---

<!--
  Provide any new parameters or behaviour with current parameters
-->

## Any other comments?

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->

Next release