### PR TITLE
feat: prune `layoutAssignments`, `loginHours` and `loginIpRanges`

### DIFF
--- a/__tests__/unit/lib/utils/fxpHelper.test.ts
+++ b/__tests__/unit/lib/utils/fxpHelper.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it, jest } from '@jest/globals'
 import type { Config } from '../../../../src/types/config'
 import { readPathFromGit } from '../../../../src/utils/fsHelper'
 import {
-  asArray,
   convertJsonToXml,
   parseXmlFileToJson,
   xml2Json,
@@ -15,32 +14,6 @@ const mockedReadPathFromGit = jest.mocked(readPathFromGit)
 jest.mock('../../../../src/utils/fsHelper')
 
 describe('fxpHelper', () => {
-  describe('asArray', () => {
-    describe('when called with array', () => {
-      // Arrange
-      const expected = ['test']
-
-      it('returns the same array', () => {
-        // Act
-        const actual = asArray(expected)
-
-        // Assert
-        expect(actual).toBe(expected)
-      })
-    })
-    describe('when called with object', () => {
-      // Arrange
-      const expected = 'test'
-
-      it('returns the array with this object', () => {
-        // Act
-        const actual = asArray(expected)
-
-        // Assert
-        expect(actual).toEqual([expected])
-      })
-    })
-  })
   describe('parseXmlFileToJson', () => {
     const config: Config = {
       from: '',

--- a/__tests__/unit/lib/utils/metadataDiff.test.ts
+++ b/__tests__/unit/lib/utils/metadataDiff.test.ts
@@ -210,11 +210,7 @@ describe.each([[{}], [xmlHeader]])(`MetadataDiff`, header => {
     work = getWork()
     work.config.from = 'from'
     work.config.to = 'to'
-    metadataDiff = new MetadataDiff(
-      work.config,
-      globalMetadata,
-      inFileAttribute
-    )
+    metadataDiff = new MetadataDiff(work.config, inFileAttribute)
   })
 
   describe(`compare with ${JSON.stringify(header)} header`, () => {

--- a/src/metadata/a48.json
+++ b/src/metadata/a48.json
@@ -1505,14 +1505,40 @@
     "xmlTag": "fieldPermissions",
     "key": "field",
     "excluded": true
-  },
-  {
+  },{
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
     "xmlName": "ProfileFlowAccess",
     "xmlTag": "flowAccesses",
     "key": "flow",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/a48.json
+++ b/src/metadata/a48.json
@@ -1529,7 +1529,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1538,7 +1537,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v46.json
+++ b/src/metadata/v46.json
@@ -1298,7 +1298,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1307,7 +1306,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v46.json
+++ b/src/metadata/v46.json
@@ -1289,7 +1289,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v46.json
+++ b/src/metadata/v46.json
@@ -1287,6 +1287,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v47.json
+++ b/src/metadata/v47.json
@@ -1521,7 +1521,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v47.json
+++ b/src/metadata/v47.json
@@ -1530,7 +1530,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1539,7 +1538,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v47.json
+++ b/src/metadata/v47.json
@@ -1519,6 +1519,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v49.json
+++ b/src/metadata/v49.json
@@ -1549,7 +1549,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v49.json
+++ b/src/metadata/v49.json
@@ -1547,6 +1547,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v49.json
+++ b/src/metadata/v49.json
@@ -1558,7 +1558,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1567,7 +1566,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1584,7 +1584,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1593,7 +1593,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1602,7 +1601,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v50.json
+++ b/src/metadata/v50.json
@@ -1582,6 +1582,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1652,6 +1652,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1663,7 +1663,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1672,7 +1671,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v51.json
+++ b/src/metadata/v51.json
@@ -1654,7 +1654,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1661,7 +1661,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1659,6 +1659,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v52.json
+++ b/src/metadata/v52.json
@@ -1670,7 +1670,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1679,7 +1678,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1661,7 +1661,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1659,6 +1659,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v53.json
+++ b/src/metadata/v53.json
@@ -1670,7 +1670,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1679,7 +1678,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1712,6 +1712,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1714,7 +1714,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v54.json
+++ b/src/metadata/v54.json
@@ -1723,7 +1723,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1732,7 +1731,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1812,7 +1812,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1821,7 +1821,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1830,7 +1829,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -1810,6 +1810,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -1840,7 +1840,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -1849,7 +1849,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1858,7 +1857,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -1838,6 +1838,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1889,7 +1889,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1887,6 +1887,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1898,7 +1898,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1907,7 +1906,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1896,7 +1896,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1894,6 +1894,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1905,7 +1905,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1914,7 +1913,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1927,7 +1927,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1936,7 +1935,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1918,7 +1918,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1916,6 +1916,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1961,7 +1961,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1970,7 +1969,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1950,6 +1950,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1952,7 +1952,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1959,7 +1959,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1957,6 +1957,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1968,7 +1968,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1977,7 +1976,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1959,7 +1959,7 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLayoutAssignments",
     "xmlTag": "layoutAssignments",
-    "key": "<object>",
+    "key": "layout",
     "excluded": true
   },
   {

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1957,6 +1957,33 @@
     "inFolder": false,
     "metaFile": false,
     "parentXmlName": "Profile",
+    "xmlName": "ProfileLayoutAssignments",
+    "xmlTag": "layoutAssignments",
+    "key": "<object>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginHours",
+    "xmlTag": "loginHours",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
+    "xmlName": "ProfileLoginIpRange",
+    "xmlTag": "loginIpRanges",
+    "key": "<array>",
+    "excluded": true
+  },
+  {
+    "inFolder": false,
+    "metaFile": false,
+    "parentXmlName": "Profile",
     "xmlName": "LoginFlow",
     "xmlTag": "loginFlows",
     "key": "friendlyname",

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1968,7 +1968,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginHours",
     "xmlTag": "loginHours",
-    "key": "<array>",
     "excluded": true
   },
   {
@@ -1977,7 +1976,6 @@
     "parentXmlName": "Profile",
     "xmlName": "ProfileLoginIpRange",
     "xmlTag": "loginIpRanges",
-    "key": "<array>",
     "excluded": true
   },
   {

--- a/src/post-processor/flowTranslationProcessor.ts
+++ b/src/post-processor/flowTranslationProcessor.ts
@@ -1,4 +1,6 @@
 'use strict'
+
+import { castArray } from 'lodash'
 import { join, parse } from 'path/posix'
 
 import { pathExists } from 'fs-extra'
@@ -14,7 +16,6 @@ import type { Work } from '../types/work'
 import { readDir, writeFile } from '../utils/fsHelper'
 import { isSamePath, isSubDir, readFile } from '../utils/fsUtils'
 import {
-  asArray,
   convertJsonToXml,
   parseXmlFileToJson,
   xml2Json,
@@ -111,7 +112,7 @@ export default class FlowTranslationProcessor extends BaseProcessor {
     // biome-ignore lint/suspicious/noExplicitAny: Any is expected here
     actualFlowDefinition: any
   ) {
-    const flowDefinitions = asArray(
+    const flowDefinitions = castArray(
       jsonTranslation.Translations?.flowDefinitions
     )
     const fullNames = new Set(
@@ -133,7 +134,7 @@ export default class FlowTranslationProcessor extends BaseProcessor {
       { path: translationPath, oid: this.config.to },
       this.config
     )
-    const flowDefinitions = asArray(
+    const flowDefinitions = castArray(
       translationJSON?.Translations?.flowDefinitions
     )
     flowDefinitions.forEach(flowDefinition =>

--- a/src/service/inFileHandler.ts
+++ b/src/service/inFileHandler.ts
@@ -24,7 +24,7 @@ export default class InFileHandler extends StandardHandler {
   ) {
     super(line, metadataDef, work, metadata)
     const inFileMetadata = getInFileAttributes(metadata)
-    this.metadataDiff = new MetadataDiff(this.config, metadata, inFileMetadata)
+    this.metadataDiff = new MetadataDiff(this.config, inFileMetadata)
   }
 
   public override async handleAddition() {

--- a/src/service/objectTranslationHandler.ts
+++ b/src/service/objectTranslationHandler.ts
@@ -21,11 +21,7 @@ export default class ObjectTranslationHandler extends ResourceHandler {
 
   protected async _copyObjectTranslation(path: string) {
     const inFileMetadata = getInFileAttributes(this.metadata)
-    const metadataDiff = new MetadataDiff(
-      this.config,
-      this.metadata,
-      inFileMetadata
-    )
+    const metadataDiff = new MetadataDiff(this.config, inFileMetadata)
     await metadataDiff.compare(path)
     const { xmlContent } = metadataDiff.prune()
     await writeFile(path, xmlContent, this.config)

--- a/src/utils/fxpHelper.ts
+++ b/src/utils/fxpHelper.ts
@@ -25,11 +25,6 @@ const JSON_PARSER_OPTION = {
   suppressEmptyNode: false,
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-export const asArray = (node: any[] | any) => {
-  return Array.isArray(node) ? node : [node]
-}
-
 export const xml2Json = (xmlContent: string) => {
   // biome-ignore lint/suspicious/noExplicitAny: Any is expected here
   let jsonContent: any = {}

--- a/src/utils/fxpHelper.ts
+++ b/src/utils/fxpHelper.ts
@@ -25,7 +25,8 @@ const JSON_PARSER_OPTION = {
   suppressEmptyNode: false,
 }
 
-export const asArray = (node: string[] | string) => {
+// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+export const asArray = (node: any[] | any) => {
   return Array.isArray(node) ? node : [node]
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Implement `layoutAssignments`, `loginHours` and `loginIpRanges` pruning algorithm.

For `layoutAssignments` the implementation outputs the previous list and new list difference based on object comparison

For `loginHours` and `loginIpRanges` the implementation outputs the new list only when the previous list and the new list are different.

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #953
closes #948