### PR TITLE
feat: implementation of the ContainedDecomposed type

### DIFF
--- a/__tests__/unit/lib/service/containedDecomposedHandler.test.ts
+++ b/__tests__/unit/lib/service/containedDecomposedHandler.test.ts
@@ -1,0 +1,195 @@
+'use strict'
+import { describe, expect, it, jest } from '@jest/globals'
+
+import { MetadataRepository } from '../../../../src/metadata/MetadataRepository'
+import ContainedDecomposedHandler from '../../../../src/service/containedDecomposedHandler'
+import type { Work } from '../../../../src/types/work'
+import { copyFiles, readDir } from '../../../../src/utils/fsHelper'
+import { getGlobalMetadata, getWork } from '../../../__utils__/globalTestHelper'
+
+jest.mock('../../../../src/utils/fsHelper')
+
+const mockedReadDir = jest.mocked(readDir)
+
+let globalMetadata: MetadataRepository
+beforeAll(async () => {
+  globalMetadata = await getGlobalMetadata()
+})
+
+let work: Work
+beforeEach(() => {
+  jest.clearAllMocks()
+  work = getWork()
+  work.config.generateDelta = true
+})
+
+describe('ContainedDecomposedHandler', () => {
+  describe.each(['permissionsets', 'other', 'permissionsets/subFolder'])(
+    'when it is not decomposed',
+    folder => {
+      let line: string
+      beforeEach(() => {
+        line = `force-app/main/${folder}/Subject.permissionset-meta.xml`
+      })
+
+      it('should add addition to the package.xml', async () => {
+        // Arrange
+        const sut = new ContainedDecomposedHandler(
+          `A       ${line}`,
+          globalMetadata.get('permissionsets')!,
+          work,
+          globalMetadata
+        )
+        // Act
+        await sut.handle()
+
+        // Assert
+        expect(work.diffs.package.get('PermissionSet')).toContain('Subject')
+        expect(work.diffs.destructiveChanges.has('PermissionSet')).toBe(false)
+        expect(copyFiles).toBeCalledTimes(1)
+      })
+
+      it('should add modification to the package.xml', async () => {
+        // Arrange
+        const sut = new ContainedDecomposedHandler(
+          `M       ${line}`,
+          globalMetadata.get('permissionsets')!,
+          work,
+          globalMetadata
+        )
+        // Act
+        await sut.handle()
+
+        // Assert
+        expect(work.diffs.package.get('PermissionSet')).toContain('Subject')
+        expect(work.diffs.destructiveChanges.has('PermissionSet')).toBe(false)
+        expect(copyFiles).toBeCalledTimes(1)
+      })
+
+      it('should add deletion to the package.xml', async () => {
+        // Arrange
+        const sut = new ContainedDecomposedHandler(
+          `D       ${line}`,
+          globalMetadata.get('permissionsets')!,
+          work,
+          globalMetadata
+        )
+        // Act
+        await sut.handle()
+
+        // Assert
+        expect(work.diffs.package.has('PermissionSet')).toBe(false)
+        expect(work.diffs.destructiveChanges.get('PermissionSet')).toContain(
+          'Subject'
+        )
+        expect(copyFiles).not.toBeCalled()
+      })
+    }
+  )
+  describe('when it is decomposed', () => {
+    it('should copy all decomposed files when adding a file', async () => {
+      // Arrange
+      const decomposedLine =
+        'force-app/main/default/permissionsets/Admin/objectPermissions/Account.objectPermissions-meta.xml'
+      const existingFiles = [
+        'force-app/main/default/permissionsets/Admin/Admin.permissionset-meta.xml',
+        'force-app/main/default/permissionsets/Admin/objectPermissions/Account.objectPermissions-meta.xml',
+        'force-app/main/default/permissionsets/Admin/fieldPermissions/Account.Name.fieldPermissions-meta.xml',
+      ]
+      mockedReadDir.mockResolvedValue(existingFiles)
+
+      const sut = new ContainedDecomposedHandler(
+        `A       ${decomposedLine}`,
+        globalMetadata.get('permissionsets')!,
+        work,
+        globalMetadata
+      )
+
+      // Act
+      await sut.handle()
+
+      // Assert
+      expect(work.diffs.package.get('PermissionSet')).toContain('Admin')
+      expect(work.diffs.destructiveChanges.has('PermissionSet')).toBe(false)
+      expect(copyFiles).toBeCalledTimes(2)
+    })
+
+    it('should copy all decomposed files when modifying a file', async () => {
+      // Arrange
+      const decomposedLine =
+        'force-app/main/default/permissionsets/Admin/objectPermissions/Account.objectPermissions-meta.xml'
+      const existingFiles = [
+        'force-app/main/default/permissionsets/Admin/Admin.permissionset-meta.xml',
+        'force-app/main/default/permissionsets/Admin/objectPermissions/Account.objectPermissions-meta.xml',
+        'force-app/main/default/permissionsets/Admin/fieldPermissions/Account.Name.fieldPermissions-meta.xml',
+      ]
+      mockedReadDir.mockResolvedValue(existingFiles)
+
+      const sut = new ContainedDecomposedHandler(
+        `M       ${decomposedLine}`,
+        globalMetadata.get('permissionsets')!,
+        work,
+        globalMetadata
+      )
+
+      // Act
+      await sut.handle()
+
+      // Assert
+      expect(work.diffs.package.get('PermissionSet')).toContain('Admin')
+      expect(work.diffs.destructiveChanges.has('PermissionSet')).toBe(false)
+      expect(copyFiles).toBeCalledTimes(2)
+    })
+
+    it('should handle deletion with remaining files as modification', async () => {
+      // Arrange
+      const decomposedLine =
+        'force-app/main/default/permissionsets/Admin/objectPermissions/Account.objectPermissions-meta.xml'
+      const existingFiles = [
+        'force-app/main/default/permissionsets/Admin/Admin.permissionset-meta.xml',
+        'force-app/main/default/permissionsets/Admin/objectPermissions/Account.objectPermissions-meta.xml',
+        'force-app/main/default/permissionsets/Admin/fieldPermissions/Account.Name.fieldPermissions-meta.xml',
+      ]
+      mockedReadDir.mockResolvedValue(existingFiles)
+
+      const sut = new ContainedDecomposedHandler(
+        `D       ${decomposedLine}`,
+        globalMetadata.get('permissionsets')!,
+        work,
+        globalMetadata
+      )
+
+      // Act
+      await sut.handle()
+
+      // Assert
+      expect(work.diffs.package.get('PermissionSet')).toContain('Admin')
+      expect(work.diffs.destructiveChanges.has('PermissionSet')).toBe(false)
+      expect(copyFiles).toBeCalledTimes(2)
+    })
+
+    it('should handle deletion with no remaining files as destructive change', async () => {
+      // Arrange
+      const decomposedLine =
+        'force-app/main/default/permissionsets/Admin/objectPermissions/Account.objectPermissions-meta.xml'
+      mockedReadDir.mockResolvedValue([])
+
+      const sut = new ContainedDecomposedHandler(
+        `D       ${decomposedLine}`,
+        globalMetadata.get('permissionsets')!,
+        work,
+        globalMetadata
+      )
+
+      // Act
+      await sut.handle()
+
+      // Assert
+      expect(work.diffs.package.has('PermissionSet')).toBe(false)
+      expect(work.diffs.destructiveChanges.get('PermissionSet')).toContain(
+        'Admin'
+      )
+      expect(copyFiles).not.toBeCalled()
+    })
+  })
+})

--- a/__tests__/unit/lib/service/inResourceHandler.test.ts
+++ b/__tests__/unit/lib/service/inResourceHandler.test.ts
@@ -27,13 +27,6 @@ const experienceBundleType = {
   suffix: 'site',
   xmlName: 'ExperienceBundle',
 }
-const permissionSetType = {
-  directoryName: 'permissionsets',
-  inFolder: false,
-  metaFile: false,
-  suffix: 'permissionset',
-  xmlName: 'PermissionSet',
-}
 const element = 'myResources'
 const basePath = 'force-app/main/default/staticresources'
 const entityPath = `${basePath}/${element}.js`
@@ -88,12 +81,6 @@ describe('InResourceHandler', () => {
             experienceBundleType,
             'my_experience_bundle',
             5,
-          ],
-          [
-            'CustomerSupport/permissionSetFieldPermissions/Account.Test__c.permissionSetFieldPermission-meta.xml',
-            permissionSetType,
-            'CustomerSupport',
-            2,
           ],
         ])(
           'should copy the matching folder resource, matching meta file and subject file %s',
@@ -185,33 +172,6 @@ describe('InResourceHandler', () => {
             `${basePath}/${element}.${type}${METAFILE_SUFFIX}`
           )
         })
-      })
-    })
-
-    describe('when outside its folder', () => {
-      it('should match via the extension', async () => {
-        // Arrange
-        const metadataElement = `MarketingUser`
-        const path = `force-app/main/default/wrongFolder/${metadataElement}.permissionset-meta.xml`
-        const line = `A  ${path}`
-
-        const sut = new InResourceHandler(
-          line,
-          permissionSetType,
-          work,
-          globalMetadata
-        )
-        mockedReadDir.mockResolvedValueOnce([])
-
-        // Act
-        await sut.handle()
-
-        // Assert
-        expect(
-          Array.from(work.diffs.package.get(permissionSetType.xmlName)!)
-        ).toEqual([metadataElement])
-        expect(copyFiles).toBeCalledTimes(2)
-        expect(copyFiles).toHaveBeenCalledWith(work.config, path)
       })
     })
   })

