### PR TITLE
refactor: replace fast-equals with in-house deepEqualJson

### DIFF
--- a/__tests__/perf/deepEqualJson.bench.ts
+++ b/__tests__/perf/deepEqualJson.bench.ts
@@ -1,0 +1,99 @@
+import { bench, describe } from 'vitest'
+
+import { deepEqualJson } from '../../src/utils/metadataDiff/deepEqualJson.js'
+
+// XML-shaped fixtures matching txml output: nested objects with @_attr
+// keys and arrays of repeated tags. The diff hot path compares
+// (fromElem, toElem) and (fromArr, toArr) of this shape.
+const buildElement = (i: number): Record<string, unknown> => ({
+  '@_id': `id-${i}`,
+  fullName: `Label_${i}`,
+  language: 'en_US',
+  protected: 'false',
+  shortDescription: `Short_${i}`,
+  value: `Some value ${i} with spaces`,
+})
+
+const buildNestedElement = (i: number): Record<string, unknown> => ({
+  '@_xmlns': 'http://soap.sforce.com/2006/04/metadata',
+  fullName: `Profile_${i}`,
+  fieldPermissions: Array.from({ length: 10 }, (_, j) => ({
+    editable: 'true',
+    field: `Account.Field_${j}__c`,
+    readable: 'true',
+  })),
+  objectPermissions: Array.from({ length: 5 }, (_, j) => ({
+    allowCreate: 'true',
+    allowDelete: 'false',
+    allowEdit: 'true',
+    object: `Object_${j}__c`,
+  })),
+  userLicense: 'Salesforce',
+})
+
+// Shallow scalar-heavy element (the most common XML diff input)
+const shallowA = buildElement(0)
+const shallowB = buildElement(0)
+const shallowDifferent = { ...buildElement(0), value: 'different' }
+
+// Deeply nested with arrays (Profile-shape)
+const nestedA = buildNestedElement(0)
+const nestedB = buildNestedElement(0)
+const nestedDifferent = {
+  ...buildNestedElement(0),
+  fieldPermissions: [
+    ...(buildNestedElement(0).fieldPermissions as Record<string, unknown>[]),
+    { editable: 'true', field: 'Extra', readable: 'true' },
+  ],
+}
+
+// Array-of-elements (drainArrays hot path)
+const arrayA = Array.from({ length: 100 }, (_, i) => buildElement(i))
+const arrayB = Array.from({ length: 100 }, (_, i) => buildElement(i))
+const arrayDifferentLast = (() => {
+  const out = arrayA.map(e => ({ ...e }))
+  out[99] = { ...(out[99] as Record<string, unknown>), value: 'changed' }
+  return out
+})()
+
+describe('deepEqualJson-equal-shallow', () => {
+  bench('shallow-equal', () => {
+    deepEqualJson(shallowA, shallowB)
+  })
+})
+
+describe('deepEqualJson-different-shallow', () => {
+  bench('shallow-different-last-field', () => {
+    deepEqualJson(shallowA, shallowDifferent)
+  })
+})
+
+describe('deepEqualJson-equal-nested', () => {
+  bench('nested-equal', () => {
+    deepEqualJson(nestedA, nestedB)
+  })
+})
+
+describe('deepEqualJson-different-nested', () => {
+  bench('nested-different-array-length', () => {
+    deepEqualJson(nestedA, nestedDifferent)
+  })
+})
+
+describe('deepEqualJson-equal-large-array', () => {
+  bench('array-of-100-elements-equal', () => {
+    deepEqualJson(arrayA, arrayB)
+  })
+})
+
+describe('deepEqualJson-different-large-array', () => {
+  bench('array-of-100-elements-last-differs', () => {
+    deepEqualJson(arrayA, arrayDifferentLast)
+  })
+})
+
+describe('deepEqualJson-reference-identical', () => {
+  bench('same-reference-short-circuit', () => {
+    deepEqualJson(arrayA, arrayA)
+  })
+})

