### PR TITLE
fix: use npm instead of yarn to manage versions

### DIFF
--- a/.github/workflows/manage-versions.yml
+++ b/.github/workflows/manage-versions.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 14.x
           registry-url: https://registry.npmjs.org/
 
-      - name: Rollback version
-        run: yarn tag add "sfdx-git-delta@${{ github.event.inputs.source }}" "${{ github.event.inputs.target }}"
+      - name: Change version
+        run: npm dist-tag add "sfdx-git-delta@${{ github.event.inputs.source }}" "${{ github.event.inputs.target }}"
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

---

<!--
  Check all that apply
-->

- [ ] Added (for new features).
- [ ] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [X] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

## Explain your changes

---

Use npm instead of yarn
Yarn is failing locally and is not reliable to manage version distribution

