### PR TITLE
fix: add `WorkflowFlowAction` to sub-object types

### DIFF
--- a/__tests__/integration/services.test.ts
+++ b/__tests__/integration/services.test.ts
@@ -32,6 +32,11 @@ const testContext = [
     'WorkflowAlert',
   ],
   [
+    'force-app/main/default/workflows/Account/workflowFlowActions/TestFlowAction.workflowFlowAction-meta.xml',
+    new Set(['Account.TestFlowAction']),
+    'WorkflowFlowAction',
+  ],
+  [
     'force-app/main/default/bots/TestBot/TestBot.bot-meta.xml',
     new Set(['TestBot']),
     'Bot',

--- a/src/constant/metadataConstants.ts
+++ b/src/constant/metadataConstants.ts
@@ -32,6 +32,7 @@ export const SUB_OBJECT_TYPES = [
   'WebLink',
   'WorkflowAlert',
   'WorkflowFieldUpdate',
+  'WorkflowFlowAction',
   'WorkflowKnowledgePublish',
   'WorkflowOutboundMessage',
   'WorkflowRule',

--- a/src/service/typeHandlerFactory.ts
+++ b/src/service/typeHandlerFactory.ts
@@ -69,6 +69,7 @@ const handlerMap = {
   Workflow: InFile,
   WorkflowAlert: Decomposed,
   WorkflowFieldUpdate: Decomposed,
+  WorkflowFlowAction: Decomposed,
   WorkflowKnowledgePublish: Decomposed,
   WorkflowOutboundMessage: Decomposed,
   WorkflowRule: Decomposed,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

Fixes the issues described in https://github.com/scolladon/sfdx-git-delta/issues/993, which is `WorkflowFlowAction` being generated without the parent workflow name in the incremental package.xml.

Current release (6.2.0)
``` xml
    <types>
        <members>Populate_PBA_from_Primary_CDM_User_record</members>
        <name>WorkflowFlowAction</name>
    </types>
```

When testing above fixes 
``` xml
    <types>
        <members>Account.Populate_PBA_from_Primary_CDM_User_record</members>
        <name>WorkflowFlowAction</name>
    </types>
```
# Does this close any currently open issues?

---

closes #993

- [ ] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

I can provide a WorkflowFlowAction sample in your sfdx-git-delta reproduction playground repo.

See https://github.com/scolladon/sfdx-git-delta-reproduction-playground/pull/10