--- a/__tests__/unit/lib/service/typeHandlerFactory.test.ts
+++ b/__tests__/unit/lib/service/typeHandlerFactory.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from '@jest/globals'
 
 import { MetadataRepository } from '../../../../src/metadata/MetadataRepository'
+import ContainedDecomposedHandler from '../../../../src/service/containedDecomposedHandler'
 import CustomField from '../../../../src/service/customFieldHandler'
 import Decomposed from '../../../../src/service/decomposedHandler'
 import FlowHandler from '../../../../src/service/flowHandler'
@@ -23,6 +24,7 @@ describe('the type handler factory', () => {
   })
   describe.each([
     [CustomField, ['fields']],
+    [ContainedDecomposedHandler, ['permissionsets']],
     [
       Decomposed,
       [
@@ -38,7 +40,7 @@ describe('the type handler factory', () => {
       ],
     ],
     [InFolder, ['dashboards', 'documents', 'reports']],
-    [InResource, ['staticresources', 'aura', 'lwc', 'permissionsets']],
+    [InResource, ['staticresources', 'aura', 'lwc']],
     [Standard, ['classes']],
     [SharedFolder, ['moderation', 'wave', 'discovery']],
   ])('give %p handler', (handler, types) => {

--- a/src/adapter/GitAdapter.ts
+++ b/src/adapter/GitAdapter.ts
@@ -71,7 +71,7 @@ export default class GitAdapter {
 
   public async pathExists(path: string) {
     if (this.pathExistsCache.has(path)) {
-      return this.pathExistsCache.get(path)
+      return this.pathExistsCache.get(path)!
     }
     const doesPathExists = await this.pathExistsImpl(path)
     this.pathExistsCache.set(path, doesPathExists)

--- a/src/service/containedDecomposedHandler.ts
+++ b/src/service/containedDecomposedHandler.ts
@@ -1,0 +1,140 @@
+'use strict'
+import { join } from 'node:path'
+import { DOT, PATH_SEP } from '../constant/fsConstants.js'
+import { METAFILE_SUFFIX } from '../constant/metadataConstants.js'
+import StandardHandler from './standardHandler.js'
+
+import { pathExists, readDir } from '../utils/fsHelper.js'
+
+export default class ContainedDecomposedHandler extends StandardHandler {
+  // This type can be either in its directoryName folder or not, into a single file
+  // Ex : 'force-app/main/permissionsets/MyCustomPSet.permissionset-meta.xml
+  // Ex : 'force-app/main/notpermissionsetfolder/MyCustomPSet.permissionset-meta.xml
+  // If the file is added or modified then it is an addition and the element must be added in the package.xml
+  // If the file is deleted it is a deletion
+  // In this case it works like the standardhandler
+  //
+  // Or it can be contained into a folder with its content splitted into multiple files (here https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_decomposed_md_types.htm#permset)
+  // Ex : 'force-app/main/permissionsets/MyCustomPSet/MyCustomPSet.permissionset-meta.xml
+  // Ex : 'force-app/main/permissionsets/MyCustomPSet/MyCustomPSet.userPermissions-meta.xml
+  // Ex : 'force-app/main/permissionsets/MyCustomPSet/objectSettings/Account.objectSettings-meta.xml
+  // If any file is added or modified then it is an addition, every file should be copied and the parent element should be added in the package.xml
+  // If a file is deleted but sub file remain then it is an addition, every file should be copied and the parent element should be added in the package.xml
+  // If a file is deleted and the containing folder is deleted as well then it is a deletion and the element should be added in the destructiveChanges.xml
+
+  protected metadataName: string | undefined
+
+  public override async handleAddition() {
+    this.metadataName = await this._getMetadataName()
+    await super.handleAddition()
+    if (!this.config.generateDelta) return
+
+    // For decomposed format, copy all related files
+    if (await this._isDecomposedFormat()) {
+      await this._copyDecomposedFiles()
+    }
+  }
+
+  public override async handleDeletion() {
+    this.metadataName = await this._getMetadataName()
+
+    // Check if any related files/folders still exist
+    const hasRelatedContent = await this._hasRelatedContent()
+
+    if (hasRelatedContent) {
+      // If there are still related files, treat as modification
+      await this.handleModification()
+    } else {
+      await super.handleDeletion()
+    }
+  }
+
+  protected async _getMetadataName() {
+    const elementName = this.parsedLine.name
+      .replace(METAFILE_SUFFIX, '')
+      .split(DOT)[0]
+
+    // Start from the current directory and check parent folders
+    for (let i = this.splittedLine.length - 1; i >= 0; i--) {
+      // Exit if we've gone past the directoryName
+      if (this.splittedLine[i] === this.metadataDef.directoryName) {
+        break
+      }
+
+      const currentPath = this.splittedLine.slice(0, i).join(PATH_SEP)
+
+      // Check for direct metadata file
+      const metadataFile = `${elementName}.${this.metadataDef.suffix}${METAFILE_SUFFIX}`
+      const metadataPath = join(currentPath, metadataFile)
+
+      if (await pathExists(metadataPath, this.config)) {
+        return join(currentPath, elementName)
+      }
+
+      // Check for decomposed format folder
+      const folderPath = join(currentPath, elementName)
+      if (await pathExists(folderPath, this.config)) {
+        const files = await readDir(folderPath, this.config)
+        const hasMetadataFile = files.some(file =>
+          file.endsWith(`${this.metadataDef.suffix}${METAFILE_SUFFIX}`)
+        )
+
+        if (hasMetadataFile) {
+          return join(folderPath, elementName)
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  protected async _isDecomposedFormat(): Promise<boolean> {
+    if (!this.metadataName) return false
+
+    const folderPath = this.metadataName.substring(
+      0,
+      this.metadataName.lastIndexOf(PATH_SEP)
+    )
+    return await pathExists(folderPath, this.config)
+  }
+
+  protected async _hasRelatedContent(): Promise<boolean> {
+    if (!this.metadataName) {
+      return false
+    }
+
+    const folderPath = this.metadataName.substring(
+      0,
+      this.metadataName.lastIndexOf(PATH_SEP)
+    )
+
+    try {
+      // Check if the folder exists and has any content
+      const files = await readDir(folderPath, this.config)
+      return files.length > 0
+    } catch {
+      // If folder doesn't exist or can't be read, check for single file
+      const metadataFile = `${this.metadataName}.${this.metadataDef.suffix}${METAFILE_SUFFIX}`
+      return await pathExists(metadataFile, this.config)
+    }
+  }
+
+  protected async _copyDecomposedFiles() {
+    if (!this.metadataName) return
+
+    const folderPath = this.metadataName.substring(
+      0,
+      this.metadataName.lastIndexOf(PATH_SEP)
+    )
+
+    try {
+      // Copy all files in the folder and subfolders
+      const files = await readDir(folderPath, this.work.config)
+      for (const file of files) {
+        await this._copy(file)
+      }
+    } catch (error) {
+      console.error(`Error copying decomposed files: ${error}`)
+    }
+  }
+}

--- a/src/service/containedDecomposedHandler.ts
+++ b/src/service/containedDecomposedHandler.ts
@@ -1,140 +1,88 @@
 'use strict'
-import { join } from 'node:path'
-import { DOT, PATH_SEP } from '../constant/fsConstants.js'
+import { ParsedPath, join, parse } from 'node:path/posix'
+import { PATH_SEP } from '../constant/fsConstants.js'
 import { METAFILE_SUFFIX } from '../constant/metadataConstants.js'
+import { readDir } from '../utils/fsHelper.js'
 import StandardHandler from './standardHandler.js'
 
-import { pathExists, readDir } from '../utils/fsHelper.js'
-
 export default class ContainedDecomposedHandler extends StandardHandler {
-  // This type can be either in its directoryName folder or not, into a single file
-  // Ex : 'force-app/main/permissionsets/MyCustomPSet.permissionset-meta.xml
-  // Ex : 'force-app/main/notpermissionsetfolder/MyCustomPSet.permissionset-meta.xml
-  // If the file is added or modified then it is an addition and the element must be added in the package.xml
-  // If the file is deleted it is a deletion
-  // In this case it works like the standardhandler
-  //
-  // Or it can be contained into a folder with its content splitted into multiple files (here https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_decomposed_md_types.htm#permset)
-  // Ex : 'force-app/main/permissionsets/MyCustomPSet/MyCustomPSet.permissionset-meta.xml
-  // Ex : 'force-app/main/permissionsets/MyCustomPSet/MyCustomPSet.userPermissions-meta.xml
-  // Ex : 'force-app/main/permissionsets/MyCustomPSet/objectSettings/Account.objectSettings-meta.xml
-  // If any file is added or modified then it is an addition, every file should be copied and the parent element should be added in the package.xml
-  // If a file is deleted but sub file remain then it is an addition, every file should be copied and the parent element should be added in the package.xml
-  // If a file is deleted and the containing folder is deleted as well then it is a deletion and the element should be added in the destructiveChanges.xml
-
-  protected metadataName: string | undefined
+  protected holderFolder: ParsedPath | undefined
 
   public override async handleAddition() {
-    this.metadataName = await this._getMetadataName()
+    await this._setholderFolder()
     await super.handleAddition()
     if (!this.config.generateDelta) return
 
     // For decomposed format, copy all related files
-    if (await this._isDecomposedFormat()) {
+    if (this._isDecomposedFormat()) {
       await this._copyDecomposedFiles()
     }
   }
 
   public override async handleDeletion() {
-    this.metadataName = await this._getMetadataName()
+    await this._setholderFolder()
+    if (this._isDecomposedFormat()) {
+      // Check if any related files/folders still exist
+      const hasRelatedContent = await this._hasRelatedContent()
 
-    // Check if any related files/folders still exist
-    const hasRelatedContent = await this._hasRelatedContent()
-
-    if (hasRelatedContent) {
-      // If there are still related files, treat as modification
-      await this.handleModification()
+      if (hasRelatedContent) {
+        // If there are still related files, treat as modification
+        await this.handleModification()
+      } else {
+        await super.handleDeletion()
+      }
     } else {
       await super.handleDeletion()
     }
   }
 
-  protected async _getMetadataName() {
-    const elementName = this.parsedLine.name
-      .replace(METAFILE_SUFFIX, '')
-      .split(DOT)[0]
-
-    // Start from the current directory and check parent folders
-    for (let i = this.splittedLine.length - 1; i >= 0; i--) {
-      // Exit if we've gone past the directoryName
-      if (this.splittedLine[i] === this.metadataDef.directoryName) {
-        break
-      }
-
-      const currentPath = this.splittedLine.slice(0, i).join(PATH_SEP)
-
-      // Check for direct metadata file
-      const metadataFile = `${elementName}.${this.metadataDef.suffix}${METAFILE_SUFFIX}`
-      const metadataPath = join(currentPath, metadataFile)
-
-      if (await pathExists(metadataPath, this.config)) {
-        return join(currentPath, elementName)
-      }
-
-      // Check for decomposed format folder
-      const folderPath = join(currentPath, elementName)
-      if (await pathExists(folderPath, this.config)) {
-        const files = await readDir(folderPath, this.config)
-        const hasMetadataFile = files.some(file =>
-          file.endsWith(`${this.metadataDef.suffix}${METAFILE_SUFFIX}`)
-        )
-
-        if (hasMetadataFile) {
-          return join(folderPath, elementName)
-        }
-      }
+  protected _setholderFolder() {
+    if (this.holderFolder) {
+      return
     }
 
-    return undefined
+    if (!this._isDecomposedFormat()) {
+      this.holderFolder = parse(
+        this.line
+          .replace(METAFILE_SUFFIX, '')
+          .replace(`.${this.metadataDef.suffix}`, '')
+      )
+      return
+    }
+    // Get the parent folder name from the path
+    const parentFolderName = this.splittedLine.at(-2)
+
+    // If parent folder is objectSettings, use the grandparent folder name
+    // Otherwise use the parent folder name
+    const index = parentFolderName === 'objectSettings' ? -3 : -2
+
+    this.holderFolder = parse(this.splittedLine.slice(0, index).join(PATH_SEP))
   }
 
-  protected async _isDecomposedFormat(): Promise<boolean> {
-    if (!this.metadataName) return false
-
-    const folderPath = this.metadataName.substring(
-      0,
-      this.metadataName.lastIndexOf(PATH_SEP)
+  protected _isDecomposedFormat() {
+    return (
+      !this.parsedLine.base.includes(`.${this.metadataDef.suffix}`) ||
+      this.parsedLine.dir.split(PATH_SEP).pop() === this.parsedLine.name
     )
-    return await pathExists(folderPath, this.config)
   }
 
   protected async _hasRelatedContent(): Promise<boolean> {
-    if (!this.metadataName) {
-      return false
-    }
-
-    const folderPath = this.metadataName.substring(
-      0,
-      this.metadataName.lastIndexOf(PATH_SEP)
+    const files = await readDir(
+      join(this.holderFolder!.dir, this.holderFolder!.base),
+      this.config
     )
-
-    try {
-      // Check if the folder exists and has any content
-      const files = await readDir(folderPath, this.config)
-      return files.length > 0
-    } catch {
-      // If folder doesn't exist or can't be read, check for single file
-      const metadataFile = `${this.metadataName}.${this.metadataDef.suffix}${METAFILE_SUFFIX}`
-      return await pathExists(metadataFile, this.config)
-    }
+    return files.length > 0
   }
 
   protected async _copyDecomposedFiles() {
-    if (!this.metadataName) return
+    await this._copy(join(this.holderFolder!.dir, this.holderFolder!.base))
+  }
 
-    const folderPath = this.metadataName.substring(
-      0,
-      this.metadataName.lastIndexOf(PATH_SEP)
-    )
+  protected override _getElementName() {
+    return this.holderFolder!.base
+  }
 
-    try {
-      // Copy all files in the folder and subfolders
-      const files = await readDir(folderPath, this.work.config)
-      for (const file of files) {
-        await this._copy(file)
-      }
-    } catch (error) {
-      console.error(`Error copying decomposed files: ${error}`)
-    }
+  protected override _isProcessable() {
+    return true
   }
 }

--- a/src/service/typeHandlerFactory.ts
+++ b/src/service/typeHandlerFactory.ts
@@ -4,6 +4,7 @@ import { Metadata } from '../types/metadata.js'
 import type { Work } from '../types/work.js'
 
 import Bot from './botHandler.js'
+import ContainedDecomposed from './containedDecomposedHandler.js'
 import CustomFieldHandler from './customFieldHandler.js'
 import CustomLabel from './customLabelHandler.js'
 import CustomObject from './customObjectHandler.js'
@@ -44,7 +45,7 @@ const handlerMap = {
   ListView: Decomposed,
   MarketingAppExtension: InFile,
   MatchingRules: InFile,
-  PermissionSet: InResource,
+  PermissionSet: ContainedDecomposed,
   Profile: InFile,
   RecordType: Decomposed,
   Report: InFolder,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Build a ContainedDecomposed type implementation to deal with the specific [PermissionSet case](https://github.com/forcedotcom/cli/discussions/2544#discussioncomment-9045716)

This implementation works for both [decomposed](https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_ws_decomposed_md_types.htm#permset) and composed version of the PermissionSet metadata
Actual implementation is specific to the PermissionSet use case.
Nonetheless, it is not too much complicated to extends for future use cases.

# Does this close any currently open issues?

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #1001 

- [X] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

