### PR TITLE
fix: readDir git based implementation

### DIFF
--- a/__tests__/unit/lib/post-processor/flowTranslationProcessor.test.js
+++ b/__tests__/unit/lib/post-processor/flowTranslationProcessor.test.js
@@ -104,6 +104,27 @@ describe('FlowTranslationProcessor', () => {
         expect(mockParse).toHaveBeenCalledTimes(1)
         expect(copyFiles).toHaveBeenCalled()
       })
+      describe('when the folder is not a git repository', () => {
+        beforeEach(() => {
+          // Arrange
+          copyFiles.mockImplementationOnce(() =>
+            Promise.reject(new Error('fatal: not a git repository'))
+          )
+        })
+        it('should throw an exception', async () => {
+          // Arrange
+          expect.assertions(2)
+
+          // Act
+          try {
+            await sut.process()
+          } catch (error) {
+            // Assert
+            expect(error).toBeTruthy()
+            expect(copyFiles).toHaveBeenCalled()
+          }
+        })
+      })
     })
 
     describe('when there is already a translation related to a flow', () => {

--- a/__tests__/unit/lib/service/inFolderHandler.test.js
+++ b/__tests__/unit/lib/service/inFolderHandler.test.js
@@ -61,7 +61,7 @@ describe('InFolderHander', () => {
         expect(readDir).toHaveBeenCalledTimes(1)
         expect(copyFiles).toHaveBeenCalledTimes(3)
         expect(copyFiles).toHaveBeenCalledWith(
-          work,
+          work.config,
           expect.stringContaining(METAFILE_SUFFIX),
           expect.stringContaining(METAFILE_SUFFIX)
         )

--- a/__tests__/unit/lib/service/inResourceHandler.test.js
+++ b/__tests__/unit/lib/service/inResourceHandler.test.js
@@ -62,7 +62,7 @@ describe('InResourceHandler', () => {
           readDir.mockImplementation(() =>
             Promise.resolve([
               'other.resource-meta.xml',
-              'other',
+              'other/',
               'image.resource-meta.xml',
             ])
           )

--- a/__tests__/unit/lib/service/inResourceHandler.test.js
+++ b/__tests__/unit/lib/service/inResourceHandler.test.js
@@ -180,7 +180,7 @@ describe('InResourceHandler', () => {
         expect(...work.diffs.package.get(objectType)).toEqual('resource')
         expect(pathExists).toHaveBeenCalledWith(
           expect.stringContaining('resource'),
-          work
+          work.config
         )
       })
     })
@@ -207,7 +207,7 @@ describe('InResourceHandler', () => {
         )
         expect(pathExists).toHaveBeenCalledWith(
           expect.stringContaining('resource'),
-          work
+          work.config
         )
       })
     })

--- a/__tests__/unit/lib/service/inResourceHandler.test.js
+++ b/__tests__/unit/lib/service/inResourceHandler.test.js
@@ -85,17 +85,17 @@ describe('InResourceHandler', () => {
             expect(...work.diffs.package.get(type)).toEqual(entity)
             expect(copyFiles).toBeCalledTimes(expectedCount)
             expect(copyFiles).toHaveBeenCalledWith(
-              work,
+              work.config,
               `${base}${type}/${path}`,
               `${base}${type}/${path}`
             )
             expect(copyFiles).toHaveBeenCalledWith(
-              work,
+              work.config,
               `${base}${type}/${path}${METAFILE_SUFFIX}`,
               `${base}${type}/${path}${METAFILE_SUFFIX}`
             )
             expect(copyFiles).toHaveBeenCalledWith(
-              work,
+              work.config,
               `${base}${type}/${entity}.resource${METAFILE_SUFFIX}`,
               `${base}${type}/${entity}.resource${METAFILE_SUFFIX}`
             )
@@ -117,7 +117,7 @@ describe('InResourceHandler', () => {
           expect(...work.diffs.package.get(type)).toEqual(entity)
           expect(copyFiles).toBeCalledTimes(1)
           expect(copyFiles).toHaveBeenCalledWith(
-            work,
+            work.config,
             `${base}${type}/${path}`,
             `${base}${type}/${path}`
           )
@@ -142,12 +142,12 @@ describe('InResourceHandler', () => {
           expect(...work.diffs.package.get(objectType)).toEqual('resource')
           expect(copyFiles).toBeCalledTimes(2)
           expect(copyFiles).toHaveBeenCalledWith(
-            work,
+            work.config,
             `${entityPath}`,
             `${entityPath}`
           )
           expect(copyFiles).toHaveBeenCalledWith(
-            work,
+            work.config,
             `${entityPath}${METAFILE_SUFFIX}`,
             `${entityPath}${METAFILE_SUFFIX}`
           )

--- a/__tests__/unit/lib/service/inTranslationHandler.test.js
+++ b/__tests__/unit/lib/service/inTranslationHandler.test.js
@@ -51,7 +51,7 @@ describe('InTranslation', () => {
 
       expect(copyFiles).toBeCalledTimes(2)
       expect(copyFiles).toHaveBeenCalledWith(
-        work,
+        work.config,
         expect.stringContaining('Account-es.objectTranslation'),
         expect.stringContaining('Account-es.objectTranslation')
       )
@@ -77,12 +77,12 @@ describe('InTranslation', () => {
 
         expect(copyFiles).toBeCalledTimes(2)
         expect(copyFiles).toHaveBeenCalledWith(
-          work,
+          work.config,
           expect.stringContaining('BillingFloor__c.fieldTranslation'),
           expect.stringContaining('BillingFloor__c.fieldTranslation')
         )
         expect(copyFiles).toHaveBeenCalledWith(
-          work,
+          work.config,
           expect.stringContaining('Account-es.objectTranslation'),
           expect.stringContaining('Account-es.objectTranslation')
         )

--- a/__tests__/unit/lib/service/standardHandler.test.js
+++ b/__tests__/unit/lib/service/standardHandler.test.js
@@ -145,9 +145,9 @@ describe(`StandardHandler`, () => {
         expect(work.warnings).toEqual([])
         expect(work.diffs.package.get(objectType)).toEqual(new Set([entity]))
         expect(work.diffs.destructiveChanges.size).toEqual(0)
-        expect(copyFiles).toBeCalledWith(work, entityPath, entityPath)
+        expect(copyFiles).toBeCalledWith(work.config, entityPath, entityPath)
         expect(copyFiles).toBeCalledWith(
-          work,
+          work.config,
           entityPath.replace(METAFILE_SUFFIX, ''),
           entityPath.replace(METAFILE_SUFFIX, '')
         )
@@ -169,9 +169,9 @@ describe(`StandardHandler`, () => {
         expect(work.warnings).toEqual([])
         expect(work.diffs.package.get(objectType)).toEqual(new Set([entity]))
         expect(work.diffs.destructiveChanges.size).toEqual(0)
-        expect(copyFiles).toBeCalledWith(work, entityPath, entityPath)
+        expect(copyFiles).toBeCalledWith(work.config, entityPath, entityPath)
         expect(copyFiles).toBeCalledWith(
-          work,
+          work.config,
           entityPath.replace(METAFILE_SUFFIX, ''),
           entityPath.replace(METAFILE_SUFFIX, '')
         )
@@ -197,9 +197,9 @@ describe(`StandardHandler`, () => {
         expect(work.diffs.package.get('testSuites')).toEqual(new Set(['suite']))
         expect(work.diffs.destructiveChanges.size).toEqual(0)
         expect(copyFiles).toBeCalledTimes(1)
-        expect(copyFiles).toBeCalledWith(work, entityPath, entityPath)
+        expect(copyFiles).toBeCalledWith(work.config, entityPath, entityPath)
         expect(copyFiles).toBeCalledWith(
-          work,
+          work.config,
           expect.stringContaining(METAFILE_SUFFIX),
           expect.stringContaining(METAFILE_SUFFIX)
         )
@@ -223,9 +223,9 @@ describe(`StandardHandler`, () => {
         expect(work.diffs.package.get('testSuites')).toEqual(new Set(['suite']))
         expect(work.diffs.destructiveChanges.size).toEqual(0)
         expect(copyFiles).toBeCalledTimes(1)
-        expect(copyFiles).toBeCalledWith(work, entityPath, entityPath)
+        expect(copyFiles).toBeCalledWith(work.config, entityPath, entityPath)
         expect(copyFiles).not.toBeCalledWith(
-          work,
+          work.config,
           expect.stringContaining(METAFILE_SUFFIX),
           expect.stringContaining(METAFILE_SUFFIX)
         )
@@ -253,7 +253,7 @@ describe(`StandardHandler`, () => {
         expect(work.warnings).toEqual([])
         expect(work.diffs.package.get(objectType)).toEqual(new Set([entity]))
         expect(work.diffs.destructiveChanges.size).toEqual(0)
-        expect(copyFiles).toBeCalledWith(work, entityPath, entityPath)
+        expect(copyFiles).toBeCalledWith(work.config, entityPath, entityPath)
       }
     )
     it('should add deleted element to destructiveChanges and do not copy file', async () => {

--- a/__tests__/unit/lib/service/standardHandler.test.js
+++ b/__tests__/unit/lib/service/standardHandler.test.js
@@ -39,7 +39,9 @@ describe(`StandardHandler`, () => {
 
   it('should catch errors silently and store them', async () => {
     // Arrange
-    copyFiles.mockImplementationOnce(() => Promise.reject(new Error('test')))
+    copyFiles.mockImplementationOnce(() =>
+      Promise.reject(new Error('fatal: not a git repository'))
+    )
     const sut = new StandardHandler(
       `${ADDITION}       ${entityPath}`,
       objectType,

--- a/__tests__/unit/lib/utils/fsHelper.test.js
+++ b/__tests__/unit/lib/utils/fsHelper.test.js
@@ -90,18 +90,23 @@ describe('copyFile', () => {
       })
     })
     describe('when content is not a git location', () => {
-      it('should log a warning', async () => {
+      it('should throw an error', async () => {
+        expect.assertions(4)
         // Arrange
-        getStreamContent.mockImplementation(() => 'fatal')
+        const fatalError = 'fatal: not a git repository'
+        getStreamContent.mockImplementation(() => 'fatal: not a git repository')
 
         // Act
-        await copyFiles(work, 'source/warning', 'output/warning')
+        try {
+          await copyFiles(work.config, 'source/warning', 'output/warning')
 
-        // Assert
-        expect(spawn).toBeCalled()
-        expect(getStreamContent).toBeCalled()
-        expect(outputFile).not.toBeCalled()
-        expect(work.warnings.length).toBe(1)
+          // Assert
+        } catch (error) {
+          expect(spawn).toBeCalled()
+          expect(getStreamContent).toBeCalled()
+          expect(outputFile).not.toBeCalled()
+          expect(error.message).toEqual(fatalError)
+        }
       })
     })
     describe('when content is a file', () => {

--- a/__tests__/unit/lib/utils/fsHelper.test.js
+++ b/__tests__/unit/lib/utils/fsHelper.test.js
@@ -142,7 +142,7 @@ describe('readDir', () => {
       const dirContent = await readDir(dir, work)
 
       // Assert
-      expect(dirContent).toEqual(expect.arrayContaining([`${dir}${file}`]))
+      expect(dirContent).toEqual(expect.arrayContaining([`${file}`]))
       expect(getStreamContent).toHaveBeenCalled()
     })
   })

--- a/__tests__/unit/lib/utils/fsHelper.test.js
+++ b/__tests__/unit/lib/utils/fsHelper.test.js
@@ -43,11 +43,11 @@ describe('copyFile', () => {
   describe('when file is already copied', () => {
     it('should not copy file', async () => {
       // Arrange
-      await copyFiles(work, 'source/file', 'output/file')
+      await copyFiles(work.config, 'source/file', 'output/file')
       jest.resetAllMocks()
 
       // Act
-      await copyFiles(work, 'source/file', 'output/file')
+      await copyFiles(work.config, 'source/file', 'output/file')
 
       // Assert
       expect(spawn).not.toBeCalled()
@@ -62,7 +62,7 @@ describe('copyFile', () => {
       getStreamContent.mockImplementation(() => '')
 
       // Act
-      await copyFiles(work, 'source/doNotCopy', 'output/doNotCopy')
+      await copyFiles(work.config, 'source/doNotCopy', 'output/doNotCopy')
 
       // Assert
       expect(spawn).toBeCalled()
@@ -81,7 +81,7 @@ describe('copyFile', () => {
         getStreamContent.mockImplementation(() => 'content')
 
         // Act
-        await copyFiles(work, 'source/copyDir', 'output/copyDir')
+        await copyFiles(work.config, 'source/copyDir', 'output/copyDir')
 
         // Assert
         expect(spawn).toBeCalledTimes(2)
@@ -116,7 +116,7 @@ describe('copyFile', () => {
       })
       it('should copy the file', async () => {
         // Act
-        await copyFiles(work, 'source/copyfile', 'output/copyfile')
+        await copyFiles(work.config, 'source/copyfile', 'output/copyfile')
 
         // Assert
         expect(spawn).toBeCalled()

--- a/src/post-processor/flowTranslationProcessor.js
+++ b/src/post-processor/flowTranslationProcessor.js
@@ -70,7 +70,7 @@ class FlowTranslationProcessor extends BaseProcessor {
       if (this.config.generateDelta) {
         const source = join(this.config.source, translationPath)
         const target = join(this.config.output, translationPath)
-        copyTranslationsPromises.push(copyFiles(this.work, source, target))
+        copyTranslationsPromises.push(copyFiles(this.config, source, target))
       }
     }
     await Promise.all(copyTranslationsPromises)

--- a/src/service/customObjectHandler.js
+++ b/src/service/customObjectHandler.js
@@ -24,10 +24,10 @@ class CustomObjectHandler extends StandardHandler {
       parse(this.line).dir,
       FIELD_DIRECTORY_NAME
     )
-    const exists = await pathExists(fieldsFolder, this.work)
+    const exists = await pathExists(fieldsFolder, this.config)
     if (!exists) return
 
-    const fields = await readDir(fieldsFolder, this.work)
+    const fields = await readDir(fieldsFolder, this.config)
     const masterDetailsFields = await asyncFilter(fields, async fieldPath => {
       const content = await readPathFromGit(
         join(this.config.repo, fieldsFolder, fieldPath),

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -34,7 +34,7 @@ class InFolderHandler extends StandardHandler {
 
   async _copySpecialExtension() {
     const parsedLine = parse(this.line)
-    const dirContent = await readDir(parsedLine.dir, this.work)
+    const dirContent = await readDir(parsedLine.dir, this.config)
 
     await Promise.all(
       dirContent

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -78,7 +78,10 @@ class ResourceHandler extends StandardHandler {
   async _buildElementMap(srcPath) {
     if (!elementSrc.has(srcPath)) {
       const dirContent = await readDir(srcPath, this.config)
-      elementSrc.set(srcPath, dirContent)
+      elementSrc.set(
+        srcPath,
+        dirContent.map(f => f.replace(/\/$/, ''))
+      )
     }
   }
 }

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -41,7 +41,7 @@ class ResourceHandler extends StandardHandler {
 
   async handleDeletion() {
     const [, , srcPath, elementName] = this._parseLine()
-    const exists = await pathExists(join(srcPath, elementName), this.work)
+    const exists = await pathExists(join(srcPath, elementName), this.config)
     if (exists) {
       await this.handleModification()
     } else {
@@ -77,7 +77,7 @@ class ResourceHandler extends StandardHandler {
 
   async _buildElementMap(srcPath) {
     if (!elementSrc.has(srcPath)) {
-      const dirContent = await readDir(srcPath, this.work)
+      const dirContent = await readDir(srcPath, this.config)
       elementSrc.set(srcPath, dirContent)
     }
   }

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -102,7 +102,7 @@ class StandardHandler {
   }
 
   async _copyWithMetaFile(src, dst) {
-    const file = copyFiles(this.config, src, dst)
+    await copyFiles(this.config, src, dst)
     if (
       StandardHandler.metadata.get(this.type).metaFile === true &&
       !`${src}`.endsWith(METAFILE_SUFFIX)
@@ -113,7 +113,6 @@ class StandardHandler {
         this._getMetaTypeFilePath(dst)
       )
     }
-    await file
   }
 
   _getMetaTypeFilePath(path) {

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -102,13 +102,13 @@ class StandardHandler {
   }
 
   async _copyWithMetaFile(src, dst) {
-    const file = copyFiles(this.work, src, dst)
+    const file = copyFiles(this.config, src, dst)
     if (
       StandardHandler.metadata.get(this.type).metaFile === true &&
       !`${src}`.endsWith(METAFILE_SUFFIX)
     ) {
       await copyFiles(
-        this.work,
+        this.config,
         this._getMetaTypeFilePath(src),
         this._getMetaTypeFilePath(dst)
       )

--- a/src/utils/fsHelper.js
+++ b/src/utils/fsHelper.js
@@ -57,9 +57,7 @@ const readDir = async (dir, config) => {
   const dirContent = []
   if (data.startsWith(FOLDER)) {
     const [, , ...files] = data.split(EOLRegex)
-    for (const file of files) {
-      dirContent.push(join(dir, file))
-    }
+    dirContent.push(...files)
   }
   return dirContent
 }
@@ -74,10 +72,11 @@ const readFile = async path => {
 async function* scan(dir, config) {
   const entries = await readDir(dir, config)
   for (const file of entries) {
+    const filePath = join(dir, file)
     if (file.endsWith('/')) {
-      yield* scan(file, config)
+      yield* scan(filePath, config)
     } else {
-      yield file
+      yield filePath
     }
   }
 }

--- a/src/utils/fsHelper.js
+++ b/src/utils/fsHelper.js
@@ -12,8 +12,7 @@ const FATAL = 'fatal'
 const showCmd = ['--no-pager', 'show']
 const copiedFiles = new Set()
 
-const copyFiles = async (work, src, dst) => {
-  const { config } = work
+const copyFiles = async (config, src, dst) => {
   if (copiedFiles.has(src)) return
   copiedFiles.add(src)
 
@@ -29,10 +28,10 @@ const copyFiles = async (work, src, dst) => {
       const fileDst = join(config.output, folder, file)
       const fileSrc = join(config.repo, folder, file)
 
-      await copyFiles(work, fileSrc, fileDst)
+      await copyFiles(config, fileSrc, fileDst)
     }
   } else if (data.startsWith(FATAL)) {
-    work.warnings.push(data)
+    throw new Error(data)
   } else {
     await outputFile(dst, data)
   }

--- a/src/utils/fsHelper.js
+++ b/src/utils/fsHelper.js
@@ -13,7 +13,7 @@ const showCmd = ['--no-pager', 'show']
 const copiedFiles = new Set()
 
 const copyFiles = async (work, src, dst) => {
-  const config = work.config
+  const { config } = work
   if (copiedFiles.has(src)) return
   copiedFiles.add(src)
 
@@ -48,13 +48,13 @@ const readPathFromGit = async (path, config) => {
   return data
 }
 
-const pathExists = async (path, work) => {
-  const data = await readPathFromGit(path, work)
+const pathExists = async (path, config) => {
+  const data = await readPathFromGit(path, config)
   return data.startsWith(FATAL)
 }
 
-const readDir = async (dir, work) => {
-  const data = await readPathFromGit(dir, work)
+const readDir = async (dir, config) => {
+  const data = await readPathFromGit(dir, config)
   const dirContent = []
   if (data.startsWith(FOLDER)) {
     const [, , ...files] = data.split(EOLRegex)
@@ -72,11 +72,11 @@ const readFile = async path => {
   return file
 }
 
-async function* scan(dir, work) {
-  const entries = await readDir(dir, work)
+async function* scan(dir, config) {
+  const entries = await readDir(dir, config)
   for (const file of entries) {
     if (file.endsWith('/')) {
-      yield* scan(file, work)
+      yield* scan(file, config)
     } else {
       yield file
     }
@@ -103,5 +103,5 @@ module.exports.readDir = readDir
 module.exports.readFile = readFile
 module.exports.readPathFromGit = readPathFromGit
 module.exports.scan = scan
-module.exports.scanExtension = (dir, ext, work) =>
-  filterExt(scan(dir, work), ext)
+module.exports.scanExtension = (dir, ext, config) =>
+  filterExt(scan(dir, config), ext)


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

---

<!--
  Check all that apply
-->

- [ ] Added (for new features).
- [ ] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [X] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Fix home made git based `readDir` implementation and usage

`fs.readdir` [returns](https://nodejs.org/api/fs.html#fspromisesreaddirpath-options) a `fs.Dirent` data structure which tell us if the element is a folder or a file.
Using git to explore folder content returns string.
A element is a folder if it ends with '/'
Some part of the code relied on not having this slash at the end of a file.

Fix config parameter in `fsHelper`
Improve error handling in `fsHelper`

## Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #413 
closes #414 
closes #416

- [X] Jest test added to check the fix is applied.

## Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

Build a lwc component with subfolder (for test for example), modify the js file, check all the content of the module (even sub folder) is copied to output

[This playground](https://github.com/joernflath/sfdx-git-delta-reproduction-playground) can be used as well
[This branch](https://github.com/scolladon/sfdx-git-delta-reproduction-playground/tree/issue/414) in our playground can be used as well

## Any other comments

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
