### PR TITLE
feat: add `WorkflowFlowActions` metadata support

### DIFF
--- a/__tests__/unit/lib/service/inFileHandler.test.ts
+++ b/__tests__/unit/lib/service/inFileHandler.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../../../src/utils/fsHelper')
 const workflowType = {
   childXmlNames: [
     'WorkflowFieldUpdate',
+    'WorkflowFlowAction',
     'WorkflowKnowledgePublish',
     'WorkflowTask',
     'WorkflowAlert',
@@ -70,7 +71,7 @@ describe.each([true, false])(`inFileHandler -d: %s`, generateDelta => {
       )
       mockCompare.mockImplementation(() =>
         Promise.resolve({
-          added: new Map([['WorkflowAlert', new Set(['test'])]]),
+          added: new Map([['WorkflowFlowAction', new Set(['test'])]]),
           deleted: new Map(),
         })
       )
@@ -82,7 +83,7 @@ describe.each([true, false])(`inFileHandler -d: %s`, generateDelta => {
       // Assert
       expect(work.diffs.destructiveChanges.size).toEqual(0)
       expect(work.diffs.package.get('Workflow')).toEqual(new Set(['Account']))
-      expect(work.diffs.package.get('WorkflowAlert')).toEqual(
+      expect(work.diffs.package.get('WorkflowFlowAction')).toEqual(
         new Set(['Account.test'])
       )
 

--- a/src/metadata/v46.ts
+++ b/src/metadata/v46.ts
@@ -956,6 +956,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -987,6 +988,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v47.ts
+++ b/src/metadata/v47.ts
@@ -1191,6 +1191,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1222,6 +1223,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v48.ts
+++ b/src/metadata/v48.ts
@@ -1191,6 +1191,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1222,6 +1223,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v49.ts
+++ b/src/metadata/v49.ts
@@ -1219,6 +1219,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1250,6 +1251,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v50.ts
+++ b/src/metadata/v50.ts
@@ -1254,6 +1254,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1285,6 +1286,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v51.ts
+++ b/src/metadata/v51.ts
@@ -1324,6 +1324,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1355,6 +1356,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v52.ts
+++ b/src/metadata/v52.ts
@@ -1331,6 +1331,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1362,6 +1363,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v53.ts
+++ b/src/metadata/v53.ts
@@ -1331,6 +1331,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1362,6 +1363,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v54.ts
+++ b/src/metadata/v54.ts
@@ -1382,6 +1382,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1413,6 +1414,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v55.ts
+++ b/src/metadata/v55.ts
@@ -1487,6 +1487,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1518,6 +1519,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v56.ts
+++ b/src/metadata/v56.ts
@@ -1522,6 +1522,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1553,6 +1554,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v57.ts
+++ b/src/metadata/v57.ts
@@ -1578,6 +1578,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1609,6 +1610,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v58.ts
+++ b/src/metadata/v58.ts
@@ -1585,6 +1585,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1616,6 +1617,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v59.ts
+++ b/src/metadata/v59.ts
@@ -1656,6 +1656,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1687,6 +1688,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v60.ts
+++ b/src/metadata/v60.ts
@@ -1704,6 +1704,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1735,6 +1736,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v61.ts
+++ b/src/metadata/v61.ts
@@ -1711,6 +1711,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1742,6 +1743,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v62.ts
+++ b/src/metadata/v62.ts
@@ -1718,6 +1718,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1749,6 +1750,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {

--- a/src/metadata/v63.ts
+++ b/src/metadata/v63.ts
@@ -1718,6 +1718,7 @@ export default [
   {
     childXmlNames: [
       'WorkflowFieldUpdate',
+      'WorkflowFlowAction',
       'WorkflowKnowledgePublish',
       'WorkflowTask',
       'WorkflowAlert',
@@ -1749,6 +1750,16 @@ export default [
     parentXmlName: 'Workflow',
     xmlName: 'WorkflowFieldUpdate',
     xmlTag: 'fieldUpdates',
+    key: 'fullName',
+  },
+  {
+    directoryName: 'workflowFlowActions',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'workflowFlowAction',
+    parentXmlName: 'Workflow',
+    xmlName: 'WorkflowFlowAction',
+    xmlTag: 'flowActions',
     key: 'fullName',
   },
   {


### PR DESCRIPTION
---

I think we've talked about this previously in my plugin, but Workflow Flow Actions was missing in the Salesforce metadata registry. When opting into Salesforce's decomposed workflows, this caused my flow actions in my org to be decomposed in the parent file.

I recently contributed to SDR via https://github.com/forcedotcom/source-deploy-retrieve/pull/1467 to add Workflow Flow Actions to the overall metadata registry and the decomposed workflows preset. This was accepted by Salesforce and looks to be on track to be in the next CLI release. This will require sfdx-git-delta to be updated to detect decomposed workflow flow actions when this update is released to the public.

Based on the open PR in https://github.com/forcedotcom/cli, this update will be included in the 2.72.21 (Jan 15, 2025) build.


# Does this close any currently open issues?

No open issues but this will cause an issue if left unresolved once Salesforce CLI 2.72.21 is released and users attempt to use sfdx-git-delta to detect changes to decomposed workflow flow actions afterwards.

- [ ] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

You have existing decomposed tests already, not sure if you want to update/add this specific metadata type to the test or not. This is my first true contribution to sfdx-git-delta, so I'll leave the call up to you if you want me to add/update any tests for this metadata registry update.

# Any other comments

Depends on Salesforce CLI release 2.72.21 (Jan 15, 2025) build. Probably want to release it around then to coincide with users using the latest available CLI.
