### PR TITLE
fix: metadata definition for `ExpressionSetDefinitionVersion`

### DIFF
--- a/src/metadata/v55.json
+++ b/src/metadata/v55.json
@@ -200,7 +200,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "actionPlanTemplates",

--- a/src/metadata/v56.json
+++ b/src/metadata/v56.json
@@ -207,7 +207,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "expressionSetObjectAlias",

--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -228,7 +228,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "expressionSetObjectAlias",

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -235,7 +235,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "expressionSetObjectAlias",

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -291,7 +291,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "expressionSetObjectAlias",

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -340,7 +340,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "expressionSetObjectAlias",

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -347,7 +347,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "expressionSetObjectAlias",

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -354,7 +354,7 @@
     "inFolder": false,
     "metaFile": false,
     "suffix": "expressionSetVersion",
-    "xmlName": "ExpressionSetVersion"
+    "xmlName": "ExpressionSetDefinitionVersion"
   },
   {
     "directoryName": "expressionSetObjectAlias",


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

This is an attempt to fix the metadata definition of `ExpressionSetDefinitionVersion`

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #959
