### PR TITLE
fix: use `keywords` instead of `keyword` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sfdx-git-delta",
   "version": "5.40.2",
   "description": "Generate the sfdx content in source format and destructive change from two git commits",
-  "keyword": [
+  "keywords": [
     "salesforce",
     "package",
     "git",


### PR DESCRIPTION
Thanks for this awesome plugin. I'm using it in several projects!

I'm working on a website for exploring awesome sfdx/sf plugins and was wondering why it didn't show `sfdx-git-delta`.

https://amtrack.github.io/sf-plugin-explorer/

![Untitled](https://github.com/scolladon/sfdx-git-delta/assets/789765/11cdba68-ae1a-4b89-9aae-577016cfdbbe)

