### PR TITLE
fix: use file path with ignore patterns

### DIFF
--- a/__tests__/unit/lib/utils/repoGitDiff.test.js
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.js
@@ -130,7 +130,7 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('can filter ignored files', async () => {
-    const output = 'force-app/main/default/lwc/jsconfig.json'
+    const output = 'force-app/main/default/pages/test.page-meta.xml'
     child_process.__setOutput([[`1${TAB}1${TAB}${output}`], [], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
@@ -143,7 +143,7 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('can filter ignored destructive files', async () => {
-    const output = 'force-app/main/default/lwc/jsconfig.json'
+    const output = 'force-app/main/default/pages/test.page-meta.xml'
     child_process.__setOutput([[], [`1${TAB}1${TAB}${output}`], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignoreDestructive: FORCEIGNORE_MOCK_PATH },
@@ -178,7 +178,7 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('cannot filter deletion if only ignored is specified files', async () => {
-    const output = 'force-app/main/default/lwc/jsconfig.json'
+    const output = 'force-app/main/default/pages/test.page-meta.xml'
     child_process.__setOutput([[], [`1${TAB}1${TAB}${output}`], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },
@@ -191,7 +191,7 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('cannot filter non deletion if only ignored destructive is specified files', async () => {
-    const output = 'force-app/main/default/lwc/jsconfig.json'
+    const output = 'force-app/main/default/pages/test.page-meta.xml'
     child_process.__setOutput([[], [], [`1${TAB}1${TAB}${output}`]])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignoreDestructive: FORCEIGNORE_MOCK_PATH },
@@ -203,7 +203,7 @@ describe(`test if repoGitDiff`, () => {
   })
 
   test('can filter sub folders', async () => {
-    const output = 'force-app/main/default/lwc/jsconfig.json'
+    const output = 'force-app/main/default/pages/test.page-meta.xml'
     child_process.__setOutput([[`1${TAB}1${TAB}${output}`], [], []])
     const repoGitDiff = new RepoGitDiff(
       { output: '', repo: '', ignore: FORCEIGNORE_MOCK_PATH },

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -179,6 +179,7 @@ class RepoGitDiff {
   }
 
   _filterIgnore(line, ignoreSetup) {
+    const filePath = line.replace(GIT_DIFF_TYPE_REGEX, '')
     let helper
     if (this.config.ignoreDestructive && line.startsWith(DELETION)) {
       helper = ignoreSetup[1].helper
@@ -191,7 +192,7 @@ class RepoGitDiff {
 
     let keepLine = true
     if (helper) {
-      keepLine = !helper?.ignores(line)
+      keepLine = !helper?.ignores(filePath)
     }
 
     return keepLine

--- a/src/utils/repoGitDiff.js
+++ b/src/utils/repoGitDiff.js
@@ -179,7 +179,6 @@ class RepoGitDiff {
   }
 
   _filterIgnore(line, ignoreSetup) {
-    const filePath = line.replace(GIT_DIFF_TYPE_REGEX, '')
     let helper
     if (this.config.ignoreDestructive && line.startsWith(DELETION)) {
       helper = ignoreSetup[1].helper
@@ -192,6 +191,7 @@ class RepoGitDiff {
 
     let keepLine = true
     if (helper) {
+      const filePath = line.replace(GIT_DIFF_TYPE_REGEX, '')
       keepLine = !helper?.ignores(filePath)
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

---

<!--
  Check all that apply
-->

- [ ] Added (for new features).
- [ ] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [X] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

A regression as been inserted in the ignore feature at this [commit](https://github.com/scolladon/sfdx-git-delta/commit/a24536dec3d5356216558f1941a109c0a5ac28ba#diff-057ce4acbeadb39d45fbe732a7967768f68076460fad74168881b58c762135dcL180-R197)
It was not flagged by the unit test because it was testing a regex where the base of the file path did not matter.
The issue concerned ignore matcher for full path because it was not cleaning the type of the git operation of the line.
So instead of comparing just a path : `file/path/myfile.extension` it was comparing `M	file/path/myfile.extension`.
With full path matcher it cannot work.

The fix is simple, it just need to clean the git operation of the line to extract the file path and apply the ignore logic on that.
The unit test have been changed as well to replicate the issue and ensure the fix is working

## Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #383

- [X] Jest test added to check the fix is applied.

## Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

Reuse the playground from the issue
