### PR TITLE
ci: update e2e expected files on SDR upgrade

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -46,6 +46,33 @@ jobs:
           npm run build
           npm run lint:fix
 
+      - name: Update e2e expected files API version
+        if: steps.metadata.outputs.package-ecosystem == 'npm' && contains(steps.metadata.outputs.dependency-names, '@salesforce/source-deploy-retrieve')
+        run: |
+          # Extract new API version from the updated SDR
+          NEW_VERSION=$(node -e "import('@salesforce/source-deploy-retrieve').then(m => m.getCurrentApiVersion()).then(v => process.stdout.write(v + '.0'))")
+
+          # Fetch and checkout e2e/head in a worktree
+          git fetch origin e2e/head
+          git worktree add /tmp/e2e-head origin/e2e/head
+
+          # Update <version> tags in expected XML package manifests
+          cd /tmp/e2e-head
+          find expected/package expected/destructiveChanges -name "*.xml" -exec sed -i "s|<version>[0-9.]*</version>|<version>${NEW_VERSION}</version>|g" {} +
+
+          # Amend the last commit if version changed
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add expected/package expected/destructiveChanges
+            git commit --amend --no-edit
+            git push --force-with-lease origin HEAD:e2e/head
+          fi
+
+          # Clean up worktree
+          cd -
+          git worktree remove /tmp/e2e-head
+
       - name: Commit and push if changed
         if: steps.metadata.outputs.package-ecosystem == 'npm' && contains(steps.metadata.outputs.dependency-names, '@salesforce/source-deploy-retrieve')
         run: |


### PR DESCRIPTION
## Summary
- Adds a new step to the Dependabot auto-merge workflow that updates API version in e2e expected XML files when `@salesforce/source-deploy-retrieve` is upgraded
- Uses `git worktree` to check out the `e2e/head` branch without disturbing the PR branch
- Updates `<version>` tags in `expected/package` and `expected/destructiveChanges` XML files to match the new SDR API version
- Amends the last commit on `e2e/head` with `--force-with-lease` for safe push

## Context
When Dependabot upgrades SDR, the API version can change (e.g. 65→66). The current workflow syncs the internal registry but does NOT update the e2e expected XML files, causing e2e test failures on `<version>` mismatch.

## Test plan
- [ ] Review the workflow YAML for correct step ordering and syntax
- [ ] Verify the `if` condition matches existing SDR-specific steps
- [ ] Confirm `getCurrentApiVersion()` returns a number (append `.0` for `<version>66.0</version>` format)
- [ ] Validate worktree cleanup happens even on success path