### PR TITLE
feat: adding prediction builder ai metadata types

### DIFF
--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1798,31 +1798,31 @@
     "excluded": true
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "actionPlanTemplates",
     "inFolder": false,
     "metaFile": false,
@@ -1796,33 +1824,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1796,5 +1796,33 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1866,5 +1866,33 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1868,31 +1868,31 @@
     "excluded": true
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "decisionTables",
     "inFolder": false,
     "metaFile": false,
@@ -1866,33 +1894,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1873,5 +1873,33 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "decisionTables",
     "inFolder": false,
     "metaFile": false,
@@ -1873,33 +1901,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1875,31 +1875,31 @@
     "excluded": true
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1873,5 +1873,33 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "decisionTables",
     "inFolder": false,
     "metaFile": false,
@@ -1873,33 +1901,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1875,31 +1875,31 @@
     "excluded": true
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1903,31 +1903,31 @@
     "excluded": true
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1901,5 +1901,33 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "uiObjectRelationConfigs",
     "inFolder": false,
     "metaFile": false,
@@ -1901,33 +1929,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1994,31 +1994,31 @@
     "excluded": true
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1992,5 +1992,33 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "uiObjectRelationConfigs",
     "inFolder": false,
     "metaFile": false,
@@ -1992,33 +2020,5 @@
     "xmlTag": "workflowTasks",
     "key": "name",
     "excluded": true
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -2027,5 +2027,33 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -2029,31 +2029,31 @@
     "xmlName": "SustainabilityUom"
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "eventRelays",
     "inFolder": false,
     "metaFile": false,
@@ -2027,33 +2055,5 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "eventRelays",
     "inFolder": false,
     "metaFile": false,
@@ -2118,33 +2146,5 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -2118,5 +2118,33 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -2120,31 +2120,31 @@
     "xmlName": "SustainabilityUom"
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "eventRelays",
     "inFolder": false,
     "metaFile": false,
@@ -2118,33 +2146,5 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -2118,5 +2118,33 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -2120,31 +2120,31 @@
     "xmlName": "SustainabilityUom"
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1,5 +1,33 @@
 [
   {
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  },
+  {
     "directoryName": "eventRelays",
     "inFolder": false,
     "metaFile": false,
@@ -2118,33 +2146,5 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  },
-  {
-    "directoryName": "aiApplicationConfigs",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "aiapplicationconfig",
-    "xmlName": "AIApplicationConfig"
-  },
-  {
-    "directoryName": "aiApplications",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "ai",
-    "xmlName": "AIApplication"
-  },
-  {
-    "directoryName": "mlDataDefinitions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlDataDefinition",
-    "xmlName": "MLDataDefinition"
-  },
-  {
-    "directoryName": "mlPredictions",
-    "inFolder": false,
-    "metaFile": false,
-    "suffix": "mlPrediction",
-    "xmlName": "MLPredictionDefinition"
   }
 ]

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -2118,5 +2118,33 @@
     "metaFile": false,
     "suffix": "sustainabilityUom",
     "xmlName": "SustainabilityUom"
-  }
+  },
+  {
+      "directoryName": "aiApplicationConfigs",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "aiapplicationconfig",
+      "xmlName": "AIApplicationConfig"
+    },
+    {
+      "directoryName": "aiApplications",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "ai",
+      "xmlName": "AIApplication"
+    },
+    {
+      "directoryName": "mlDataDefinitions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlDataDefinition",
+      "xmlName": "MLDataDefinition"
+    },
+    {
+      "directoryName": "mlPredictions",
+      "inFolder": false,
+      "metaFile": false,
+      "suffix": "mlPrediction",
+      "xmlName": "MLPredictionDefinition"
+    }
 ]

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -2120,31 +2120,31 @@
     "xmlName": "SustainabilityUom"
   },
   {
-      "directoryName": "aiApplicationConfigs",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "aiapplicationconfig",
-      "xmlName": "AIApplicationConfig"
-    },
-    {
-      "directoryName": "aiApplications",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "ai",
-      "xmlName": "AIApplication"
-    },
-    {
-      "directoryName": "mlDataDefinitions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlDataDefinition",
-      "xmlName": "MLDataDefinition"
-    },
-    {
-      "directoryName": "mlPredictions",
-      "inFolder": false,
-      "metaFile": false,
-      "suffix": "mlPrediction",
-      "xmlName": "MLPredictionDefinition"
-    }
+    "directoryName": "aiApplicationConfigs",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "aiapplicationconfig",
+    "xmlName": "AIApplicationConfig"
+  },
+  {
+    "directoryName": "aiApplications",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ai",
+    "xmlName": "AIApplication"
+  },
+  {
+    "directoryName": "mlDataDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlDataDefinition",
+    "xmlName": "MLDataDefinition"
+  },
+  {
+    "directoryName": "mlPredictions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "mlPrediction",
+    "xmlName": "MLPredictionDefinition"
+  }
 ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

Adding 4 metadata types to the different metadata files to allow Einstein Prediction Builder delta deployments.

<!--
  Describe with your own words the content of the Pull Request
-->

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

No Issue related to this.

# Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

# Any other comments


an AI Model was created and deployed through VS Code with these files and it works so deltas will work as well, the  

directoryName, suffix and xmlName were triple checked with a local example.
inFolder and metaFile where set to false as I copied the connectedApps one.
---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
