### PR TITLE
feat: add support for Health Cloud metadata

### DIFF
--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "uiObjectRelationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiObjectRelationConfig",
+    "xmlName": "UIObjectRelationConfig"
+  },
+  {
     "directoryName": "slackapps",
     "inFolder": false,
     "metaFile": true,

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1,5 +1,19 @@
 [
   {
+    "directoryName": "uiObjectRelationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiObjectRelationConfig",
+    "xmlName": "UIObjectRelationConfig"
+  },
+  {
+    "directoryName": "timelineObjectDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "timelineObjectDefinition",
+    "xmlName": "TimelineObjectDefinition"
+  },
+  {
     "directoryName": "slackapps",
     "inFolder": false,
     "metaFile": true,

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -1,5 +1,19 @@
 [
   {
+    "directoryName": "uiObjectRelationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiObjectRelationConfig",
+    "xmlName": "UIObjectRelationConfig"
+  },
+  {
+    "directoryName": "timelineObjectDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "timelineObjectDefinition",
+    "xmlName": "TimelineObjectDefinition"
+  },
+  {
     "directoryName": "slackapps",
     "inFolder": false,
     "metaFile": true,

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -2027,5 +2027,19 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
+  },
+  {
+    "directoryName": "uiObjectRelationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiObjectRelationConfig",
+    "xmlName": "UIObjectRelationConfig"
+  },
+  {
+    "directoryName": "timelineObjectDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "timelineObjectDefinition",
+    "xmlName": "TimelineObjectDefinition"
   }
 ]

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1,5 +1,19 @@
 [
   {
+    "directoryName": "uiObjectRelationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiObjectRelationConfig",
+    "xmlName": "UIObjectRelationConfig"
+  },
+  {
+    "directoryName": "timelineObjectDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "timelineObjectDefinition",
+    "xmlName": "TimelineObjectDefinition"
+  },
+  {
     "directoryName": "slackapps",
     "inFolder": false,
     "metaFile": true,
@@ -2027,19 +2041,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "uiObjectRelationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "uiObjectRelationConfig",
-    "xmlName": "UIObjectRelationConfig"
-  },
-  {
-    "directoryName": "timelineObjectDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "timelineObjectDefinition",
-    "xmlName": "TimelineObjectDefinition"
   }
 ]

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1,5 +1,19 @@
 [
   {
+    "directoryName": "uiObjectRelationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiObjectRelationConfig",
+    "xmlName": "UIObjectRelationConfig"
+  },
+  {
+  "directoryName": "timelineObjectDefinitions",
+  "inFolder": false,
+  "metaFile": false,
+  "suffix": "timelineObjectDefinition",
+  "xmlName": "TimelineObjectDefinition"
+  },
+  {
     "directoryName": "slackapps",
     "inFolder": false,
     "metaFile": true,
@@ -2027,19 +2041,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "uiObjectRelationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "uiObjectRelationConfig",
-    "xmlName": "UIObjectRelationConfig"
-  },
-  {
-    "directoryName": "timelineObjectDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "timelineObjectDefinition",
-    "xmlName": "TimelineObjectDefinition"
   }
 ]

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -2027,5 +2027,19 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
+  },
+  {
+    "directoryName": "uiObjectRelationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiObjectRelationConfig",
+    "xmlName": "UIObjectRelationConfig"
+  },
+  {
+    "directoryName": "timelineObjectDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "timelineObjectDefinition",
+    "xmlName": "TimelineObjectDefinition"
   }
 ]


### PR DESCRIPTION
Fix for the issue -  https://github.com/scolladon/sfdx-git-delta/issues/650 - added TimelineObjectDefinition and UIObjectRelationConfig for version 57 and 58.

<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

This PR related to the issue https://github.com/scolladon/sfdx-git-delta/issues/650

We are using Salesforce Health Cloud and git delta deployment. We are not seeing the support Health Cloud metadata objects e.g. [UIObjectRelationConfig](https://developer.salesforce.com/docs/atlas.en-us.health_cloud_object_reference.meta/health_cloud_object_reference/meta_uiobjectrelationconfig.htm), [TimelineObjectDefinition](https://developer.salesforce.com/docs/atlas.en-us.health_cloud_object_reference.meta/health_cloud_object_reference/meta_timelineobjectdefinition.htm)

<!--
  Describe with your own words the content of the Pull Request
-->

# Does this close any currently open issues?

---

closes #650 

- [ ] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

# Any other comments

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
