### PR TITLE
fix: generate incremental (`-d`) with source (`-s`) parameter

### DIFF
--- a/src/utils/fsHelper.js
+++ b/src/utils/fsHelper.js
@@ -16,7 +16,6 @@ const copyFiles = async (config, src, dst) => {
   if (copiedFiles.has(src)) return
   copiedFiles.add(src)
 
-  src = relative(config.source, src)
   const data = await readPathFromGit(src, config)
   if (!data) {
     return


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Remove relative path definition based on source parameter when generating incremental source
`--source` parameter is already used to scope the content of the diff
At that moment only sources related to what is asked are sent to copy.

## Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #416

## Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

Use the `--source` parameter