### PR TITLE
feat: add restriction rules metadata

### DIFF
--- a/__tests__/unit/lib/service/standardHandler.test.js
+++ b/__tests__/unit/lib/service/standardHandler.test.js
@@ -42,6 +42,11 @@ const testContext = {
       new Set(['Controller']),
     ],
     [
+      'restrictionRules',
+      'force-app/main/default/restrictionRules/Account.rule-meta.xml',
+      new Set(['Account']),
+    ],
+    [
       'objects',
       'force-app/main/default/objects/Test/Account/Account.object-meta.xml',
       new Set(['Account']),
@@ -71,6 +76,11 @@ const testContext = {
       'force-app/main/default/classes/Test/Controller.cls-meta.xml',
       new Set(['Controller']),
     ],
+    [
+      'restrictionRules',
+      'force-app/main/default/restrictionRules/Test/Account.rule-meta.xml',
+      new Set(['Account']),
+    ],
   ],
   work: {
     config: { output: '', repo: '', generateDelta: true },
@@ -81,7 +91,7 @@ const testContext = {
 describe(`standardHandler`, () => {
   let globalMetadata
   beforeAll(async () => {
-    globalMetadata = await metadataManager.getDefinition('directoryName', 50)
+    globalMetadata = await metadataManager.getDefinition('directoryName', 54)
   })
 
   beforeEach(() => {
@@ -100,9 +110,9 @@ describe(`standardHandler`, () => {
       globalMetadata
     )
     await handler.handle()
-    expect(testContext.work.diffs.package.get('classes')).toEqual(
-      testContext.testData[5][2]
-    )
+    expect(
+      testContext.work.diffs.package.get(testContext.testData[0][0])
+    ).toEqual(testContext.testData[0][2])
   })
 
   test('do not handle not ADM line', async () => {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:coverage": "jest --coverage --runInBand",
     "test:debug": "node --inspect node_modules/.bin/jest",
     "test:debug:break": "node --inspect-brk node_modules/.bin/jest",
+    "test:watch": "jest --watch",
     "postpack": "rm -f oclif.manifest.json && prettier --write README.md",
     "postrelease": "yarn release:tags && yarn  release:github",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1120,6 +1120,13 @@
     "xmlName": "RecordActionDeployment"
   },
   {
+    "directoryName": "restrictionRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "rule",
+    "xmlName": "RestrictionRule"
+  },
+  {
     "directoryName": "EmbeddedServiceConfig",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1120,6 +1120,13 @@
     "xmlName": "RecordActionDeployment"
   },
   {
+    "directoryName": "restrictionRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "rule",
+    "xmlName": "RestrictionRule"
+  },
+  {
     "directoryName": "EmbeddedServiceConfig",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1120,6 +1120,13 @@
     "xmlName": "RecordActionDeployment"
   },
   {
+    "directoryName": "restrictionRules",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "rule",
+    "xmlName": "RestrictionRule"
+  },
+  {
     "directoryName": "EmbeddedServiceConfig",
     "inFolder": false,
     "metaFile": false,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

---

<!--
  Check all that apply
-->

- [X] Added (for new features).
- [ ] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [ ] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Add restriction rule metadata support for API 52, 53 and 54.
Shape of the metadata is based on the actual [documentation](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_restrictionrule.htm).
I also tested the format from a fresh scratch org to be sure:
![Screenshot 2022-06-04 at 11 17 11](https://user-images.githubusercontent.com/522422/171993321-e8e060e0-d3cb-45be-a53f-ea367a49638d.png)


## Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #308

- [X] Jest test added to check the fix is applied.

## Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

Create a restriction rule
Retrieve it 
Commit it
Run sgd and look at the result

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

**Operating System:** Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:37 PDT 2022; root:xnu-8020.121.3~4/RELEASE_ARM64_T6000

**yarn version:** 1.22.15

**node version:** v14.19.3

**git version:** 2.21.1

**sfdx version:** sfdx-cli/7.152.0 darwin-x64 node-v14.19.3

**sgd plugin version:** 5.2.0