### PR TITLE
fix(metadata): generate Report/ReportFolder and Dashboard/DashboardFolder correctly

### DIFF
--- a/__tests__/functional/delta.nut.ts
+++ b/__tests__/functional/delta.nut.ts
@@ -70,8 +70,8 @@ describe('sgd source delta NUTS', () => {
     const destructiveChangesLineCount = await getFileLineNumber(
       'e2e/expected/destructiveChanges/destructiveChanges.xml'
     )
-    expect(packageLineCount).to.equal(232)
-    expect(destructiveChangesLineCount).to.equal(137)
+    expect(packageLineCount).to.equal(235)
+    expect(destructiveChangesLineCount).to.equal(140)
     expect(result).to.include('"status": 0')
   })
 })

--- a/__tests__/integration/services.test.ts
+++ b/__tests__/integration/services.test.ts
@@ -196,9 +196,24 @@ const testContext = [
     'Dashboard',
   ],
   [
+    'force-app/main/default/dashboards/folder.dashboardFolder-meta.xml',
+    new Set(['folder']),
+    'DashboardFolder',
+  ],
+  [
+    'force-app/main/default/dashboards/folder/folder.dashboardFolder-meta.xml',
+    new Set(['folder/folder']),
+    'DashboardFolder',
+  ],
+  [
+    'force-app/main/default/reports/folder/file.report-meta.xml',
+    new Set(['folder/file']),
+    'Report',
+  ],
+  [
     'force-app/main/default/reports/folder.reportFolder-meta.xml',
     new Set(['folder']),
-    'Report',
+    'ReportFolder',
   ],
   [
     'force-app/main/default/documents/folder.documentFolder-meta.xml',
@@ -461,7 +476,6 @@ const testContext = [
     'FeatureParameterDate',
   ],
 ]
-
 const existingFiles = [
   'force-app/main/default/permissionsets/Admin/Admin.permissionset-meta.xml',
 ]

--- a/__tests__/unit/lib/service/inNestedFolderHandler.test.ts
+++ b/__tests__/unit/lib/service/inNestedFolderHandler.test.ts
@@ -1,0 +1,182 @@
+'use strict'
+import { describe, expect, it, jest } from '@jest/globals'
+
+import { METAFILE_SUFFIX } from '../../../../src/constant/metadataConstants'
+import { MetadataRepository } from '../../../../src/metadata/MetadataRepository'
+import InNestedFolder from '../../../../src/service/inNestedFolderHandler'
+import type { Work } from '../../../../src/types/work'
+import { copyFiles, readDirs } from '../../../../src/utils/fsHelper'
+import { getGlobalMetadata, getWork } from '../../../__utils__/globalTestHelper'
+
+jest.mock('../../../../src/utils/fsHelper')
+const mockedReadDirs = jest.mocked(readDirs)
+
+const entity = 'folder/test'
+const extension = 'report'
+const objectType = {
+  directoryName: 'reports',
+  inFolder: true,
+  metaFile: true,
+  xmlName: 'Report',
+  content: [
+    {
+      suffix: 'report',
+      xmlName: 'Report',
+    },
+    {
+      suffix: 'reportFolder',
+      xmlName: 'ReportFolder',
+    },
+  ],
+}
+
+const testContext = [
+  [
+    `A       force-app/main/default/${objectType.directoryName}/${entity}.${extension}-meta.xml`,
+    new Set([entity]),
+    'Report',
+  ],
+  [
+    `A       force-app/main/default/${objectType.directoryName}/${entity}.reportFolder-meta.xml`,
+    new Set([entity]),
+    'ReportFolder',
+  ],
+  [
+    `A       force-app/main/default/${objectType.directoryName}/folder/${entity}.reportFolder-meta.xml`,
+    new Set([`folder/${entity}`]),
+    'ReportFolder',
+  ],
+  [
+    `A       force-app/main/default/${objectType.directoryName}/folder/folder/${entity}.reportFolder-meta.xml`,
+    new Set([`folder/folder/${entity}`]),
+    'ReportFolder',
+  ],
+]
+
+let work: Work
+beforeEach(() => {
+  jest.clearAllMocks()
+  work = getWork()
+})
+
+describe('InNestedFolderHandler', () => {
+  let globalMetadata: MetadataRepository
+  beforeAll(async () => {
+    globalMetadata = await getGlobalMetadata()
+  })
+
+  describe.each(testContext)(
+    'when called with generateDelta false',
+    (
+      changePath: string | Set<string>,
+      expected: string | Set<string>,
+      expectedType: string | Set<string>
+    ) => {
+      beforeEach(() => {
+        work.config.generateDelta = false
+      })
+      it(`should not copy meta files nor copy special extension when adding ${expectedType}`, async () => {
+        // Arrange
+        const sut = new InNestedFolder(
+          changePath as string,
+          objectType,
+          work,
+          globalMetadata
+        )
+
+        // Act
+        await sut.handleAddition()
+
+        // Assert
+        expect(work.diffs.package.get(expectedType as string)).toEqual(expected)
+        expect(copyFiles).not.toHaveBeenCalled()
+      })
+    }
+  )
+
+  describe.each(testContext)(
+    'when called with generateDelta true',
+    (
+      changePath: string | Set<string>,
+      expected: string | Set<string>,
+      expectedType: string | Set<string>
+    ) => {
+      beforeEach(() => {
+        work.config.generateDelta = true
+      })
+
+      describe(`when readDirs does not return files`, () => {
+        it(`should not copy special extension and copy meta files in addition ${expectedType}`, async () => {
+          // Arrange
+          const sut = new InNestedFolder(
+            changePath as string,
+            objectType,
+            work,
+            globalMetadata
+          )
+          mockedReadDirs.mockImplementation(() => Promise.resolve([]))
+
+          // Act
+          await sut.handleAddition()
+
+          // Assert
+          expect(work.diffs.package.get(expectedType as string)).toEqual(
+            expected
+          )
+          expect(readDirs).toHaveBeenCalledTimes(1)
+          expect(copyFiles).toHaveBeenCalledTimes(3)
+          expect(copyFiles).toHaveBeenCalledWith(
+            work.config,
+            expect.stringContaining(METAFILE_SUFFIX)
+          )
+        })
+      })
+
+      describe('when readDirs returns files', () => {
+        it('should copy special extension', async () => {
+          // Arrange
+          const sut = new InNestedFolder(
+            changePath as string,
+            objectType,
+            work,
+            globalMetadata
+          )
+          mockedReadDirs.mockImplementationOnce(() =>
+            Promise.resolve([entity, 'not/matching'])
+          )
+
+          // Act
+          await sut.handleAddition()
+
+          // Assert
+          expect(work.diffs.package.get(expectedType as string)).toEqual(
+            expected
+          )
+          expect(readDirs).toHaveBeenCalledTimes(1)
+          expect(copyFiles).toHaveBeenCalledTimes(5)
+        })
+      })
+    }
+  )
+
+  describe('when the line should not be processed', () => {
+    it.each([
+      `force-app/main/default/${objectType.directoryName}/test.otherExtension`,
+    ])('does not handle the line', async entityPath => {
+      // Arrange
+      const sut = new InNestedFolder(
+        `A       ${entityPath}`,
+        objectType,
+        work,
+        globalMetadata
+      )
+
+      // Act
+      await sut.handle()
+
+      // Assert
+      expect(work.diffs.package.size).toBe(0)
+      expect(copyFiles).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/unit/lib/service/typeHandlerFactory.test.ts
+++ b/__tests__/unit/lib/service/typeHandlerFactory.test.ts
@@ -7,6 +7,7 @@ import CustomField from '../../../../src/service/customFieldHandler'
 import Decomposed from '../../../../src/service/decomposedHandler'
 import FlowHandler from '../../../../src/service/flowHandler'
 import InFolder from '../../../../src/service/inFolderHandler'
+import InNestedFolder from '../../../../src/service/inNestedFolderHandler'
 import InResource from '../../../../src/service/inResourceHandler'
 import SharedFolder from '../../../../src/service/sharedFolderHandler'
 import Standard from '../../../../src/service/standardHandler'
@@ -39,7 +40,8 @@ describe('the type handler factory', () => {
         'webLinks',
       ],
     ],
-    [InFolder, ['dashboards', 'documents', 'reports']],
+    [InFolder, ['documents']],
+    [InNestedFolder, ['dashboards', 'reports']],
     [InResource, ['staticresources', 'aura', 'lwc']],
     [Standard, ['classes']],
     [SharedFolder, ['moderation', 'wave', 'discovery']],

--- a/src/metadata/v63.ts
+++ b/src/metadata/v63.ts
@@ -989,15 +989,33 @@ export default [
     directoryName: 'reports',
     inFolder: true,
     metaFile: false,
-    suffix: 'report',
     xmlName: 'Report',
+    content: [
+      {
+        suffix: 'report',
+        xmlName: 'Report',
+      },
+      {
+        suffix: 'reportFolder',
+        xmlName: 'ReportFolder',
+      },
+    ],
   },
   {
     directoryName: 'dashboards',
     inFolder: true,
     metaFile: false,
-    suffix: 'dashboard',
     xmlName: 'Dashboard',
+    content: [
+      {
+        suffix: 'dashboard',
+        xmlName: 'Dashboard',
+      },
+      {
+        suffix: 'dashboardFolder',
+        xmlName: 'DashboardFolder',
+      },
+    ],
   },
   {
     directoryName: 'analyticSnapshots',

--- a/src/metadata/v64.ts
+++ b/src/metadata/v64.ts
@@ -1003,15 +1003,33 @@ export default [
     directoryName: 'reports',
     inFolder: true,
     metaFile: false,
-    suffix: 'report',
     xmlName: 'Report',
+    content: [
+      {
+        suffix: 'report',
+        xmlName: 'Report',
+      },
+      {
+        suffix: 'reportFolder',
+        xmlName: 'ReportFolder',
+      },
+    ],
   },
   {
     directoryName: 'dashboards',
     inFolder: true,
     metaFile: false,
-    suffix: 'dashboard',
     xmlName: 'Dashboard',
+    content: [
+      {
+        suffix: 'dashboard',
+        xmlName: 'Dashboard',
+      },
+      {
+        suffix: 'dashboardFolder',
+        xmlName: 'DashboardFolder',
+      },
+    ],
   },
   {
     directoryName: 'analyticSnapshots',

--- a/src/service/inNestedFolderHandler.ts
+++ b/src/service/inNestedFolderHandler.ts
@@ -1,0 +1,39 @@
+'use strict'
+
+import { join } from 'node:path/posix'
+import { METAFILE_SUFFIX } from '../constant/metadataConstants.js'
+import { MetadataRepository } from '../metadata/MetadataRepository.js'
+import { getSharedFolderMetadata } from '../metadata/metadataManager.js'
+import { Metadata } from '../types/metadata.js'
+import type { Manifest, Work } from '../types/work.js'
+import { fillPackageWithParameter } from '../utils/packageHelper.js'
+import InFolderHandler from './inFolderHandler.js'
+
+export default class InNestedFolderHandler extends InFolderHandler {
+  protected readonly sharedFolderMetadata: Map<string, string>
+
+  constructor(
+    line: string,
+    metadataDef: Metadata,
+    work: Work,
+    metadata: MetadataRepository
+  ) {
+    super(line, metadataDef, work, metadata)
+    this.sharedFolderMetadata = getSharedFolderMetadata(this.metadata)
+  }
+
+  protected override async _copyFolderMetaFile() {
+    const [, folderPath, folderName] = this._parseLine()!
+    const folderFileName = `${folderName}${METAFILE_SUFFIX}`
+    await this._copyWithMetaFile(join(folderPath, folderFileName))
+  }
+
+  protected override _fillPackage(store: Manifest) {
+    const type = this.sharedFolderMetadata.get(this.ext!) as string
+    fillPackageWithParameter({
+      store,
+      type: type,
+      member: this._getElementName(),
+    })
+  }
+}

--- a/src/service/typeHandlerFactory.ts
+++ b/src/service/typeHandlerFactory.ts
@@ -13,6 +13,7 @@ import FlowHandler from './flowHandler.js'
 import InBundle from './inBundleHandler.js'
 import InFile from './inFileHandler.js'
 import InFolder from './inFolderHandler.js'
+import InNestedFolder from './inNestedFolderHandler.js'
 import InResource from './inResourceHandler.js'
 import Lwc from './lwcHandler.js'
 import ObjectTranslation from './objectTranslationHandler.js'
@@ -30,7 +31,7 @@ const handlerMap = {
   CustomLabel: CustomLabel,
   CustomObject: CustomObject,
   CustomObjectTranslation: ObjectTranslation,
-  Dashboard: InFolder,
+  Dashboard: InNestedFolder,
   DigitalExperienceBundle: InBundle,
   Document: InFolder,
   EmailTemplate: InFolder,
@@ -48,7 +49,7 @@ const handlerMap = {
   PermissionSet: ContainedDecomposed,
   Profile: InFile,
   RecordType: Decomposed,
-  Report: InFolder,
+  Report: InNestedFolder,
   SharingCriteriaRule: Decomposed,
   SharingGuestRule: Decomposed,
   SharingOwnerRule: Decomposed,


### PR DESCRIPTION
Previously, the package builder placed report folders under the Report type (and dashboard folders under Dashboard). This fails when migrating folder-only changes (empty folders).

Now, package.xml generation separates items and folders:
- Reports → Report
- Report folders → ReportFolder
- Dashboards → Dashboard
- Dashboard folders → DashboardFolder

This supports all combinations (folders only, items only, or both) and remains backwards compatible.

<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
-->

# Explain your changes

---
The package generator was previously putting both items (reports/dashboards) and their folders
under the same type (Report or Dashboard). This is valid as long as the package contains at least one
report or dashboard.

Problem
If a package contained only empty folders (for example, migrating new folder structure without any
reports/dashboards inside), the deployment would fail. Salesforce requires folders to be represented
under their own types: ReportFolder and DashboardFolder.

Change
	•	Continue to generate items under Report / Dashboard.
	•	Generate folders under their respective folder types: ReportFolder and DashboardFolder.
	•	Works in all cases:
	•	Items + folders together
	•	Items only
	•	Folders only
<!--
  Describe with your own words the content of the Pull Request
-->

# Does this close any currently open issues?

---
No
<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #

- [x] Jest tests added to cover the fix.
- [x] NUT tests updated to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

# Any other comments

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