--- a/__tests__/unit/lib/utils/metadataDiff/deepEqualJson.test.ts
+++ b/__tests__/unit/lib/utils/metadataDiff/deepEqualJson.test.ts
@@ -74,6 +74,15 @@ describe('deepEqualJson', () => {
       const a = [1, 2, [3]]
       expect(deepEqualJson(a, a)).toBe(true)
     })
+
+    it('When nested children share a reference, Then the work-stack short-circuits on identity for the sub-tree', () => {
+      // Shared nested object lands on the work stack; the in-loop `ai === bi`
+      // identity check makes the comparison skip its sub-tree entirely.
+      const shared = { inner: { deep: 'value' } }
+      const a = { wrapper: shared, other: 'x' }
+      const b = { wrapper: shared, other: 'x' }
+      expect(deepEqualJson(a, b)).toBe(true)
+    })
   })
 
   describe('Given empty structures', () => {

--- a/__tests__/unit/lib/utils/metadataDiff/deepEqualJson.test.ts
+++ b/__tests__/unit/lib/utils/metadataDiff/deepEqualJson.test.ts
@@ -161,5 +161,18 @@ describe('deepEqualJson', () => {
       // Both have one key; "a" vs "b" — caught by hasOwnProperty guard
       expect(deepEqualJson({ a: undefined }, { b: undefined })).toBe(false)
     })
+
+    it('When one side has an inherited (non-own) property matching the other side own key, Then returns false', () => {
+      // Hardens against a `key in b` mutation: `in` would walk the prototype
+      // chain and report `true` for inherited properties, defeating the
+      // own-keys-only contract.
+      const proto = { shared: 'inherited' }
+      const a = { shared: 'inherited' }
+      const bInherits = Object.create(proto) as Record<string, unknown>
+      // bInherits has zero own keys; key counts differ → false even before the
+      // hasOwn check. Add an own decoy to force same length without own match.
+      bInherits['decoy'] = 'x'
+      expect(deepEqualJson(a, bInherits)).toBe(false)
+    })
   })
 })

