### PR TITLE
feat: fast `flowTranslationProcessor` exit

### DIFF
--- a/src/post-processor/flowTranslationProcessor.js
+++ b/src/post-processor/flowTranslationProcessor.js
@@ -26,8 +26,10 @@ class FlowTranslationProcessor extends BaseProcessor {
   }
 
   async process() {
-    await this._buildFlowDefinitionsMap()
-    await this._handleFlowTranslation()
+    if (this._shouldProcess()) {
+      await this._buildFlowDefinitionsMap()
+      await this._handleFlowTranslation()
+    }
   }
 
   async _buildFlowDefinitionsMap() {
@@ -89,6 +91,10 @@ class FlowTranslationProcessor extends BaseProcessor {
     if (packagedElements?.has(fullName)) {
       this.translationPaths.add(translationPath)
     }
+  }
+
+  _shouldProcess() {
+    return this.work.diffs.package.has(FLOW_DIRECTORY_NAME)
   }
 
   async _getIgnoreInstance() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Implement fast exit of `flowTranslationProcessor` when the changes detected does not have Flows as there is no point to look for translation then

## Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

~~closes #~~

- [x] Jest test added to check the fix is applied.
