### PR TITLE
fix: add `--loglevel` breaking change explanation

### DIFF
--- a/docs/migrating-to-v6.0.0.md
+++ b/docs/migrating-to-v6.0.0.md
@@ -13,6 +13,7 @@ Version `v6.0.0` brings the plugin into the **sf plugin v2 architecture**, which
 - [Plugin output format changes](#default-output)
 - [Streamlined JSON output](#json-output)
 - [Switch to ES modules (no more CommonJS)](#export-module)
+- [Setting LogLevel](#setting-log-level)
 
 ## Installation Details
 
@@ -165,3 +166,9 @@ Here’s is how to import the plugin:
 ```js
 import sgd from 'sfdx-git-delta'
 ```
+
+### <a name="setting-log-level"></a> Setting LogLevel
+
+Previously with `sfdx/cli` LogLevel was set using the `--loglevel` parameter. It is still usable but is ignored and logs a warning message.  
+Now with the `salesforce/cli` LogLevel is set with the [SF_LOG_LEVEL environment variable](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/
+sfdx_dev_cli_log_messages.htm) and the parameter will soon be removed

--- a/docs/migrating-to-v6.0.0.md
+++ b/docs/migrating-to-v6.0.0.md
@@ -169,6 +169,6 @@ import sgd from 'sfdx-git-delta'
 
 ### <a name="setting-log-level"></a> Setting LogLevel
 
-Previously with `sfdx/cli` LogLevel was set using the `--loglevel` parameter. It is still usable but is ignored and logs a warning message.  
+Previously with `sfdx/cli` LogLevel was set using the `--loglevel` parameter. It is deprecated, you cannot set the loglevel this way anymore.
 Now with the `salesforce/cli` LogLevel is set with the [SF_LOG_LEVEL environment variable](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/
-sfdx_dev_cli_log_messages.htm) and the parameter will soon be removed
+sfdx_dev_cli_log_messages.htm)

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -1,4 +1,4 @@
-import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
+import { Flags, SfCommand, loglevel } from '@salesforce/sf-plugins-core'
 
 import sgd from '../../../main.js'
 import type { Config } from '../../../types/config.js'
@@ -115,6 +115,7 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
       summary: messages.getMessage('flags.deprecated', ['source-dir']),
       exists: true,
     }),
+    loglevel,
   }
 
   public async run(): Promise<SgdResult> {

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -1,4 +1,4 @@
-import { Flags, SfCommand, loglevel } from '@salesforce/sf-plugins-core'
+import { Flags, SfCommand } from '@salesforce/sf-plugins-core'
 
 import sgd from '../../../main.js'
 import type { Config } from '../../../types/config.js'
@@ -115,7 +115,6 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
       summary: messages.getMessage('flags.deprecated', ['source-dir']),
       exists: true,
     }),
-    loglevel,
   }
 
   public async run(): Promise<SgdResult> {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

**Do not add** the [backward compatible](https://github.com/salesforcecli/cli/wiki/Migrate-Plugins-Built-for-sfdx#backward-compatibility) loglevel noop parameter
Explain in the migration guide how to set [loglevel](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_dev_cli_log_messages.htm?q=log) now

cf this [cli-friends discussion](https://colladonsebas-yvi8516.slack.com/archives/C02R1NEG2G3/p1736332220137169)

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #974