### PR TITLE
feat: enable git diff on submodules

### DIFF
--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -13,7 +13,7 @@ fs.__setMockFiles = newMockFiles => {
   mockContent = new Map()
   filePathList = new Set()
   for (const file in newMockFiles) {
-    filePathList.add(path.basename(file))
+    filePathList.add(file)
     const dir = path.basename(path.dirname(file))
     if (!mockFiles.has(dir)) {
       mockFiles.set(dir, [])

--- a/__tests__/unit/lib/utils/cliHelper.test.js
+++ b/__tests__/unit/lib/utils/cliHelper.test.js
@@ -32,7 +32,7 @@ const mockFiles = {
 }
 
 describe(`test if the application`, () => {
-  beforeAll(() => {
+  beforeEach(() => {
     fs.errorMode = false
     fs.statErrorMode = false
     fs.__setMockFiles(mockFiles)
@@ -226,8 +226,6 @@ describe(`test if the application`, () => {
   })
 
   test('do not throw errors when repo contains submodule git file', async () => {
-    fs.errorMode = false
-    fs.statErrorMode = false
     fs.__setMockFiles({
       ...mockFiles,
       'submodule/.git': 'lorem ipsum',
@@ -243,8 +241,6 @@ describe(`test if the application`, () => {
   })
 
   test('do not throw errors when repo submodule git folder', async () => {
-    fs.errorMode = false
-    fs.statErrorMode = false
     fs.__setMockFiles({
       ...mockFiles,
       'submodule/.git': '',

--- a/__tests__/unit/lib/utils/cliHelper.test.js
+++ b/__tests__/unit/lib/utils/cliHelper.test.js
@@ -26,14 +26,16 @@ const testConfig = {
   apiVersion: '46',
 }
 
+const mockFiles = {
+  output: '',
+  '.': '',
+}
+
 describe(`test if the application`, () => {
   beforeAll(() => {
     fs.errorMode = false
     fs.statErrorMode = false
-    fs.__setMockFiles({
-      output: '',
-      '.': '',
-    })
+    fs.__setMockFiles(mockFiles)
   })
 
   test('throws errors when to parameter is not filled', async () => {
@@ -220,6 +222,44 @@ describe(`test if the application`, () => {
     )
     await expect(cliHelper.validateConfig()).rejects.not.toThrow(
       format(messages.errorParameterIsNotGitSHA, 'from', TAG_REF_TYPE)
+    )
+  })
+
+  test('do not throw errors when repo contains submodule git file', async () => {
+    fs.errorMode = false
+    fs.statErrorMode = false
+    fs.__setMockFiles({
+      ...mockFiles,
+      'submodule/.git': 'lorem ipsum',
+    })
+    let cliHelper = new CLIHelper({
+      ...testConfig,
+      generateDelta: false,
+      repo: 'submodule/',
+    })
+    expect.assertions(1)
+    await expect(cliHelper.validateConfig()).rejects.not.toThrow(
+      format(messages.errorPathIsNotGit, 'submodule/')
+    )
+  })
+
+  test('do not throw errors when repo submodule git folder', async () => {
+    fs.errorMode = false
+    fs.statErrorMode = false
+    fs.__setMockFiles({
+      ...mockFiles,
+      'submodule/.git': '',
+    })
+    let cliHelper = new CLIHelper({
+      ...testConfig,
+      generateDelta: false,
+      repo: 'submodule/',
+    })
+    // let cliHelper = new CLIHelper({ ...testConfig, repo: './submodule' })
+    expect.assertions(1)
+    // cliHelper.validateConfig()
+    await expect(cliHelper.validateConfig()).rejects.not.toThrow(
+      format(messages.errorPathIsNotGit, 'submodule/.git')
     )
   })
 })

--- a/__tests__/unit/lib/utils/cliHelper.test.js
+++ b/__tests__/unit/lib/utils/cliHelper.test.js
@@ -234,7 +234,6 @@ describe(`test if the application`, () => {
     })
     let cliHelper = new CLIHelper({
       ...testConfig,
-      generateDelta: false,
       repo: 'submodule/',
     })
     expect.assertions(1)
@@ -252,7 +251,6 @@ describe(`test if the application`, () => {
     })
     let cliHelper = new CLIHelper({
       ...testConfig,
-      generateDelta: false,
       repo: 'submodule/',
     })
     // let cliHelper = new CLIHelper({ ...testConfig, repo: './submodule' })

--- a/src/utils/cliHelper.js
+++ b/src/utils/cliHelper.js
@@ -22,7 +22,10 @@ const dirExists = async dir => await fsExists(dir, 'isDirectory')
 const fileExists = async file => await fsExists(file, 'isFile')
 
 const isGit = async dir => {
-  return await dirExists(join(dir, GIT_FOLDER))
+  const isGitDir = await dirExists(join(dir, GIT_FOLDER))
+  const isGitFile = await fileExists(join(dir, GIT_FOLDER))
+
+  return isGitDir || isGitFile
 }
 
 const isBlank = str => !str || /^\s*$/.test(str)


### PR DESCRIPTION
Fixes isGit method to check whether .git is a folder or file (this is the case on submodules)

<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

---

<!--
  Check all that apply
-->

- [ ] Added (for new features).
- [X] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [ ] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

It adds new condition on the isGit method that also checks whether a .git file exists

## Where has this been tested?

---

<!--
$ uname -v ; yarn -v ; node -v ; git --version ; sfdx --version ; sfdx plugins
-->

Locally

**Operating System:** MacOS Monterey

**yarn version:** 1.22.19

**node version:** 18.8.0

**git version:** 2.37.0

**sfdx version:** 7.166.1

**sgd plugin version:** …
