### PR TITLE
feat: add FeatureParameter metadata support

### DIFF
--- a/__tests__/integration/services.test.ts
+++ b/__tests__/integration/services.test.ts
@@ -437,6 +437,21 @@ const testContext = [
     new Set(['WaveXmdTest']),
     'WaveXmd',
   ],
+  [
+    'force-app/main/default/featureParameters/FeatureParameterIntegerTest.featureParameterInteger',
+    new Set(['FeatureParameterIntegerTest']),
+    'FeatureParameterInteger',
+  ],
+  [
+    'force-app/main/default/featureParameters/FeatureParameterBooleanTest.featureParameterBoolean',
+    new Set(['FeatureParameterBooleanTest']),
+    'FeatureParameterBoolean',
+  ],
+  [
+    'force-app/main/default/featureParameters/FeatureParameterDateTest.featureParameterDate',
+    new Set(['FeatureParameterDateTest']),
+    'FeatureParameterDate',
+  ],
 ]
 
 let globalMetadata: MetadataRepository

--- a/src/metadata/v46.json
+++ b/src/metadata/v46.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "recommendationStrategies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v47.json
+++ b/src/metadata/v47.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "actionPlanTemplates",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v49.json
+++ b/src/metadata/v49.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "webstoretemplate",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "useraccesspolicies",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
     "directoryName": "dw",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
   "directoryName": "conversationMessageDefinitions",
   "inFolder": false,
   "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
   "directoryName": "conversationMessageDefinitions",
   "inFolder": false,
   "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
   "directoryName": "conversationMessageDefinitions",
   "inFolder": false,
   "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1,5 +1,26 @@
 [
   {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterInteger",
+    "xmlName": "FeatureParameterInteger"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterBoolean",
+    "xmlName": "FeatureParameterBoolean"
+  },
+  {
+    "directoryName": "featureParameters",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "featureParameterDate",
+    "xmlName": "FeatureParameterDate"
+  },
+  {
   "directoryName": "conversationMessageDefinitions",
   "inFolder": false,
   "metaFile": false,


### PR DESCRIPTION
# Explain your changes

---

Add metadata support for all three types of Feature Parameters:
- [FeatureParameterBoolean](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_featureparameterboolean.htm)
- [FeatureParameterDate](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_featureparameterdate.htm)
- [FeatureParameterInteger](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_featureparameterinteger.htm)