### PR TITLE
refactor: copy files smarter

### DIFF
--- a/__tests__/unit/lib/service/botHandler.test.js
+++ b/__tests__/unit/lib/service/botHandler.test.js
@@ -77,7 +77,25 @@ describe('BotHandler', () => {
           new Set(['TestBot.v1'])
         )
         expect(copyFiles).toBeCalledTimes(4)
+        expect(copyFiles).toBeCalledWith(
+          work.config,
+          `force-app/main/default/bots/TestBot/v1.botVersion-meta.xml`
+        )
+        expect(copyFiles).toBeCalledWith(
+          work.config,
+          `force-app/main/default/bots/TestBot/v1.botVersion`
+        )
+        expect(copyFiles).toBeCalledWith(
+          work.config,
+          `force-app/main/default/bots/TestBot/TestBot.bot`
+        )
+        expect(copyFiles).toBeCalledWith(
+          work.config,
+          `force-app/main/default/bots/TestBot/TestBot.bot-meta.xml`
+        )
       })
     })
   })
+
+  // TODO getMetaTypeFilePath
 })

--- a/__tests__/unit/lib/service/inResourceHandler.test.js
+++ b/__tests__/unit/lib/service/inResourceHandler.test.js
@@ -75,18 +75,30 @@ describe('InResourceHandler', () => {
           )
         })
         it.each([
-          ['staticresources', 'StaticResource', 'image', 'image.png', 3],
-          ['staticresources', 'StaticResource', 'image', 'image/logo.png', 3],
           [
+            'imageFile.png',
+            'staticresources',
+            'StaticResource',
+            'imageFile',
+            2,
+          ],
+          [
+            'imageFolder/logo.png',
+            'staticresources',
+            'StaticResource',
+            'imageFolder',
+            3,
+          ],
+          [
+            'my_experience_bundle/config/myexperiencebundle.json',
             'experiences',
             'ExperienceBundle',
             'my_experience_bundle',
-            'my_experience_bundle/config/myexperiencebundle.json',
-            5,
+            3,
           ],
         ])(
-          'should copy the matching folder resource, matching meta file and subject file',
-          async (type, xmlName, entity, path, expectedCount) => {
+          'should copy the matching folder resource, matching meta file and subject file %s',
+          async (path, type, xmlName, entity, expectedCopyCount) => {
             // Arrange
             const base = 'force-app/main/default/'
             const line = `A       ${base}${type}/${path}`
@@ -97,14 +109,10 @@ describe('InResourceHandler', () => {
 
             // Assert
             expect(...work.diffs.package.get(xmlName)).toEqual(entity)
-            expect(copyFiles).toBeCalledTimes(expectedCount)
+            expect(copyFiles).toBeCalledTimes(expectedCopyCount)
             expect(copyFiles).toHaveBeenCalledWith(
               work.config,
               `${base}${type}/${path}`
-            )
-            expect(copyFiles).toHaveBeenCalledWith(
-              work.config,
-              `${base}${type}/${path}${METAFILE_SUFFIX}`
             )
             expect(copyFiles).toHaveBeenCalledWith(
               work.config,
@@ -130,7 +138,7 @@ describe('InResourceHandler', () => {
 
           // Assert
           expect(...work.diffs.package.get(xmlName)).toEqual(entity)
-          expect(copyFiles).toBeCalledTimes(1)
+          expect(copyFiles).toBeCalledTimes(2)
           expect(copyFiles).toHaveBeenCalledWith(
             work.config,
             `${base}${type}/${path}`
@@ -139,7 +147,7 @@ describe('InResourceHandler', () => {
       })
 
       describe('when no matching resource exist', () => {
-        it('should not copy resource files', async () => {
+        it('should try copy resource files', async () => {
           // Arrange
           const sut = new InResourceHandler(
             line,
@@ -156,7 +164,7 @@ describe('InResourceHandler', () => {
           expect(...work.diffs.package.get(xmlName)).toEqual(element)
           expect(copyFiles).toBeCalledTimes(2)
           expect(copyFiles).toHaveBeenCalledWith(work.config, `${entityPath}`)
-          expect(copyFiles).not.toHaveBeenCalledWith(
+          expect(copyFiles).toHaveBeenCalledWith(
             work.config,
             `${basePath}/${element}.${type}${METAFILE_SUFFIX}`
           )

--- a/src/service/botHandler.js
+++ b/src/service/botHandler.js
@@ -21,7 +21,7 @@ class BotHandler extends SharedFolderHandler {
   }
 
   async _addParentBot() {
-    const botName = this._getParsedPath().dir.split(sep).pop()
+    const botName = this.parentFolder.split(sep).pop()
     fillPackageWithParameter({
       store: this.diffs.package,
       type: BOT_TYPE,

--- a/src/service/botHandler.js
+++ b/src/service/botHandler.js
@@ -2,6 +2,7 @@
 const SharedFolderHandler = require('./sharedFolderHandler')
 const { fillPackageWithParameter } = require('../utils/packageHelper')
 const { parse, sep } = require('path')
+const { DOT } = require('../utils/fsHelper')
 
 const BOT_TYPE = 'Bot'
 const BOT_EXTENSION = 'bot'
@@ -13,7 +14,7 @@ class BotHandler extends SharedFolderHandler {
       parsedPath.dir.split(sep).pop(),
       parsedPath.name,
     ])
-    return [...elementName].join('.')
+    return [...elementName].join(DOT)
   }
   async handleAddition() {
     await super.handleAddition()

--- a/src/service/inFileHandler.js
+++ b/src/service/inFileHandler.js
@@ -5,7 +5,7 @@ const {
 } = require('../utils/metadataConstants')
 const StandardHandler = require('./standardHandler')
 const { basename } = require('path')
-const { writeFile } = require('../utils/fsHelper')
+const { writeFile, DOT } = require('../utils/fsHelper')
 const {
   getInFileAttributes,
   isPackable,
@@ -16,7 +16,7 @@ const {
   fillPackageWithParameter,
 } = require('../utils/packageHelper')
 
-const getRootType = line => basename(line).split('.')[0]
+const getRootType = line => basename(line).split(DOT)[0]
 const getNamePrefix = ({ subType, line }) =>
   subType !== LABEL_XML_NAME ? `${getRootType(line)}.` : ''
 

--- a/src/service/inFolderHandler.js
+++ b/src/service/inFolderHandler.js
@@ -52,11 +52,9 @@ class InFolderHandler extends StandardHandler {
   }
 
   _isProcessable() {
-    const parsedLine = parse(this.line)
-    const parentFolder = parsedLine.dir.split(sep).pop()
     return (
       super._isProcessable() ||
-      parentFolder !== this.type ||
+      this._parentFolderIsNotTheType() ||
       this.ext.endsWith(INFOLDER_SUFFIX)
     )
   }

--- a/src/service/sharedFolderHandler.js
+++ b/src/service/sharedFolderHandler.js
@@ -2,6 +2,8 @@
 const StandardHandler = require('./standardHandler')
 const { fillPackageWithParameter } = require('../utils/packageHelper')
 const { getSharedFolderMetadata } = require('../metadata/metadataManager')
+const { METAFILE_SUFFIX } = require('../utils/metadataConstants')
+const { parse, join } = require('path')
 
 class SharedFolderHandler extends StandardHandler {
   sharedFolderMetadata
@@ -23,6 +25,14 @@ class SharedFolderHandler extends StandardHandler {
 
   _isProcessable() {
     return super._isProcessable() || this.sharedFolderMetadata.has(this.ext)
+  }
+
+  _getMetaTypeFilePath(path) {
+    const parsedPath = parse(path)
+    return join(
+      parsedPath.dir,
+      `${parsedPath.name}${parsedPath.ext}${METAFILE_SUFFIX}`
+    )
   }
 }
 

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -11,7 +11,7 @@ const {
   cleanUpPackageMember,
   fillPackageWithParameter,
 } = require('../utils/packageHelper')
-const { copyFiles } = require('../utils/fsHelper')
+const { copyFiles, DOT } = require('../utils/fsHelper')
 
 const RegExpEscape = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
@@ -42,7 +42,7 @@ class StandardHandler {
     this.parsedLine = parse(this.line)
     this.ext = this.parsedLine.base
       .replace(METAFILE_SUFFIX, '')
-      .split('.')
+      .split(DOT)
       .pop()
 
     this.parentFolder = this.parsedLine.dir.split(sep).slice(-1)[0]

--- a/src/service/standardHandler.js
+++ b/src/service/standardHandler.js
@@ -39,11 +39,13 @@ class StandardHandler {
       [DELETION]: this.handleDeletion,
       [MODIFICATION]: this.handleModification,
     }
-
-    this.ext = parse(this.line)
-      .base.replace(METAFILE_SUFFIX, '')
+    this.parsedLine = parse(this.line)
+    this.ext = this.parsedLine.base
+      .replace(METAFILE_SUFFIX, '')
       .split('.')
       .pop()
+
+    this.parentFolder = this.parsedLine.dir.split(sep).slice(-1)[0]
   }
 
   async handle() {
@@ -100,13 +102,19 @@ class StandardHandler {
 
   async _copyWithMetaFile(src) {
     if (this._delegateFileCopy()) {
-      await copyFiles(this.config, src)
+      await this._copy(src)
       if (
         this.metadata.get(this.type).metaFile === true &&
         !`${src}`.endsWith(METAFILE_SUFFIX)
       ) {
-        await copyFiles(this.config, this._getMetaTypeFilePath(src))
+        await this._copy(this._getMetaTypeFilePath(src))
       }
+    }
+  }
+
+  async _copy(elementPath) {
+    if (this._delegateFileCopy()) {
+      await copyFiles(this.config, elementPath)
     }
   }
 
@@ -114,7 +122,9 @@ class StandardHandler {
     const parsedPath = parse(path)
     return join(
       parsedPath.dir,
-      `${parsedPath.name}.${this.ext}${METAFILE_SUFFIX}`
+      `${parsedPath.name}.${
+        this.metadata.get(this.type).suffix
+      }${METAFILE_SUFFIX}`
     )
   }
 
@@ -129,18 +139,16 @@ class StandardHandler {
     )
   }
 
-  _getRelativeMetadataXmlFileName(path) {
-    return `${parse(path).base.replace(this.ext, '').replace(/\.$/, '')}.${
-      this.metadata.get(this.type).suffix
-    }${METAFILE_SUFFIX}`
-  }
-
   _isProcessable() {
     return this.metadata.get(this.type).suffix === this.ext
   }
 
   _delegateFileCopy() {
     return true
+  }
+
+  _parentFolderIsNotTheType() {
+    return this.parentFolder !== this.type
   }
 }
 

--- a/src/utils/fsHelper.js
+++ b/src/utils/fsHelper.js
@@ -130,3 +130,4 @@ module.exports.scan = scan
 module.exports.scanExtension = (dir, ext, config) =>
   filterExt(scan(dir, config), ext)
 module.exports.writeFile = writeFile
+module.exports.DOT = '.'


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Simplify `InResourceHandler` file copy implementation so it does less copy than before.
This way it will do less call to git and less call to the file system.
Give more tools to the `standardHander` to:
- get information about the parent folder in the line.
- get metadata file name

Override metadata file name for `SharedFolderHandler` type as this type definition is shared with metadata leaving in the same folder