### PR TITLE
fix: workflow knowledge publish decomposed sub type suffix

### DIFF
--- a/src/metadata/a48.json
+++ b/src/metadata/a48.json
@@ -1272,7 +1272,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v46.json
+++ b/src/metadata/v46.json
@@ -1040,7 +1040,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v47.json
+++ b/src/metadata/v47.json
@@ -1272,7 +1272,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v49.json
+++ b/src/metadata/v49.json
@@ -1300,7 +1300,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1335,7 +1335,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1405,7 +1405,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1412,7 +1412,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1412,7 +1412,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1465,7 +1465,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1563,7 +1563,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -1591,7 +1591,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1640,7 +1640,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1647,7 +1647,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1669,7 +1669,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1703,7 +1703,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1710,7 +1710,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1710,7 +1710,7 @@
     "directoryName": "workflowKnowledgePublishs",
     "inFolder": false,
     "metaFile": false,
-    "suffix": "workflowKnowledgePublishe",
+    "suffix": "workflowKnowledgePublish",
     "parentXmlName": "Workflow",
     "xmlName": "WorkflowKnowledgePublish",
     "xmlTag": "knowledgePublishes",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

fix workflow knowledge publish decomposed sub type suffix

