### PR TITLE
feat: add Expression Set metadatas support

### DIFF
--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -196,6 +196,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "actionPlanTemplates",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -203,6 +203,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetObjectAlias",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetObjectAlias",
+    "xmlName": "ExpressionSetObjectAlias"
+  },
+  {
     "directoryName": "actionPlanTemplates",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -203,6 +203,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "expressionSetObjectAlias",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -224,6 +224,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetObjectAlias",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetObjectAlias",
+    "xmlName": "ExpressionSetObjectAlias"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -224,6 +224,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "expressionSetObjectAlias",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -231,6 +231,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetObjectAlias",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetObjectAlias",
+    "xmlName": "ExpressionSetObjectAlias"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -231,6 +231,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "expressionSetObjectAlias",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -294,6 +294,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "contextDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "contextDefinition",
+    "xmlName": "ContextDefinition"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -287,6 +287,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "expressionSetObjectAlias",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -294,6 +294,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "ExpressionSetMessageToken",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetMessageToken",
+    "xmlName": "ExpressionSetMessageToken"
+  },
+  {
     "directoryName": "contextDefinitions",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -287,6 +287,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetObjectAlias",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetObjectAlias",
+    "xmlName": "ExpressionSetObjectAlias"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -329,6 +329,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "contextDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "contextDefinition",
+    "xmlName": "ContextDefinition"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -336,6 +336,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "expressionSetObjectAlias",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -322,6 +322,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetObjectAlias",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetObjectAlias",
+    "xmlName": "ExpressionSetObjectAlias"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1,5 +1,19 @@
 [
   {
+    "directoryName": "productSpecificationTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "productSpecificationType",
+    "xmlName": "ProductSpecificationType"
+  },
+  {
+    "directoryName": "productSpecificationRecTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "productSpecificationRecType",
+    "xmlName": "ProductSpecificationRecType"
+  },
+  {
     "directoryName": "externalClientApps",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -329,6 +329,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "ExpressionSetMessageToken",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetMessageToken",
+    "xmlName": "ExpressionSetMessageToken"
+  },
+  {
     "directoryName": "contextDefinitions",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -336,6 +336,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "ExpressionSetMessageToken",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetMessageToken",
+    "xmlName": "ExpressionSetMessageToken"
+  },
+  {
     "directoryName": "contextDefinitions",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -336,6 +336,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "contextDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "contextDefinition",
+    "xmlName": "ContextDefinition"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -343,6 +343,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "expressionSetObjectAlias",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -329,6 +329,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetObjectAlias",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetObjectAlias",
+    "xmlName": "ExpressionSetObjectAlias"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1,5 +1,19 @@
 [
   {
+    "directoryName": "productSpecificationTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "productSpecificationType",
+    "xmlName": "ProductSpecificationType"
+  },
+  {
+    "directoryName": "productSpecificationRecTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "productSpecificationRecType",
+    "xmlName": "ProductSpecificationRecType"
+  },
+  {
     "directoryName": "externalClientApps",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -336,6 +336,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "ExpressionSetMessageToken",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetMessageToken",
+    "xmlName": "ExpressionSetMessageToken"
+  },
+  {
     "directoryName": "contextDefinitions",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -336,6 +336,13 @@
     "xmlName": "ExpressionSetObjectAlias"
   },
   {
+    "directoryName": "contextDefinitions",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "contextDefinition",
+    "xmlName": "ContextDefinition"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -343,6 +343,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetVersion",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetVersion",
+    "xmlName": "ExpressionSetVersion"
+  },
+  {
     "directoryName": "expressionSetObjectAlias",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -329,6 +329,13 @@
     "xmlName": "ExpressionSetDefinition"
   },
   {
+    "directoryName": "expressionSetObjectAlias",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "expressionSetObjectAlias",
+    "xmlName": "ExpressionSetObjectAlias"
+  },
+  {
     "directoryName": "explainabilityActionDefinition",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "uiFormatSpecificationSets",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "uiFormatSpecificationSet",
+    "xmlName": "UiFormatSpecificationSet"
+  },
+  {
     "directoryName": "productSpecificationTypes",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1,5 +1,19 @@
 [
   {
+    "directoryName": "productSpecificationTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "productSpecificationType",
+    "xmlName": "ProductSpecificationType"
+  },
+  {
+    "directoryName": "productSpecificationRecTypes",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "productSpecificationRecType",
+    "xmlName": "ProductSpecificationRecType"
+  },
+  {
     "directoryName": "externalClientApps",
     "inFolder": false,
     "metaFile": false,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Support for :

[`ContextDefinition`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_contextdefinition.htm?q=Context%20Definitions)
[`ExpressionSetMessageToken`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_expressionsetmessagetoken.htm?q=ExpressionSetMessageToken)
[`ExpressionSetObjectAlias`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_expressionsetobjectalias.htm?q=ExpressionSetMessageToken)
[`ProductSpecificationType`](https://developer.salesforce.com/docs/atlas.en-us.revenue_lifecycle_management_dev_guide.meta/revenue_lifecycle_management_dev_guide/sforce_api_objects_productspecificationtype.htm)
[`ProductSpecificationRecType`](https://developer.salesforce.com/docs/atlas.en-us.revenue_lifecycle_management_dev_guide.meta/revenue_lifecycle_management_dev_guide/sforce_api_objects_productspecificationrectype.htm)
[`UiFormatSpecificationSet`](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_uiformatspecificationset.htm)
`ExpressionSetVersion` (not described in the metadata API documentation but available through it)

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #959