### PR TITLE
fix: remove escaping in the published release message

### DIFF
--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -44,19 +44,19 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Publish to npm
-        run: yarn publish --access public --tag "latest-rc" --new-version $(yarn --silent app:version)
+        run: yarn publish --access public --tag latest-rc --new-version ${{ needs.prepare-release.outputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   test-release:
-    needs: release
+    needs: [prepare-release, release]
     runs-on: ubuntu-latest
     steps:
       - name: Install sfdx-cli
         run: npm install -g sfdx-cli
 
       - name: Install new plugin version
-        run: echo y | sfdx plugins:install "sfdx-git-delta@latest-rc"
+        run: echo y | sfdx plugins:install sfdx-git-delta@${{ needs.prepare-release.outputs.version }}
 
       - name: Test new plugin version
         run: sfdx sgd:source:delta --help

--- a/.github/workflows/on-published-release.yml
+++ b/.github/workflows/on-published-release.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ github.token }}
           comment-template: |
-            Shipped in [release \`{release_tag}\`]({release_link}).
-            You can install the new version using the version number or the \`latest-rc\` channel
-            \`\`\`sh
+            Shipped in [release `{release_tag}`]({release_link}).
+            You can install the new version using the version number or the `latest-rc` channel
+            ```sh
             $ sfdx plugins:install sfdx-git-delta@latest-rc
             $ sfdx plugins:install sfdx-git-delta@{release_tag}
-            \`\`\`
+            ```

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "homepage": "https://github.com/scolladon/sfdx-git-delta#readme",
   "scripts": {
     "analysis": "codeclimate analyze",
-    "app:version": "echo $npm_package_version",
     "audit:fix": "npm i --package-lock-only && npm audit fix && rm yarn.lock && yarn import && rm package-lock.json",
     "commit": "commit",
     "lint": "eslint src/",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Make sure release comments display correctly by removing escaped character
Also make sure release test installation is done with the version instead of the channel latest-rc