### PR TITLE
fix: how `--json` parameter output is handled

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,6 +22,7 @@ Thanks for sending a pull request! Please make sure to have a look to the contri
 closes #
 
 - [ ] Jest tests added to cover the fix.
+- [ ] NUT tests added to cover the fix.
 - [ ] E2E tests added to cover the fix.
 
 # Any particular element that can be tested locally

--- a/__tests__/functional/delta.nut.ts
+++ b/__tests__/functional/delta.nut.ts
@@ -9,4 +9,36 @@ describe('sgd:source:delta NUTS', () => {
     }).shellOutput
     expect(result).to.include('sgd:source:delta')
   })
+
+  it('detects not existing output folder', () => {
+    const result = execCmd('sgd:source:delta --from "HEAD"', {
+      ensureExitCode: 1,
+    }).shellOutput
+    expect(result).to.include('folder does not exist')
+    expect(result).to.include('"success": false')
+  })
+
+  it('detects not existing output folder with json outputs', () => {
+    const result = execCmd('sgd:source:delta --from "HEAD" --json', {
+      ensureExitCode: 1,
+    }).shellOutput
+    expect(result).to.include('folder does not exist')
+    expect(result).to.include('"success": false')
+  })
+
+  it('outputs json', () => {
+    const result = execCmd('sgd:source:delta --from "HEAD" -o reports', {
+      ensureExitCode: 0,
+    }).shellOutput
+    expect(result).to.include('"error": null')
+    expect(result).to.include('"success": true')
+  })
+
+  it('outputs json with `--json`', () => {
+    const result = execCmd('sgd:source:delta --from "HEAD" -o reports --json', {
+      ensureExitCode: 0,
+    }).shellOutput
+    expect(result).to.include('"error": null')
+    expect(result).to.include('"success": true')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@swc/core": "^1.3.58",
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^20.1.5",
+    "@types/node": "^20.1.7",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
     "chai": "^4.3.7",

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -105,6 +105,6 @@ export default class SourceDeltaGenerate extends SfdxCommand {
       process.exitCode = 1
     }
     this.ux.log(JSON.stringify(output, null, 2))
-    return null
+    return output
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,10 +2234,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.1.5":
-  version: 20.1.5
-  resolution: "@types/node@npm:20.1.5"
-  checksum: 0d073ed7b9cc51e2354dcf3a8ccca84d08c7d513fa8fac9462cabc164435b30f2ad296e9f2f911e6ce72da837b704f1075379be84a93bb24f76d328a2d9e8561
+"@types/node@npm:^20.1.7":
+  version: 20.1.7
+  resolution: "@types/node@npm:20.1.7"
+  checksum: b722794290d22db1741e739c256876ca774b76ea2d647d9ec9d52c49b1b01049cc6f6332499a01ac81d641e8d078b33e4c5c59e409db80390ac6b8d7ef0c08a7
   languageName: node
   linkType: hard
 
@@ -8717,7 +8717,7 @@ __metadata:
     "@swc/core": ^1.3.58
     "@types/chai": ^4.3.5
     "@types/mocha": ^10.0.1
-    "@types/node": ^20.1.5
+    "@types/node": ^20.1.7
     "@typescript-eslint/eslint-plugin": ^5.59.6
     "@typescript-eslint/parser": ^5.59.6
     chai: ^4.3.7


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Returned the result object so `--json` handler can use it to display result when the flag is set

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #568

- [ ] Jest tests added to cover the fix.
- [x] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

This fix will not handle the warning in the error array.
The git diff command in this case does not throw an error (exit code is 0) but write the warning message in `stderr`
We catch every error message from `stderr` to treat those as error and stop execution, by design.
