### PR TITLE
refactor: use native `aliases` and `deprecateAliases` sf cli feature

### DIFF
--- a/messages/delta.md
+++ b/messages/delta.md
@@ -64,10 +64,6 @@ file listing paths to explicitly include for any diff actions
 
 file listing paths to explicitly include for any destructive actions
 
-# flags.deprecated
-
-/!\ deprecated, use '--%s' instead.
-
 # error.ParameterIsNotGitSHA
 
 --%s is not a valid sha pointer: '%s' (If in CI/CD context, check the fetch depth is properly set)
@@ -83,10 +79,6 @@ API version not found or not supported, using '%s' instead
 # warning.FlowDeleted
 
 Attempt to delete the flow '%s' via destructiveChanges.xml may not work as expected (see https://github.com/scolladon/sfdx-git-delta#handle-flow-deletion)
-
-# warning.oldParameters
-
-Using the '--%s' parameter is deprecated and will soon be obsolete. Use '--%s' parameter instead.
  
 # info.CommandIsRunning
 

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -11,8 +11,6 @@ import {
   TO_DEFAULT_VALUE,
 } from '../../../utils/cliConstants.js'
 
-import { camelCase } from 'lodash-es'
-
 const messages = new MessageService()
 
 export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
@@ -41,38 +39,52 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
       summary: messages.getMessage('flags.output.summary'),
       default: OUTPUT_DEFAULT_VALUE,
       exists: true,
+      aliases: ['output'],
+      deprecateAliases: true,
     }),
     'repo-dir': Flags.directory({
       char: 'r',
       summary: messages.getMessage('flags.repo.summary'),
       default: REPO_DEFAULT_VALUE,
       exists: true,
+      aliases: ['repo'],
+      deprecateAliases: true,
     }),
     'source-dir': Flags.directory({
       char: 's',
       summary: messages.getMessage('flags.source.summary'),
       default: SOURCE_DEFAULT_VALUE,
       exists: true,
+      aliases: ['source'],
+      deprecateAliases: true,
     }),
     'ignore-file': Flags.file({
       char: 'i',
       summary: messages.getMessage('flags.ignore.summary'),
       exists: true,
+      aliases: ['ignore'],
+      deprecateAliases: true,
     }),
     'ignore-destructive-file': Flags.file({
       char: 'D',
       summary: messages.getMessage('flags.ignore-destructive.summary'),
       exists: true,
+      aliases: ['ignore-destructive'],
+      deprecateAliases: true,
     }),
     'include-file': Flags.file({
       char: 'n',
       summary: messages.getMessage('flags.include.summary'),
       exists: true,
+      aliases: ['include'],
+      deprecateAliases: true,
     }),
     'include-destructive-file': Flags.file({
       char: 'N',
       summary: messages.getMessage('flags.include-destructive.summary'),
       exists: true,
+      aliases: ['include-destructive'],
+      deprecateAliases: true,
     }),
     'ignore-whitespace': Flags.boolean({
       char: 'W',
@@ -81,39 +93,6 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
     'api-version': Flags.integer({
       char: 'a',
       summary: messages.getMessage('flags.api-version.summary'),
-    }),
-    // Deprecated flags start
-    ignore: Flags.file({
-      summary: messages.getMessage('flags.deprecated', ['ignore-file']),
-      exists: true,
-    }),
-    'ignore-destructive': Flags.file({
-      summary: messages.getMessage('flags.deprecated', [
-        'ignore-destructive-file',
-      ]),
-      exists: true,
-    }),
-    include: Flags.file({
-      summary: messages.getMessage('flags.deprecated', ['include-file']),
-      exists: true,
-    }),
-    'include-destructive': Flags.file({
-      summary: messages.getMessage('flags.deprecated', [
-        'include-destructive-file',
-      ]),
-      exists: true,
-    }),
-    output: Flags.directory({
-      summary: messages.getMessage('flags.deprecated', ['output-dir']),
-      exists: true,
-    }),
-    repo: Flags.directory({
-      summary: messages.getMessage('flags.deprecated', ['repo-dir']),
-      exists: true,
-    }),
-    source: Flags.directory({
-      summary: messages.getMessage('flags.deprecated', ['source-dir']),
-      exists: true,
     }),
   }
 
@@ -135,8 +114,6 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
       to: flags['to'],
     }
 
-    this.recoverOldParametersUsage(config, flags)
-
     this.spinner.start(
       messages.getMessage('info.CommandIsRunning'),
       undefined,
@@ -157,29 +134,5 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
     }
     this.spinner.stop(messages.getMessage('info.CommandHasRun'))
     return output
-  }
-
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  private recoverOldParametersUsage(config: Config, flags: any) {
-    for (const [oldParameter, newParameter] of Object.entries({
-      ignore: 'ignore-file',
-      'ignore-destructive': 'ignore-destructive-file',
-      include: 'include-file',
-      'include-destructive': 'include-destructive-file',
-      output: 'output-dir',
-      repo: 'repo-dir',
-      source: 'source-dir',
-    })) {
-      if (oldParameter in flags) {
-        this.warn(
-          messages.getMessage('warning.oldParameters', [
-            oldParameter,
-            newParameter,
-          ])
-        )
-        const configAttribut = camelCase(oldParameter) as never
-        config[configAttribut] = flags[oldParameter as never] as never
-      }
-    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Use `aliases` and `deprecateAliases` [backward compatible Flags attribut](https://github.com/salesforcecli/cli/wiki/Migrate-Plugins-Built-for-sfdx#backward-compatibility) to deal with our old parameters.
Remove the code we wrote to deal with that