--- a/__tests__/unit/lib/utils/metadataDiff/deepEqualJson.test.ts
+++ b/__tests__/unit/lib/utils/metadataDiff/deepEqualJson.test.ts
@@ -1,0 +1,165 @@
+'use strict'
+import { describe, expect, it } from 'vitest'
+
+import { deepEqualJson } from '../../../../../src/utils/metadataDiff/deepEqualJson'
+
+describe('deepEqualJson', () => {
+  describe('Given primitive inputs', () => {
+    it('When two equal strings, Then returns true', () => {
+      expect(deepEqualJson('abc', 'abc')).toBe(true)
+    })
+
+    it('When two different strings, Then returns false', () => {
+      expect(deepEqualJson('abc', 'abd')).toBe(false)
+    })
+
+    it('When both undefined, Then returns true', () => {
+      expect(deepEqualJson(undefined, undefined)).toBe(true)
+    })
+
+    it('When both null, Then returns true', () => {
+      expect(deepEqualJson(null, null)).toBe(true)
+    })
+
+    it('When null and undefined, Then returns false', () => {
+      expect(deepEqualJson(null, undefined)).toBe(false)
+    })
+
+    it('When two equal numbers, Then returns true', () => {
+      expect(deepEqualJson(42, 42)).toBe(true)
+    })
+
+    it('When two different numbers, Then returns false', () => {
+      expect(deepEqualJson(42, 43)).toBe(false)
+    })
+
+    it('When two equal booleans, Then returns true', () => {
+      expect(deepEqualJson(true, true)).toBe(true)
+    })
+
+    it('When a string and a number with same value, Then returns false', () => {
+      expect(deepEqualJson('42', 42)).toBe(false)
+    })
+  })
+
+  describe('Given type mismatches', () => {
+    it('When object and null, Then returns false', () => {
+      expect(deepEqualJson({}, null)).toBe(false)
+    })
+
+    it('When null and object, Then returns false', () => {
+      expect(deepEqualJson(null, {})).toBe(false)
+    })
+
+    it('When primitive and object, Then returns false', () => {
+      expect(deepEqualJson('a', { 0: 'a' })).toBe(false)
+    })
+
+    it('When array and object with same keys count, Then returns false', () => {
+      expect(deepEqualJson(['a'], { 0: 'a' })).toBe(false)
+    })
+
+    it('When object and array, Then returns false', () => {
+      expect(deepEqualJson({ 0: 'a' }, ['a'])).toBe(false)
+    })
+  })
+
+  describe('Given identical references', () => {
+    it('When same object reference, Then short-circuits to true', () => {
+      const o = { a: { b: 1 } }
+      expect(deepEqualJson(o, o)).toBe(true)
+    })
+
+    it('When same array reference, Then short-circuits to true', () => {
+      const a = [1, 2, [3]]
+      expect(deepEqualJson(a, a)).toBe(true)
+    })
+  })
+
+  describe('Given empty structures', () => {
+    it('When both empty objects, Then returns true', () => {
+      expect(deepEqualJson({}, {})).toBe(true)
+    })
+
+    it('When both empty arrays, Then returns true', () => {
+      expect(deepEqualJson([], [])).toBe(true)
+    })
+
+    it('When empty object and empty array, Then returns false', () => {
+      expect(deepEqualJson({}, [])).toBe(false)
+    })
+  })
+
+  describe('Given arrays', () => {
+    it('When equal-length arrays with same primitives, Then returns true', () => {
+      expect(deepEqualJson([1, 2, 3], [1, 2, 3])).toBe(true)
+    })
+
+    it('When different-length arrays, Then returns false', () => {
+      expect(deepEqualJson([1, 2], [1, 2, 3])).toBe(false)
+    })
+
+    it('When same-length arrays with differing element, Then returns false', () => {
+      expect(deepEqualJson([1, 2, 3], [1, 9, 3])).toBe(false)
+    })
+
+    it('When arrays differ only in order, Then returns false (order-sensitive)', () => {
+      expect(deepEqualJson([1, 2, 3], [3, 2, 1])).toBe(false)
+    })
+
+    it('When arrays of equal objects, Then returns true', () => {
+      expect(deepEqualJson([{ a: 1 }, { b: 2 }], [{ a: 1 }, { b: 2 }])).toBe(
+        true
+      )
+    })
+  })
+
+  describe('Given objects', () => {
+    it('When two single-key objects with same value, Then returns true', () => {
+      expect(deepEqualJson({ a: 1 }, { a: 1 })).toBe(true)
+    })
+
+    it('When two single-key objects with different values, Then returns false', () => {
+      expect(deepEqualJson({ a: 1 }, { a: 2 })).toBe(false)
+    })
+
+    it('When two objects with different key counts, Then returns false', () => {
+      expect(deepEqualJson({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+    })
+
+    it('When two objects with same key count but different keys, Then returns false', () => {
+      expect(deepEqualJson({ a: 1 }, { b: 1 })).toBe(false)
+    })
+
+    it('When objects with same keys regardless of declaration order, Then returns true', () => {
+      expect(deepEqualJson({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+    })
+  })
+
+  describe('Given nested structures (XML-like)', () => {
+    it('When nested objects are structurally equal, Then returns true', () => {
+      const a = { tag: { '@_id': 'x', child: ['v1', 'v2'] } }
+      const b = { tag: { '@_id': 'x', child: ['v1', 'v2'] } }
+      expect(deepEqualJson(a, b)).toBe(true)
+    })
+
+    it('When a nested array element differs, Then returns false', () => {
+      const a = { tag: { child: ['v1', 'v2'] } }
+      const b = { tag: { child: ['v1', 'v3'] } }
+      expect(deepEqualJson(a, b)).toBe(false)
+    })
+
+    it('When deep nesting matches, Then returns true', () => {
+      const a = { l1: { l2: { l3: { l4: { leaf: 'x' } } } } }
+      const b = { l1: { l2: { l3: { l4: { leaf: 'x' } } } } }
+      expect(deepEqualJson(a, b)).toBe(true)
+    })
+  })
+
+  describe('Given the hasOwnProperty edge case', () => {
+    it('When one object has a key with undefined value and the other has no such key (same length), Then returns false', () => {
+      // Both have one key; "a" vs "b" — caught by hasOwnProperty guard
+      expect(deepEqualJson({ a: undefined }, { b: undefined })).toBe(false)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@salesforce/core": "^8.31.0",
         "@salesforce/sf-plugins-core": "^12.2.22",
         "@salesforce/source-deploy-retrieve": "^12.35.10",
-        "fast-equals": "^6.0.0",
         "ignore": "^7.0.5",
         "tar-stream": "3.2.0",
         "tslib": "^2.8.1",
@@ -8726,15 +8725,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
-    },
-    "node_modules/fast-equals": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
-      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@salesforce/core": "^8.31.0",
     "@salesforce/sf-plugins-core": "^12.2.22",
     "@salesforce/source-deploy-retrieve": "^12.35.10",
-    "fast-equals": "^6.0.0",
     "ignore": "^7.0.5",
     "tar-stream": "3.2.0",
     "tslib": "^2.8.1",

--- a/src/utils/metadataDiff/deepEqualJson.ts
+++ b/src/utils/metadataDiff/deepEqualJson.ts
@@ -1,42 +1,96 @@
 'use strict'
 
 /**
- * Recursive structural equality for plain JSON-like values produced by
- * txml + txmlAdapter (primitives, plain objects, arrays). Order-sensitive
- * for arrays. Replaces the narrow surface of `fast-equals.deepEqual` that
- * SGD actually used in StreamingDiff.
+ * Iterative structural equality for JSON-like values (plain objects,
+ * arrays, primitives). Order-sensitive for arrays. Replaces the narrow
+ * surface of `fast-equals.deepEqual` that SGD actually used in
+ * StreamingDiff.
  *
  * Out of scope (txml never emits these): Date, RegExp, Map, Set, Symbol,
  * Function, circular references, NaN. Falls back to `===` for any
  * non-plain-object value.
+ *
+ * Hot-path optimisations:
+ *  - Reference-equality short-circuit before any allocation
+ *  - Iterative work-stack — no recursion frames
+ *  - Parallel A/B stacks — no per-pair tuple allocation
+ *  - Inline scalar comparison inside the per-child loops — string/number
+ *    leaves never reach the work stack (the dominant case in XML diffs)
+ *  - Indexed for-loops with cached length over `for…of`
  */
 export const deepEqualJson = (a: unknown, b: unknown): boolean => {
   if (a === b) return true
-  if (typeof a !== 'object' || a === null) return false
-  if (typeof b !== 'object' || b === null) return false
-  const aIsArray = Array.isArray(a)
-  const bIsArray = Array.isArray(b)
-  if (aIsArray !== bIsArray) return false
-  if (aIsArray && bIsArray) {
-    if (a.length !== b.length) return false
-    for (let i = 0; i < a.length; i++) {
-      if (!deepEqualJson(a[i], b[i])) return false
-    }
-    return true
+  if (
+    a === null ||
+    b === null ||
+    typeof a !== 'object' ||
+    typeof b !== 'object'
+  ) {
+    return false
   }
-  const keysA = Object.keys(a)
-  const keysB = Object.keys(b)
-  if (keysA.length !== keysB.length) return false
-  for (const key of keysA) {
-    if (
-      !Object.hasOwn(b, key) ||
-      !deepEqualJson(
-        (a as Record<string, unknown>)[key],
-        (b as Record<string, unknown>)[key]
-      )
-    ) {
-      return false
+
+  // Parallel stacks: each push to stackA matches a push to stackB. Two
+  // arrays of pointers cost less than one array of [a, b] tuples both in
+  // allocation and in cache locality at pop time.
+  const stackA: object[] = [a as object]
+  const stackB: object[] = [b as object]
+
+  while (stackA.length !== 0) {
+    // Invariant: every push site filters `va === vb` first, so popped pairs
+    // are always non-identical references. No inline `===` short-circuit
+    // needed inside the loop.
+    const ai = stackA.pop() as object
+    const bi = stackB.pop() as object
+
+    const aIsArr = Array.isArray(ai)
+    if (aIsArr !== Array.isArray(bi)) return false
+
+    if (aIsArr) {
+      const arrA = ai as unknown[]
+      const arrB = bi as unknown[]
+      const len = arrA.length
+      if (len !== arrB.length) return false
+      for (let i = 0; i < len; i++) {
+        const va = arrA[i]
+        const vb = arrB[i]
+        if (va === vb) continue
+        if (
+          va === null ||
+          vb === null ||
+          typeof va !== 'object' ||
+          typeof vb !== 'object'
+        ) {
+          return false
+        }
+        stackA.push(va as object)
+        stackB.push(vb as object)
+      }
+      continue
+    }
+
+    const objA = ai as Record<string, unknown>
+    const objB = bi as Record<string, unknown>
+    const keysA = Object.keys(objA)
+    const len = keysA.length
+    if (len !== Object.keys(objB).length) return false
+    for (let i = 0; i < len; i++) {
+      const key = keysA[i] as string
+      if (!Object.hasOwn(objB, key)) return false
+      const va = objA[key]
+      const vb = objB[key]
+      if (va === vb) continue
+      if (
+        va === null ||
+        vb === null ||
+        typeof va !== 'object' ||
+        typeof vb !== 'object'
+      ) {
+        return false
+      }
+      stackA.push(va as object)
+      stackB.push(vb as object)
     }
   }
+
   return true
 }

--- a/src/utils/metadataDiff/deepEqualJson.ts
+++ b/src/utils/metadataDiff/deepEqualJson.ts
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Recursive structural equality for plain JSON-like values produced by
+ * txml + txmlAdapter (primitives, plain objects, arrays). Order-sensitive
+ * for arrays. Replaces the narrow surface of `fast-equals.deepEqual` that
+ * SGD actually used in StreamingDiff.
+ *
+ * Out of scope (txml never emits these): Date, RegExp, Map, Set, Symbol,
+ * Function, circular references, NaN. Falls back to `===` for any
+ * non-plain-object value.
+ */
+export const deepEqualJson = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true
+  if (typeof a !== 'object' || a === null) return false
+  if (typeof b !== 'object' || b === null) return false
+  const aIsArray = Array.isArray(a)
+  const bIsArray = Array.isArray(b)
+  if (aIsArray !== bIsArray) return false
+  if (aIsArray && bIsArray) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqualJson(a[i], b[i])) return false
+    }
+    return true
+  }
+  const keysA = Object.keys(a)
+  const keysB = Object.keys(b)
+  if (keysA.length !== keysB.length) return false
+  for (const key of keysA) {
+    if (
+      !Object.hasOwn(b, key) ||
+      !deepEqualJson(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key]
+      )
+    ) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/utils/metadataDiff/streamingDiff.ts
+++ b/src/utils/metadataDiff/streamingDiff.ts
@@ -1,11 +1,10 @@
 'use strict'
 import type { Writable } from 'node:stream'
 
-import { deepEqual } from 'fast-equals'
-
 import type { ManifestElement } from '../../types/handlerResult.js'
 import type { SharedFileMetadata } from '../../types/metadata.js'
 import type { XmlContent } from '../xmlHelper.js'
+import { deepEqualJson } from './deepEqualJson.js'
 import type { RootCapture, SubTypeElementHandler } from './xmlEventReader.js'
 import { writeXmlDocument } from './xmlWriter.js'
 
@@ -227,7 +226,7 @@ export class StreamingDiff {
       return
     }
     fromMap.delete(key)
-    if (deepEqual(fromElem, element)) return
+    if (deepEqualJson(fromElem, element)) return
     this.recordModified(subType, key)
     this.retainSubTypeElement(subType, element)
   }
@@ -273,7 +272,7 @@ export class StreamingDiff {
     for (const [subType, toArr] of this.passTwo.toArrays.entries()) {
       // Stryker disable next-line ArrayDeclaration -- equivalent: an injected default never matches a real toArr in deepEqual, so the change-detected outcome is identical
       const fromArr = this.passOne.fromArrays.get(subType) ?? []
-      if (!deepEqual(fromArr, toArr)) {
+      if (!deepEqualJson(fromArr, toArr)) {
         this.hasAnyChanges = true
         this.hasSurvivingChange = true
         // Stryker disable next-line ConditionalExpression -- equivalent: dropping the generateDelta guard only fills prunedBySubType under generateDelta=false, which is unobservable (buildWriter gates on generateDelta first)
@@ -307,7 +306,7 @@ export class StreamingDiff {
       // Stryker disable next-line ArrayDeclaration -- equivalent: an injected default never matches a real toArr in the changed/deepEqual computation, so the outcome is identical
       const fromArr = this.passOne.fromKeyless.get(subType) ?? []
       // Stryker disable next-line ConditionalExpression -- killable in principle: forcing changed=false makes hasAnyChanges stay false and the writer short-circuits, leaving produced output empty (covered by the "drainKeyless deepEqual false path" test). The mutant is reported survived likely due to a stryker/vitest perTest analysis quirk; manual mutation simulation confirms the test fails under it.
-      const changed = fromArr.length === 0 || !deepEqual(fromArr, toArr)
+      const changed = fromArr.length === 0 || !deepEqualJson(fromArr, toArr)
       if (changed) this.hasAnyChanges = true
       // Legacy JsonTransformer retains keyless content unconditionally when
       // toMeta is non-empty (matches getPartialContentWithoutKey). Keep that
@@ -331,7 +330,7 @@ export class StreamingDiff {
       // Stryker disable next-line ArrayDeclaration -- equivalent: an injected default never matches a real toArr in the changed/deepEqual computation, so the outcome is identical
       const fromArr = this.passOne.fromUnknown.get(subType) ?? []
       // Stryker disable next-line ConditionalExpression -- killable in principle: forcing changed=false makes hasAnyChanges stay false and the writer short-circuits, leaving produced output empty (covered by the "drainUnknown deepEqual false" test). The mutant is reported survived likely due to a stryker/vitest perTest analysis quirk; manual mutation simulation confirms the test fails under it.
-      const changed = fromArr.length === 0 || !deepEqual(fromArr, toArr)
+      const changed = fromArr.length === 0 || !deepEqualJson(fromArr, toArr)
       if (changed) this.hasAnyChanges = true
       /* v8 ignore start -- defensive: passTwo.toUnknown entries are populated only via appendBounded which always pushes at least one element, so toArr.length === 0 is unreachable */
       // Stryker disable next-line ConditionalExpression,EqualityOperator


### PR DESCRIPTION
## Explain your changes

\`fast-equals\` was used for exactly one function — \`deepEqual\` — at 4 call sites in \`src/utils/metadataDiff/streamingDiff.ts\` against a narrow input shape (parsed XML from txml: plain objects, arrays, primitives). This PR replaces it with a small in-house \`deepEqualJson\` helper.

\`\`\`typescript
export const deepEqualJson = (a: unknown, b: unknown): boolean => {
  if (a === b) return true
  if (typeof a !== 'object' || a === null) return false
  if (typeof b !== 'object' || b === null) return false
  if (Array.isArray(a) !== Array.isArray(b)) return false
  if (Array.isArray(a) && Array.isArray(b)) {
    if (a.length !== b.length) return false
    for (let i = 0; i < a.length; i++) {
      if (!deepEqualJson(a[i], b[i])) return false
    }
    return true
  }
  const keysA = Object.keys(a)
  const keysB = Object.keys(b)
  if (keysA.length !== keysB.length) return false
  for (const key of keysA) {
    if (
      !Object.hasOwn(b, key) ||
      !deepEqualJson(
        (a as Record<string, unknown>)[key],
        (b as Record<string, unknown>)[key]
      )
    ) {
      return false
    }
  }
  return true
}
\`\`\`

**Why**:

1. Defence against bad transitive publishes — same class of risk as #1308. For one function with a bounded input shape, owning ~25 LOC is the better trade.
2. Bundle save — \`fast-equals\` is ~103 KB unpacked.
3. Hexagonal consistency — XML-comparison logic lives in \`src/utils/metadataDiff/\`; the comparator is now a sibling.

**Input shape constraints** (why ~25 LOC suffices):

The values flowing through these comparisons are produced by txml + txmlAdapter — plain JSON-like data. They never contain \`Date\`, \`RegExp\`, \`Map\`, \`Set\`, \`Symbol\`, \`Function\`, circular references, or \`NaN\`. The narrow contract is documented in the design doc and the JSDoc on \`deepEqualJson\`.

**Migration**: 4 call sites in one file. \`streamingDiff.test.ts\` does not mock fast-equals — it asserts on observable diff outputs against real values, so the migration is invisible to those 161 tests.

## Does this close any currently open issues?

---

Continues #1308 (defence-in-depth). Chain: PR 1 (\`async\` ✓), PR 2 (\`simple-git\` ✓), PR 4 (\`fs-extra\` ✓), **this is PR 5**.

- [x] Vitest tests added — 34 cases for \`deepEqualJson\` (primitives, references, arrays, nested objects, hasOwn immunity to prototype walking)
- [ ] NUT tests added — N/A (no behavioural change)
- [ ] E2E tests added — N/A (e2e byte-equal validation passes unchanged)

## Any particular element that can be tested locally

---

\`\`\`bash
# Helper tests
npx vitest run __tests__/unit/lib/utils/metadataDiff/deepEqualJson.test.ts

# Diff-engine tests (verifies migration kept parity)
npx vitest run __tests__/unit/lib/utils/metadataDiff/

# Full unit suite (1365 tests)
npm run test:unit

# Verify the dep is gone
grep -rn \"from 'fast-equals'\" src/ __tests__/   # empty
npm ls fast-equals                                 # empty
\`\`\`

## Any other comments

---

**Validation performed locally**:

- \`npm run lint:fix\` — clean
- \`npm test\` (lint + unit + integration + nut + functional) — green (1365 unit tests)
- \`npm run test:perf\` — pipeline benches flat (e.g. \`pipeline-large-tree-scope\` ~3.8k ops/sec)
- \`npm pack\` — builds
- \`npx tsc --noEmit\` — clean
- e2e local + validate (against worktree binary) — **byte-equal ✅**
- typescript-reviewer agent — PASS, no blocking issues; one minor coverage suggestion (prototype-pollution immunity) addressed by the added test

**Chain status**:

\`\`\`
main
 └── PR 1 ✓ merged (#1309) — drop async
      └── PR 2 ✓ merged (#1310) — drop simple-git
           └── PR 4 ✓ merged (#1311) — drop fs-extra
                └── PR 5 ← this PR — replace fast-equals
                     └── PR 6: drop tslib (importHelpers: false)
                          └── PR 3: pin remaining direct deps to exact versions
\`\`\`

**Stats**: 5 files changed, +212 / −17 lines.