### PR TITLE
fix: get parent folder name portability

### DIFF
--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -5,7 +5,6 @@ const {
   META_REGEX,
   METAFILE_SUFFIX,
 } = require('../utils/metadataConstants')
-const { GIT_PATH_SEP } = require('../utils/gitConstants')
 const { cleanUpPackageMember } = require('../utils/packageHelper')
 const { join, parse, sep } = require('path')
 const { readDir } = require('../utils/fsHelper')
@@ -54,7 +53,7 @@ class InFolderHandler extends StandardHandler {
 
   _isProcessable() {
     const parsedLine = parse(this.line)
-    const parentFolder = parsedLine.dir.split(GIT_PATH_SEP).pop()
+    const parentFolder = parsedLine.dir.split(sep).pop()
     return (
       super._isProcessable() ||
       parentFolder !== this.type ||

--- a/src/service/inResourceHandler.js
+++ b/src/service/inResourceHandler.js
@@ -3,7 +3,7 @@ const StandardHandler = require('./standardHandler')
 const { join, parse } = require('path')
 const { pathExists, readDir } = require('../utils/fsHelper')
 const { META_REGEX } = require('../utils/metadataConstants')
-const { GIT_PATH_SEP } = require('../utils/gitConstants')
+const { sep } = require('path')
 const { cleanUpPackageMember } = require('../utils/packageHelper')
 
 const STATICRESOURCE_TYPE = 'staticresources'
@@ -78,7 +78,7 @@ class ResourceHandler extends StandardHandler {
 
   _isProcessable() {
     const parsedLine = parse(this.line)
-    const parentFolder = parsedLine.dir.split(GIT_PATH_SEP).pop()
+    const parentFolder = parsedLine.dir.split(sep).pop()
 
     return (
       super._isProcessable() ||


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

## Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Fix the way we split the path of a line to get the parent folder
Make sure it works on any `path.sep` environment specificities

## Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #548