### PR TITLE
fix: keep attributs not subject to comparison

### DIFF
--- a/src/utils/fileGitDiff.js
+++ b/src/utils/fileGitDiff.js
@@ -35,11 +35,6 @@ const getXmlTagToTypeDefinitionMap = metadata => {
 // Metadata JSON structure functional area
 const getRootMetadata = fileContent => Object.values(fileContent)?.[1]
 
-const clearMetadata = fileContent => ({
-  ...fileContent,
-  [Object.keys(fileContent)[1]]: {},
-})
-
 const getDirectoryNameForSubType = subType =>
   xmlObjectToPackageType.get(subType).directoryName
 
@@ -89,7 +84,7 @@ const generatePartialJSON = jsonContent => store => {
       storeHasMemberForType(elem.fullName)
     )
     return acc
-  }, clearMetadata(jsonContent))
+  }, jsonContent)
 }
 
 class FileGitDiff {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

When rebuilding metadata contained in file like `Workflow` or `SharingRule`
Now the algorithm rebuild only what is tracked as metadata and leave other information untouched

