### PR TITLE
feat: add support for Net Zero Cloud metadata

### DIFF
--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -2006,5 +2006,12 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
+  },
+  {
+    "directoryName": "sustainabilityUoms",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sustainabilityUom",
+    "xmlName": "SustainabilityUom"
   }
 ]

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -2041,5 +2041,61 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
+  },
+  {
+    "directoryName": "clauseCatgConfigurations",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "clauseCatgConfiguration",
+    "xmlName": "ClauseCatgConfiguration"
+  },
+  {
+    "directoryName": "disclosureDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "disclosureDefinition",
+    "xmlName": "DisclosureDefinition"
+  },
+  {
+    "directoryName": "disclosureDefinitionVersions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "disclosureDefinitionVersion",
+    "xmlName": "DisclosureDefinitionVersion"
+  },
+  {
+    "directoryName": "disclosureTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "disclosureType ",
+    "xmlName": "DisclosureType"
+  },
+  {
+    "directoryName": "fuelTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "fuelType",
+    "xmlName": "FuelType"
+  },
+  {
+    "directoryName": "fuelTypeSustnUoms",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "fuelTypeSustnUom",
+    "xmlName": "FuelTypeSustnUom"
+  },
+  {
+    "directoryName": "sustnUomConversions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sustnUomConversion",
+    "xmlName": "SustnUomConversion"
+  },
+  {
+    "directoryName": "sustainabilityUoms",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sustainabilityUom",
+    "xmlName": "SustainabilityUom"
   }
 ]

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -2041,5 +2041,61 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
+  },
+  {
+    "directoryName": "clauseCatgConfigurations",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "clauseCatgConfiguration",
+    "xmlName": "ClauseCatgConfiguration"
+  },
+  {
+    "directoryName": "disclosureDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "disclosureDefinition",
+    "xmlName": "DisclosureDefinition"
+  },
+  {
+    "directoryName": "disclosureDefinitionVersions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "disclosureDefinitionVersion",
+    "xmlName": "DisclosureDefinitionVersion"
+  },
+  {
+    "directoryName": "disclosureTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "disclosureType ",
+    "xmlName": "DisclosureType"
+  },
+  {
+    "directoryName": "fuelTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "fuelType",
+    "xmlName": "FuelType"
+  },
+  {
+    "directoryName": "fuelTypeSustnUoms",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "fuelTypeSustnUom",
+    "xmlName": "FuelTypeSustnUom"
+  },
+  {
+    "directoryName": "sustnUomConversions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sustnUomConversion",
+    "xmlName": "SustnUomConversion"
+  },
+  {
+    "directoryName": "sustainabilityUoms",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "sustainabilityUom",
+    "xmlName": "SustainabilityUom"
   }
 ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

Add support for Net Zero Cloud metadata types per https://developer.salesforce.com/docs/atlas.en-us.netzero_cloud_dev_guide.meta/netzero_cloud_dev_guide/netzero_cloud_metadata_api_parent.htm for api version 57 and 58 (SustainabilityUom for v56).

    ClauseCatgConfiguration
    DisclosureDefinition
    DisclosureDefinitionVersion
    DisclosureType
    FuelType
    FuelTypeSustnUom
    SustnUomConversion
    SustainabilityUom  (56+)

# Does this close any currently open issues?

---

No open issue.

- [ ] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

# Any other comments

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
