### PR TITLE
feat: add ChoiceList metadata support

### DIFF
--- a/src/metadata/v62.ts
+++ b/src/metadata/v62.ts
@@ -1,5 +1,12 @@
 export default [
   {
+    directoryName: 'ChoiceList',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'ChoiceList',
+    xmlName: 'ChoiceList',
+  },
+  {
     directoryName: 'documentTemplates',
     inFolder: false,
     metaFile: false,

--- a/src/metadata/v63.ts
+++ b/src/metadata/v63.ts
@@ -1,5 +1,12 @@
 export default [
   {
+    directoryName: 'ChoiceList',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'ChoiceList',
+    xmlName: 'ChoiceList',
+  },
+  {
     directoryName: 'documentTemplates',
     inFolder: false,
     metaFile: false,

--- a/src/metadata/v64.ts
+++ b/src/metadata/v64.ts
@@ -1,5 +1,12 @@
 export default [
   {
+    directoryName: 'ChoiceList',
+    inFolder: false,
+    metaFile: false,
+    suffix: 'ChoiceList',
+    xmlName: 'ChoiceList',
+  },
+  {
     directoryName: 'documentTemplates',
     inFolder: false,
     metaFile: false,


### PR DESCRIPTION
# Explain your changes

---

Add support for ChoiceList metadata type since v62

https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_choicelist.htm


# Does this close any currently open issues?

---

No, we discovered this when adding ChoiceList metadata files to our repo for deployment
