### PR TITLE
feat: add remaining discovery framework metadata type support

### DIFF
--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -98,6 +98,20 @@
     "xmlName": "LoyaltyProgramSetup"
   },
   {
+    "directoryName": "documentCategory",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentCategory",
+    "xmlName": "DocumentCategory"
+  },
+  {
+    "directoryName": "documentCategoryDocumentTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "documentCategoryDocumentType",
+    "xmlName": "DocumentCategoryDocumentType"
+  },
+  {
     "directoryName": "AssessmentQuestions",
     "inFolder": false,
     "metaFile": false,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Add [DocumentCategory](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_documentcategory.htm) and [DocumentCategoryDocumentType](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_documentcategorydocumenttype.htm) metadata support

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #756 