### PR TITLE
feat: add `DocumentType` metadata support

### DIFF
--- a/src/metadata/a48.json
+++ b/src/metadata/a48.json
@@ -7,6 +7,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v47.json
+++ b/src/metadata/v47.json
@@ -7,6 +7,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v49.json
+++ b/src/metadata/v49.json
@@ -7,6 +7,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -7,6 +7,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -21,6 +21,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -21,6 +21,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -21,6 +21,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -49,6 +49,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -119,6 +119,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -119,6 +119,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -154,6 +154,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -154,6 +154,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -154,6 +154,13 @@
     "xmlName": "ActionPlanTemplate"
   },
   {
+    "directoryName": "documentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentType",
+    "xmlName": "DocumentType"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Add `DocumentType` metadata support
This metadata is available since `v47`.
It is located in the `documentTypes` folder with the `documentType` suffix.
It does not have meta file associated

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #443

