### PR TITLE
WIP: fix: restore default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "/messages",
     "/oclif.manifest.json"
   ],
-  "main": "lib/main.js",
+  "main": "lib/index.cjs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/scolladon/sfdx-git-delta.git"

--- a/src/index.cjs
+++ b/src/index.cjs
@@ -1,0 +1,2 @@
+const sgd = require('./main.js').default
+module.exports = sgd

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@salesforce/dev-config/tsconfig",
+  "extends": "./node_modules/@salesforce/dev-config/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "outDir": "./lib",
@@ -28,6 +28,6 @@
   },
   "include": [
     "./src/**/*",
-    "./src/**/*.json"
+    "./src/**/*.json",
   ]
 }


### PR DESCRIPTION
# Explain your changes

---

It seems typescript clause `export default someting` is translated into `exports.default = sgd;` which is somehow different that expected `module.exports = sgd`. Then having this approach in order to import this we need to do some extra work:

```
const sgd = require('module').default
```

or 

```
import sgdDefault from 'module'
const sgd = sgdDefault.default
```

This is some proposal of solving the issue which I found. It is rather provided as example, not necessarily to merge (maybe there is smarter way).

related to https://github.com/scolladon/sfdx-git-delta/issues/701