### PR TITLE
feat: add ApplicationRecordTypeConfig metadata support

### DIFF
--- a/src/metadata/v57.json
+++ b/src/metadata/v57.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "ApplicationRecordTypeConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "applicationRecordTypeConfig",
+    "xmlName": "ApplicationRecordTypeConfig"
+  },
+  {
     "directoryName": "apexEmailNotifications",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v58.json
+++ b/src/metadata/v58.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "ApplicationRecordTypeConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "applicationRecordTypeConfig",
+    "xmlName": "ApplicationRecordTypeConfig"
+  },
+  {
     "directoryName": "apexEmailNotifications",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v59.json
+++ b/src/metadata/v59.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "ApplicationRecordTypeConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "applicationRecordTypeConfig",
+    "xmlName": "ApplicationRecordTypeConfig"
+  },
+  {
     "directoryName": "externalClientApps",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v60.json
+++ b/src/metadata/v60.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "ApplicationRecordTypeConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "applicationRecordTypeConfig",
+    "xmlName": "ApplicationRecordTypeConfig"
+  },
+  {
     "directoryName": "productSpecificationTypes",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v61.json
+++ b/src/metadata/v61.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "ApplicationRecordTypeConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "applicationRecordTypeConfig",
+    "xmlName": "ApplicationRecordTypeConfig"
+  },
+  {
     "directoryName": "productSpecificationTypes",
     "inFolder": false,
     "metaFile": false,

--- a/src/metadata/v62.json
+++ b/src/metadata/v62.json
@@ -1,5 +1,12 @@
 [
   {
+    "directoryName": "ApplicationRecordTypeConfig",
+    "inFolder": false,
+    "metaFile": false,
+    "suffix": "applicationRecordTypeConfig",
+    "xmlName": "ApplicationRecordTypeConfig"
+  },
+  {
     "directoryName": "uiFormatSpecificationSets",
     "inFolder": false,
     "metaFile": false,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Add [ApplicationRecordTypeConfig](https://developer.salesforce.com/docs/atlas.en-us.psc_api.meta/psc_api/meta_applicationrecordtypeconfig.htm) metadata support

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #968