### PR TITLE
feat(main): flow deletion adds an entry for each flow version to dest…

### DIFF
--- a/__tests__/unit/lib/service/typeHandlerFactory.test.ts
+++ b/__tests__/unit/lib/service/typeHandlerFactory.test.ts
@@ -16,6 +16,15 @@ import TypeHandlerFactory from '../../../../src/service/typeHandlerFactory'
 import type { Work } from '../../../../src/types/work'
 import { getGlobalMetadata, getWork } from '../../../__utils__/globalTestHelper'
 
+jest.mock('../../../../src/utils/MessageService', () => {
+  return {
+    MessageService: jest.fn().mockImplementation(() => ({
+      getMessage: jest.fn(),
+      getMessages: jest.fn(),
+    })),
+  }
+})
+
 describe('the type handler factory', () => {
   let typeHandlerFactory: TypeHandlerFactory
   beforeAll(async () => {

--- a/src/service/flowHandler.ts
+++ b/src/service/flowHandler.ts
@@ -1,21 +1,57 @@
 'use strict'
 
+import { FLOW_XML_NAME } from '../constant/metadataConstants.js'
+import { MetadataRepository } from '../metadata/MetadataRepository.js'
+import type { Metadata } from '../types/metadata.js'
+import type { Work } from '../types/work.js'
 import { log } from '../utils/LoggingDecorator.js'
 import { MessageService } from '../utils/MessageService.js'
+import { fillPackageWithParameter } from '../utils/packageHelper.js'
 import StandardHandler from './standardHandler.js'
 
 export default class FlowHandler extends StandardHandler {
-  @log
-  public override async handleDeletion() {
-    await super.handleDeletion()
-    this.warnFlowDeleted()
+  private readonly messageService: MessageService
+
+  constructor(
+    line: string,
+    metadataDef: Metadata,
+    work: Work,
+    metadata: MetadataRepository
+  ) {
+    super(line, metadataDef, work, metadata)
+    this.messageService = new MessageService()
   }
 
-  private warnFlowDeleted() {
-    const message = new MessageService()
+  @log
+  public override async handleDeletion() {
+    try {
+      const flowName = this._getElementName()
+      const destructiveChanges = this.diffs.destructiveChanges
+
+      // Add each flow 50 times with "-n" appended
+      for (let i = 1; i <= 50; i++) {
+        const flowWithSuffix = `${flowName}-${i}`
+        fillPackageWithParameter({
+          store: destructiveChanges,
+          type: FLOW_XML_NAME,
+          member: flowWithSuffix,
+        })
+      }
+
+      // Log a single warning for the flow
+      this.warnFlowDeleted(flowName)
+    } catch (error) {
+      if (error instanceof Error) {
+        error.message = `${this.line}: ${error.message}`
+        this.warnings.push(error)
+      }
+    }
+  }
+
+  private warnFlowDeleted(flowName: string) {
     this.work.warnings.push(
       new Error(
-        message.getMessage('warning.FlowDeleted', [this._getElementName()])
+        this.messageService.getMessage('warning.FlowDeleted', [flowName])
       )
     )
   }


### PR DESCRIPTION
…ructiveChanges

<!--
Thanks for sending a pull request! Please make sure to have a look to the contribution guidelines, then fill out the blanks below.
This pull request introduces significant changes to the `FlowHandler` class to enhance flow deletion handling and improve test reliability. The main updates involve modifying how deleted flows are recorded and how warnings are generated, as well as updating tests to mock the `MessageService`.

**Flow deletion handling improvements:**

* The `FlowHandler` class now adds each deleted flow 50 times with a "-n" suffix (e.g., "Flow-1", "Flow-2", ..., "Flow-50") to the `destructiveChanges` package, ensuring all related flow versions are included during deletion.
* A single warning is logged for the deleted flow, using the `MessageService` to retrieve the warning message, and this is pushed to the `work.warnings` array.

**Test reliability improvements:**

* The `MessageService` is mocked in the unit test for `typeHandlerFactory` to prevent actual service calls and ensure consistent test results.

**Code structure and error handling:**

* The `FlowHandler` constructor now initializes its own instance of `MessageService`, and error handling in `handleDeletion` has been improved to capture and store errors with contextual information.
-->

# Explain your changes

---

<!--
  Describe with your own words the content of the Pull Request
-->

# Does this close any currently open issues?

No
---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

closes #

- [ ] Jest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---

<!--
  Provide any new parameters or new behaviour with existing parameters
-->

# Any other comments

---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
