### PR TITLE
feat: add `ExternalClientApplication` metadata support

### DIFF
--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1,5 +1,40 @@
 [
   {
+    "directoryName": "externalClientApps",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "eca",
+    "xmlName": "ExternalClientApplication"
+  },
+  {
+    "directoryName": "extlClntAppOauthSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauth",
+    "xmlName": "ExtlClntAppOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppGlobalOauthSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaGlblOauth",
+    "xmlName": "ExtlClntAppGlobalOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppOauthPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauthPlcy",
+    "xmlName": "ExtlClntAppOauthConfigurablePolicies"
+  },
+  {
+    "directoryName": "extlClntAppPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaPlcy",
+    "xmlName": "ExtlClntAppConfigurablePolicies"
+  },
+  {
     "directoryName": "apexEmailNotifications",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1,5 +1,40 @@
 [
   {
+    "directoryName": "externalClientApps",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "eca",
+    "xmlName": "ExternalClientApplication"
+  },
+  {
+    "directoryName": "extlClntAppOauthSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauth",
+    "xmlName": "ExtlClntAppOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppGlobalOauthSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaGlblOauth",
+    "xmlName": "ExtlClntAppGlobalOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppOauthPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauthPlcy",
+    "xmlName": "ExtlClntAppOauthConfigurablePolicies"
+  },
+  {
+    "directoryName": "extlClntAppPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaPlcy",
+    "xmlName": "ExtlClntAppConfigurablePolicies"
+  },
+  {
     "directoryName": "apexEmailNotifications",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1,5 +1,40 @@
 [
   {
+    "directoryName": "externalClientApps",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "eca",
+    "xmlName": "ExternalClientApplication"
+  },
+  {
+    "directoryName": "extlClntAppOauthSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauth",
+    "xmlName": "ExtlClntAppOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppGlobalOauthSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaGlblOauth",
+    "xmlName": "ExtlClntAppGlobalOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppOauthPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauthPlcy",
+    "xmlName": "ExtlClntAppOauthConfigurablePolicies"
+  },
+  {
+    "directoryName": "extlClntAppPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaPlcy",
+    "xmlName": "ExtlClntAppConfigurablePolicies"
+  },
+  {
     "directoryName": "apexEmailNotifications",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1,5 +1,40 @@
 [
   {
+    "directoryName": "externalClientApps",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "eca",
+    "xmlName": "ExternalClientApplication"
+  },
+  {
+    "directoryName": "extlClntAppOauthSettings",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauth",
+    "xmlName": "ExtlClntAppOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppGlobalOauthSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaGlblOauth",
+    "xmlName": "ExtlClntAppGlobalOauthSettings"
+  },
+  {
+    "directoryName": "extlClntAppOauthPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaOauthPlcy",
+    "xmlName": "ExtlClntAppOauthConfigurablePolicies"
+  },
+  {
+    "directoryName": "extlClntAppPolicies",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "ecaPlcy",
+    "xmlName": "ExtlClntAppConfigurablePolicies"
+  },
+  {
     "directoryName": "apexEmailNotifications",
     "inFolder": false,
     "metaFile": false,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Add support for those metadata (starting at `v59`) : 
- [`ExternalClientApplication`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_externalclientapplication.htm)
- [`ExtlClntAppGlobalOauthSettings`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_extlclntappglobaloauthsettings.htm)
- [`ExtlClntAppOauthConfigurablePolicies`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_extlclntappoauthconfigurablepolicies.htm)
- [`ExtlClntAppOauthSettings`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_extlclntappoauthsettings.htm)
- [`ExtlClntAppConfigurablePolicies`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_extlclntappconfigurablepolicies.htm)

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #955