### PR TITLE
fix: parseLine array result destructure selection

### DIFF
--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -44,7 +44,7 @@ class ResourceHandler extends StandardHandler {
   }
 
   async handleDeletion() {
-    const [, srcPath, elementName] = this._parseLine()
+    const [, , srcPath, elementName] = this._parseLine()
     const exists = await pathExists(join(srcPath, elementName))
     if (exists) {
       await this.handleModification()

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -167,7 +167,7 @@ class StandardHandler {
     const regexRepo = this.config.repo !== '.' ? this.config.repo : ''
     return join(this.config.repo, this.line).match(
       new RegExp(
-        `(${RegExpEscape(regexRepo)})(?<path>.*[/\\\\]${RegExpEscape(
+        `(?<repo>${RegExpEscape(regexRepo)})(?<path>.*[/\\\\]${RegExpEscape(
           StandardHandler.metadata.get(this.type).directoryName
         )})[/\\\\](?<name>[^/\\\\]*)+`,
         'u'


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

---

<!--
  Check all that apply
-->

- [ ] Added (for new features).
- [ ] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [X] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->
Fix the way we use what is returned form `standardHandler._parseLine()` function.
The order of extraction of the array elements was not right in the `inRessourceHandler` which led to always detecting the path as existing and then add it in the package.xml instead

## Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #280 

- [ ] Jest test added to check the fix is applied.
Not necessary