### PR TITLE
chore: add node 24 in matrix testing

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        node: [18, 20, 22]
+        node: [18, 20, 22, 24]
         cli: ['@salesforce/cli']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

Add node 24 in matrix testing in order to prepare for the sf cli support of node 24 and [deprecation of node 18](https://github.com/forcedotcom/cli/issues/3257)