### PR TITLE
feat: add extra member entry for inFolder metadata types

### DIFF
--- a/__tests__/unit/lib/utils/packageConstructor.test.js
+++ b/__tests__/unit/lib/utils/packageConstructor.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 'use strict'
 const PackageConstructor = require('../../../../src/utils/packageConstructor')
 const metadataManager = require('../../../../src/metadata/metadataManager')
@@ -5,45 +6,9 @@ const metadataManager = require('../../../../src/metadata/metadataManager')
 const options = { apiVersion: '46' }
 const tests = [
   [
-    'Object',
+    'it should create package.xml with types when diffs is not empty',
     new Map(
       Object.entries({
-        objects: new Set([
-          'Object',
-          'YetAnotherObject',
-          'OtherObject',
-          'AgainAnObject',
-          'ÀgainAndAgainAnObject',
-        ]),
-      })
-    ),
-    `<?xml version="1.0" encoding="UTF-8"?>
-<Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <types>
-        <members>ÀgainAndAgainAnObject</members>
-        <members>AgainAnObject</members>
-        <members>Object</members>
-        <members>OtherObject</members>
-        <members>YetAnotherObject</members>
-        <name>CustomObject</name>
-    </types>
-    <version>${options.apiVersion}.0</version>
-</Package>`,
-  ],
-  [
-    'empty',
-    new Map(),
-    `<?xml version="1.0" encoding="UTF-8"?>
-<Package xmlns="http://soap.sforce.com/2006/04/metadata">
-    <version>${options.apiVersion}.0</version>
-</Package>`,
-  ],
-  [
-    'full',
-    new Map(
-      Object.entries({
-        dashboards: new Set(['Dashboard']),
-        documents: new Set(['Document']),
         fields: new Set(['Field']),
         lwc: new Set(['Component']),
         objects: new Set(['Object', 'YetAnotherObject', 'OtherObject']),
@@ -62,17 +27,17 @@ const tests = [
         <name>CustomField</name>
     </types>
     <types>
-        <members>Dashboard</members>
-        <name>Dashboard</name>
-    </types>
-    <types>
-        <members>Document</members>
-        <name>Document</name>
-    </types>
-    <types>
         <members>Component</members>
         <name>LightningComponentBundle</name>
     </types>
+    <version>${options.apiVersion}.0</version>
+</Package>`,
+  ],
+  [
+    'it should create package.xml with no types when diffs is empty',
+    new Map(),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
     <version>${options.apiVersion}.0</version>
 </Package>`,
   ],
@@ -88,22 +53,97 @@ const tests = [
     <version>${options.apiVersion}.0</version>
 </Package>`,
   ],
+  [
+    `it should add folder name as an extra member when metadata type is in folder`,
+    new Map(
+      Object.entries({
+        email: new Set([
+          'folder_name_1/metadata_file_1',
+          'folder_name_1/metadata_file_2',
+          'folder_name_2/metadata_file_1',
+        ]),
+        documents: new Set([
+          'folder_name_1/metadata_file_1',
+          'folder_name_1/metadata_file_2',
+          'folder_name_2/metadata_file_1',
+        ]),
+        dashboards: new Set([
+          'folder_name_1/metadata_file_1',
+          'folder_name_1/metadata_file_2',
+          'folder_name_2/metadata_file_1',
+        ]),
+        reports: new Set([
+          'folder_name_1/metadata_file_1',
+          'folder_name_1/metadata_file_2',
+          'folder_name_2/metadata_file_1',
+        ]),
+        waveTemplates: new Set([
+          'folder_name_1/metadata_file_1',
+          'folder_name_1/metadata_file_2',
+          'folder_name_2/metadata_file_1',
+        ]),
+      })
+    ),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>folder_name_1</members>
+        <members>folder_name_1/metadata_file_1</members>
+        <members>folder_name_1/metadata_file_2</members>
+        <members>folder_name_2</members>
+        <members>folder_name_2/metadata_file_1</members>
+        <name>Dashboard</name>
+    </types>
+    <types>
+        <members>folder_name_1</members>
+        <members>folder_name_1/metadata_file_1</members>
+        <members>folder_name_1/metadata_file_2</members>
+        <members>folder_name_2</members>
+        <members>folder_name_2/metadata_file_1</members>
+        <name>Document</name>
+    </types>
+    <types>
+        <members>folder_name_1</members>
+        <members>folder_name_1/metadata_file_1</members>
+        <members>folder_name_1/metadata_file_2</members>
+        <members>folder_name_2</members>
+        <members>folder_name_2/metadata_file_1</members>
+        <name>EmailTemplate</name>
+    </types>
+    <types>
+        <members>folder_name_1</members>
+        <members>folder_name_1/metadata_file_1</members>
+        <members>folder_name_1/metadata_file_2</members>
+        <members>folder_name_2</members>
+        <members>folder_name_2/metadata_file_1</members>
+        <name>Report</name>
+    </types>
+    <types>
+        <members>folder_name_1</members>
+        <members>folder_name_1/metadata_file_1</members>
+        <members>folder_name_1/metadata_file_2</members>
+        <members>folder_name_2</members>
+        <members>folder_name_2/metadata_file_1</members>
+        <name>WaveTemplateBundle</name>
+    </types>
+    <version>${options.apiVersion}.0</version>
+</Package>`,
+  ],
 ]
 
-describe(`test if package constructor`, () => {
-  let globalMetadata
+describe(`package constructor`, () => {
   let packageConstructor
   beforeAll(async () => {
-    globalMetadata = await metadataManager.getDefinition('directoryName', 50)
+    let globalMetadata = await metadataManager.getDefinition(
+      'directoryName',
+      options.apiVersion
+    )
     packageConstructor = new PackageConstructor(options, globalMetadata)
   })
 
-  test.each(tests)(
-    'can build %s destructiveChanges.xml',
-    (type, diff, expected) => {
-      expect(packageConstructor.constructPackage(diff)).toBe(expected)
-    }
-  )
+  test.each(tests)('%s', (_, diff, expected) => {
+    expect(packageConstructor.constructPackage(diff)).toBe(expected)
+  })
   test('can handle null diff', () => {
     expect(packageConstructor.constructPackage(null)).toBe(undefined)
   })


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

- [x] Added (for new features).
- [ ] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [x] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

## Explain your changes

When deploying Documents, EmailTemplates, Reports, Dashboards and WaveTemplate metadata types, we must include `<member>folderName</member>` in the package.xml

````yml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
    <Package xmlns="http://soap.sforce.com/2006/04/metadata">
        <types>
            <members>My_Email_Templates</members>
            <members>My_Email_Templates/My_Email_Template</members>
            <name>EmailTemplate</name>
         </types>
    <version>54.0</version>
</Package>
````

otherwise you will get these errors:

https://salesforce.stackexchange.com/questions/136758/entity-type-folder-is-unknown-when-deploying-with-the-force-com-migration-t

https://salesforce.stackexchange.com/questions/313458/error-when-trying-to-push-lightning-emailtemplates-sfdx


## Does this close any currently open issues?
No

- [ x] Jest test added to check the fix is applied.

## Where has this been tested?

**Operating System:**  Darwin Kernel Version 21.4.0: Fri Mar 18 00:47:26 PDT 2022; root:xnu-8020.101.4~15/RELEASE_ARM64_T8101

**yarn version:** 1.22.17

**node version:** 16.13.1

**git version:** git version 2.32.0 (Apple Git-132)

**sfdx version:** 7.129.0

**sgd plugin version:** …
