### PR TITLE
fix: use constant for path separator

### DIFF
--- a/src/constant/fsConstants.ts
+++ b/src/constant/fsConstants.ts
@@ -1,8 +1,6 @@
 'use strict'
 
-import { posix } from 'path'
-
 export const DOT = '.'
 export const UTF8_ENCODING = 'utf8'
 export const PATH_SEPARATOR_REGEX = /[/\\]+/
-export const PATH_SEP = posix.sep
+export const PATH_SEP = '/'


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Use constant for path separator