### PR TITLE
build: allow force push with protection rule in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           yarn release
           yarn publish --access public --tag "latest-rc"
         env:
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ github.token }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Install sfdx-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           yarn release
           yarn publish --access public --tag "latest-rc"
         env:
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ github.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.RELEASE_PAT }}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Install sfdx-cli


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.
-->

## What does this pull request contain?

---

<!--
  Check all that apply
-->

- [ ] Added (for new features).
- [X] Changed (for changes in existing functionality).
- [ ] Deprecated (for soon-to-be removed features).
- [ ] Removed (for now removed features).
- [ ] Fixed (for any bug fixes).
- [ ] Security (for vulnerability fixes).

Allow release workflow to push on the repo on behalf of the repo owner

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Create a PAT, add it to the secrets and use it with github checkout.
Release workflow can then force push on the repo when a new release is done
