### PR TITLE
fix: parent file inclusion for Decomposed type

### DIFF
--- a/.github/workflows/on-merged-pull-request.yml
+++ b/.github/workflows/on-merged-pull-request.yml
@@ -48,7 +48,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Delete package dev channel PR comment
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
             Published under `${{ env.DEV_CHANNEL }}` npm channel.

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -80,7 +80,7 @@ jobs:
       - name: MegaLinter
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter/flavors/javascript@v7
+        uses: oxsecurity/megalinter/flavors/javascript@v8
         env:
           # All available variables are described in documentation
           # https://megalinter.io/latest/config-file/
@@ -164,7 +164,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Comment PR dev channel
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
             Published under `${{ env.DEV_CHANNEL }}` npm channel.

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run test:unit -- --runInBand
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true

--- a/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
+++ b/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
@@ -345,6 +345,26 @@ describe('MetadataRepositoryImpl', () => {
       })
     })
 
+    describe('when matching on xmlName', () => {
+      it('matches existing xmlName', () => {
+        // Act
+        const result = sut.get('AuraDefinitionBundle')
+
+        // Assert
+        expect(result).toStrictEqual(
+          expect.objectContaining({ directoryName: 'aura' })
+        )
+      })
+
+      it('does not match non existing xmlName', () => {
+        // Act
+        const result = sut.get('DoNotExist')
+
+        // Assert
+        expect(result).toBeUndefined()
+      })
+    })
+
     describe('when no match is found', () => {
       it('returns undefined', () => {
         // Act

--- a/__tests__/unit/lib/service/customFieldHandler.test.ts
+++ b/__tests__/unit/lib/service/customFieldHandler.test.ts
@@ -17,6 +17,7 @@ const objectType = {
   inFolder: false,
   metaFile: false,
   suffix: 'field',
+  parentXmlName: 'CustomObject',
   xmlName: 'CustomField',
 }
 const line =

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
       "clean": "if-file-deleted"
     },
     "clean": {
-      "command": "shx rm -rf 'reports/*' .nyc_output oclif.manifest.json package.tgz 'sfdx-git-delta-v*.tgz' 'stderr*.txt' 'stdout*.txt' '.stryker-tmp/*' perf-result.txt",
+      "command": "shx rm -rf 'reports/*' .nyc_output oclif.manifest.json package.tgz 'sfdx-git-delta-*.tgz' 'stderr*.txt' 'stdout*.txt' '.stryker-tmp/*' perf-result.txt",
       "files": [
         "lib",
         "reports/*",

--- a/src/constant/metadataConstants.ts
+++ b/src/constant/metadataConstants.ts
@@ -9,7 +9,6 @@ export const LABEL_DECOMPOSED_SUFFIX = 'label'
 export const MASTER_DETAIL_TAG = '<type>MasterDetail</type>'
 export const METAFILE_SUFFIX = '-meta.xml'
 export const META_REGEX = new RegExp(`${METAFILE_SUFFIX}$`)
-export const OBJECT_META_XML_SUFFIX = `object${METAFILE_SUFFIX}`
 export const OBJECT_TRANSLATION_META_XML_SUFFIX = `objectTranslation${METAFILE_SUFFIX}`
 export const OBJECT_TRANSLATION_TYPE = 'CustomObjectTranslation'
 export const OBJECT_TYPE = 'CustomObject'

--- a/src/metadata/MetadataRepositoryImpl.ts
+++ b/src/metadata/MetadataRepositoryImpl.ts
@@ -23,13 +23,16 @@ import { MetadataRepository } from './MetadataRepository.js'
 export class MetadataRepositoryImpl implements MetadataRepository {
   protected readonly metadataPerExt: Map<string, Metadata>
   protected readonly metadataPerDir: Map<string, Metadata>
+  protected readonly metadataPerXmlName: Map<string, Metadata>
   constructor(protected readonly metadatas: Metadata[]) {
     this.metadataPerExt = new Map<string, Metadata>()
     this.metadataPerDir = new Map<string, Metadata>()
+    this.metadataPerXmlName = new Map<string, Metadata>()
 
     this.metadatas.forEach(metadata => {
       this.addSuffix(metadata)
       this.addFolder(metadata)
+      this.addXmlName(metadata)
     })
   }
 
@@ -62,6 +65,12 @@ export class MetadataRepositoryImpl implements MetadataRepository {
   protected addFolder(metadata: Metadata) {
     if (metadata.directoryName) {
       this.metadataPerDir.set(metadata.directoryName, metadata)
+    }
+  }
+
+  protected addXmlName(metadata: Metadata) {
+    if (metadata.xmlName) {
+      this.metadataPerDir.set(metadata.xmlName, metadata)
     }
   }
 
@@ -98,6 +107,10 @@ export class MetadataRepositoryImpl implements MetadataRepository {
       }
     }
     return metadata
+  }
+
+  protected searchByXmlName(xmlName: string): Metadata | undefined {
+    return this.metadataPerXmlName.get(xmlName)
   }
 
   public getFullyQualifiedName(path: string): string {

--- a/src/metadata/MetadataRepositoryImpl.ts
+++ b/src/metadata/MetadataRepositoryImpl.ts
@@ -70,7 +70,7 @@ export class MetadataRepositoryImpl implements MetadataRepository {
 
   protected addXmlName(metadata: Metadata) {
     if (metadata.xmlName) {
-      this.metadataPerDir.set(metadata.xmlName, metadata)
+      this.metadataPerXmlName.set(metadata.xmlName, metadata)
     }
   }
 
@@ -80,8 +80,11 @@ export class MetadataRepositoryImpl implements MetadataRepository {
 
   public get(path: string): Metadata | undefined {
     const parts = path.split(PATH_SEP)
-    const metadata = this.searchByExtension(parts)
-    return metadata ?? this.searchByDirectory(parts)
+    return (
+      this.searchByExtension(parts) ??
+      this.searchByDirectory(parts) ??
+      this.searchByXmlName(path)
+    )
   }
 
   protected searchByExtension(parts: string[]): Metadata | undefined {

--- a/src/metadata/v46.ts
+++ b/src/metadata/v46.ts
@@ -160,16 +160,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -182,6 +182,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -189,6 +190,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -196,6 +198,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -203,6 +206,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -210,6 +214,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -217,6 +222,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -224,6 +230,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -231,6 +238,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -238,6 +246,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -245,6 +254,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v47.ts
+++ b/src/metadata/v47.ts
@@ -181,16 +181,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -203,6 +203,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -210,6 +211,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -217,6 +219,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -224,6 +227,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -231,6 +235,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -238,6 +243,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -245,6 +251,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -252,6 +259,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -259,6 +267,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -266,6 +275,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v48.ts
+++ b/src/metadata/v48.ts
@@ -160,16 +160,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -182,6 +182,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -189,6 +190,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -196,6 +198,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -203,6 +206,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -210,6 +214,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -217,6 +222,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -224,6 +230,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -231,6 +238,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -238,6 +246,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -245,6 +254,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v49.ts
+++ b/src/metadata/v49.ts
@@ -195,16 +195,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -217,6 +217,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -224,6 +225,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -231,6 +233,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -238,6 +241,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -245,6 +249,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -252,6 +257,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -259,6 +265,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -266,6 +273,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -273,6 +281,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -280,6 +289,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v50.ts
+++ b/src/metadata/v50.ts
@@ -230,16 +230,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -252,6 +252,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -259,6 +260,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -266,6 +268,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -273,6 +276,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -280,6 +284,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -287,6 +292,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -294,6 +300,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -301,6 +308,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -308,6 +316,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -315,6 +324,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v51.ts
+++ b/src/metadata/v51.ts
@@ -293,16 +293,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -315,6 +315,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -322,6 +323,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -329,6 +331,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -336,6 +339,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -343,6 +347,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -350,6 +355,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -357,6 +363,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -364,6 +371,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -371,6 +379,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -378,6 +387,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v52.ts
+++ b/src/metadata/v52.ts
@@ -293,16 +293,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -315,6 +315,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -322,6 +323,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -329,6 +331,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -336,6 +339,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -343,6 +347,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -350,6 +355,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -357,6 +363,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -364,6 +371,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -371,6 +379,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -378,6 +387,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v53.ts
+++ b/src/metadata/v53.ts
@@ -293,16 +293,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -315,6 +315,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -322,6 +323,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -329,6 +331,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -336,6 +339,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -343,6 +347,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -350,6 +355,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -357,6 +363,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -364,6 +371,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -371,6 +379,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -378,6 +387,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v54.ts
+++ b/src/metadata/v54.ts
@@ -328,16 +328,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -350,6 +350,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -357,6 +358,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -364,6 +366,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -371,6 +374,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -378,6 +382,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -385,6 +390,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -392,6 +398,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -399,6 +406,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -406,6 +414,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -413,6 +422,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v55.ts
+++ b/src/metadata/v55.ts
@@ -426,16 +426,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -448,6 +448,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -455,6 +456,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -462,6 +464,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -469,6 +472,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -476,6 +480,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -483,6 +488,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -490,6 +496,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -497,6 +504,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -504,6 +512,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -511,6 +520,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v56.ts
+++ b/src/metadata/v56.ts
@@ -447,16 +447,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -469,6 +469,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -476,6 +477,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -483,6 +485,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -490,6 +493,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -497,6 +501,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -504,6 +509,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -511,6 +517,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -518,6 +525,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -525,6 +533,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -532,6 +541,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v57.ts
+++ b/src/metadata/v57.ts
@@ -503,16 +503,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -525,6 +525,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -532,6 +533,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -539,6 +541,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -546,6 +549,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -553,6 +557,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -560,6 +565,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -567,6 +573,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -574,6 +581,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -581,6 +589,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -588,6 +597,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v58.ts
+++ b/src/metadata/v58.ts
@@ -510,16 +510,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -532,6 +532,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -539,6 +540,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -546,6 +548,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -553,6 +556,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -560,6 +564,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -567,6 +572,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -574,6 +580,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -581,6 +588,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -588,6 +596,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -595,6 +604,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v59.ts
+++ b/src/metadata/v59.ts
@@ -580,16 +580,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -602,6 +602,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -609,6 +610,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -616,6 +618,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -623,6 +626,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -630,6 +634,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -637,6 +642,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -644,6 +650,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -651,6 +658,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -658,6 +666,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -665,6 +674,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v60.ts
+++ b/src/metadata/v60.ts
@@ -629,16 +629,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -651,6 +651,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -658,6 +659,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -665,6 +667,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -672,6 +675,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -679,6 +683,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -686,6 +691,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -693,6 +699,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -700,6 +707,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -707,6 +715,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -714,6 +723,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v61.ts
+++ b/src/metadata/v61.ts
@@ -636,16 +636,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -658,6 +658,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -665,6 +666,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -672,6 +674,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -679,6 +682,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -686,6 +690,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -693,6 +698,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -700,6 +706,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -707,6 +714,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -714,6 +722,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -721,6 +730,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v62.ts
+++ b/src/metadata/v62.ts
@@ -643,16 +643,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -665,6 +665,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -672,6 +673,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -679,6 +681,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -686,6 +689,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -693,6 +697,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -700,6 +705,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -707,6 +713,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -714,6 +721,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -721,6 +729,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -728,6 +737,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/metadata/v63.ts
+++ b/src/metadata/v63.ts
@@ -643,16 +643,16 @@ export default [
   },
   {
     childXmlNames: [
-      'CustomField',
-      'Index',
       'BusinessProcess',
-      'RecordType',
       'CompactLayout',
-      'WebLink',
-      'ValidationRule',
-      'SharingReason',
-      'ListView',
+      'CustomField',
       'FieldSet',
+      'Index',
+      'ListView',
+      'RecordType',
+      'SharingReason',
+      'ValidationRule',
+      'WebLink',
     ],
     directoryName: 'objects',
     inFolder: false,
@@ -665,6 +665,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'businessProcess',
+    parentXmlName: 'CustomObject',
     xmlName: 'BusinessProcess',
   },
   {
@@ -672,6 +673,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'compactLayout',
+    parentXmlName: 'CustomObject',
     xmlName: 'CompactLayout',
   },
   {
@@ -679,6 +681,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'field',
+    parentXmlName: 'CustomObject',
     xmlName: 'CustomField',
   },
   {
@@ -686,6 +689,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'fieldSet',
+    parentXmlName: 'CustomObject',
     xmlName: 'FieldSet',
   },
   {
@@ -693,6 +697,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'index',
+    parentXmlName: 'CustomObject',
     xmlName: 'Index',
   },
   {
@@ -700,6 +705,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'listView',
+    parentXmlName: 'CustomObject',
     xmlName: 'ListView',
   },
   {
@@ -707,6 +713,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'recordType',
+    parentXmlName: 'CustomObject',
     xmlName: 'RecordType',
   },
   {
@@ -714,6 +721,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'sharingReason',
+    parentXmlName: 'CustomObject',
     xmlName: 'SharingReason',
   },
   {
@@ -721,6 +729,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'validationRule',
+    parentXmlName: 'CustomObject',
     xmlName: 'ValidationRule',
   },
   {
@@ -728,6 +737,7 @@ export default [
     inFolder: false,
     metaFile: false,
     suffix: 'webLink',
+    parentXmlName: 'CustomObject',
     xmlName: 'WebLink',
   },
   {

--- a/src/service/customFieldHandler.ts
+++ b/src/service/customFieldHandler.ts
@@ -1,43 +1,18 @@
 'use strict'
-import { join } from 'node:path/posix'
-
-import { PATH_SEP } from '../constant/fsConstants.js'
-import {
-  MASTER_DETAIL_TAG,
-  OBJECT_META_XML_SUFFIX,
-} from '../constant/metadataConstants.js'
+import { MASTER_DETAIL_TAG } from '../constant/metadataConstants.js'
 import { readPathFromGit } from '../utils/fsHelper.js'
 
 import DecomposedHandler from './decomposedHandler.js'
 
 export default class CustomFieldHandler extends DecomposedHandler {
-  public override async handleAddition() {
-    await super.handleAddition()
-    if (!this.config.generateDelta) return
-    await this._copyParentObject()
-  }
-
   // QUESTION: Why we need to add parent object for Master Detail field ? https://help.salesforce.com/s/articleView?id=000386883&type=1
-  protected async _copyParentObject() {
+  protected override async _copyParent() {
     const data = await readPathFromGit(
       { path: this.line, oid: this.config.to },
       this.config
     )
     if (!data.includes(MASTER_DETAIL_TAG)) return
 
-    const customObjectDirPath = this.splittedLine
-      .slice(0, this.splittedLine.indexOf(this.metadataDef.directoryName))
-      .join(PATH_SEP)
-    const customObjectName =
-      this.splittedLine[
-        this.splittedLine.indexOf(this.metadataDef.directoryName) - 1
-      ]
-
-    const customObjectPath = join(
-      customObjectDirPath,
-      `${customObjectName}.${OBJECT_META_XML_SUFFIX}`
-    )
-
-    await this._copyWithMetaFile(customObjectPath)
+    await super._copyParent()
   }
 }

--- a/src/service/decomposedHandler.ts
+++ b/src/service/decomposedHandler.ts
@@ -18,7 +18,9 @@ export default class DecomposedHandler extends StandardHandler {
       .join(PATH_SEP)
     const parentTypeName = this.getParentName()
 
-    const parentTypeSuffix = this.metadata.get(parentTypeName)?.suffix
+    const parentTypeSuffix = this.metadata.get(
+      this.metadataDef.parentXmlName!
+    )!.suffix
 
     const parentPath = join(
       parentDirPath,

--- a/src/service/decomposedHandler.ts
+++ b/src/service/decomposedHandler.ts
@@ -1,13 +1,42 @@
 'use strict'
+import { join } from 'node:path/posix'
+
+import { PATH_SEP } from '../constant/fsConstants.js'
+import { METAFILE_SUFFIX } from '../constant/metadataConstants.js'
 import StandardHandler from './standardHandler.js'
 
 export default class DecomposedHandler extends StandardHandler {
+  public override async handleAddition() {
+    await super.handleAddition()
+    if (!this.config.generateDelta) return
+    await this._copyParent()
+  }
+
+  protected async _copyParent() {
+    const parentDirPath = this.splittedLine
+      .slice(0, this.splittedLine.indexOf(this.metadataDef.directoryName))
+      .join(PATH_SEP)
+    const parentTypeName = this.getParentName()
+
+    const parentTypeSuffix = this.metadata.get(parentTypeName)?.suffix
+
+    const parentPath = join(
+      parentDirPath,
+      `${parentTypeName}.${parentTypeSuffix}${METAFILE_SUFFIX}`
+    )
+
+    await this._copyWithMetaFile(parentPath)
+  }
+
   protected override _getElementName() {
-    const prefix =
-      this.splittedLine[
-        this.splittedLine.indexOf(this.metadataDef.directoryName) - 1
-      ]
+    const parentTypeSuffix = this.getParentName()
     const elementName = super._getElementName()
-    return `${prefix}.${elementName}`
+    return `${parentTypeSuffix}.${elementName}`
+  }
+
+  protected getParentName() {
+    return this.splittedLine[
+      this.splittedLine.indexOf(this.metadataDef.directoryName) - 1
+    ]
   }
 }

--- a/src/types/metadata.ts
+++ b/src/types/metadata.ts
@@ -10,6 +10,7 @@ export type SharedFolderMetadata = BaseMetadata & {
 }
 
 export type SharedFileMetadata = BaseMetadata & {
+  parentXmlName?: string
   xmlTag?: string
   key?: string
   excluded?: boolean

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -2,7 +2,7 @@ const config = {
   coverageAnalysis: 'perTest',
   ignorePatterns: ['lib/', 'reports/', 'bin/', 'e2e/'],
   mutate: ['src/**/*.ts', '!src/metadata/v*.ts'],
-  reporters: ['html', 'clear-text', 'progress'],
+  reporters: ['html', 'progress'],
   testRunner: 'jest',
 }
 export default config


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Now the code ensure the parent type file is included in the output folder
It just copy the parent file but do not include the parent type in the `package.xml`

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #1000

- [x] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

