### PR TITLE
build: drop tslib by inlining TS helpers (importHelpers: false)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@salesforce/source-deploy-retrieve": "^12.35.10",
         "ignore": "^7.0.5",
         "tar-stream": "3.2.0",
-        "tslib": "^2.8.1",
         "txml": "^6.0.0",
         "zod": "^4.4.3"
       },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@salesforce/source-deploy-retrieve": "^12.35.10",
     "ignore": "^7.0.5",
     "tar-stream": "3.2.0",
-    "tslib": "^2.8.1",
     "txml": "^6.0.0",
     "zod": "^4.4.3"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "exactOptionalPropertyTypes": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "noImplicitAny": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Explain your changes

Flips \`importHelpers: false\` in \`tsconfig.json\` and removes \`tslib\` from \`dependencies\`. TypeScript now inlines the single helper SGD's compiled output uses (\`__decorate\`, for the \`@log\` decorator) instead of importing it from \`tslib\`.

**Why this works for SGD specifically**:

The project targets **ES2022** (inherited from \`@salesforce/dev-config/tsconfig-esm\`). At this target, async/await, classes, spread/rest, and most modern features are native — no helpers needed. The only TS-emitted helper across the entire compiled \`lib/\` is \`__decorate\`, used in **18 files** for the cross-cutting \`@log\` decorator.

Each of those 18 files now starts with a ~10-line inlined helper instead of \`import { __decorate } from \"tslib\"\`. The helper is byte-identical to tslib's implementation (TypeScript copies it from tslib's source), so behaviour is unchanged.

**Why**:

1. Defence against bad transitive publishes — same class of risk as #1308. tslib is Microsoft-owned so low practical risk, but minimising the direct-dep surface is the principle.
2. Closes the dep-removal chain — last "trivial-to-replace" direct dep before the final pin-exact-versions PR (#3).

## Does this close any currently open issues?

---

Continues #1308 (defence-in-depth). Chain so far: PR 1 (\`async\` ✓), PR 2 (\`simple-git\` ✓), PR 4 (\`fs-extra\` ✓), PR 5 (\`fast-equals\` ✓), **this is PR 6**.

- [x] Vitest tests — N/A, no code changes; the build behaviour change is transparent at the runtime level. Existing 1365 unit + 13 functional + 307 integration + nut tests validate behavioural parity.
- [ ] NUT tests added — N/A
- [ ] E2E tests added — N/A

## Any particular element that can be tested locally

---

\`\`\`bash
# Verify the dep is gone
grep \"from \\\"tslib\\\"\" lib/**/*.js   # empty after build
grep tslib package.json                # empty

# Confirm helper is now inlined
head -8 lib/adapter/GitAdapter.js      # starts with: var __decorate = ...
\`\`\`

## Any other comments

---

**Measurements (before → after)**:

| Metric | Before | After | Delta |
| --- | --- | --- | --- |
| \`lib/\` total JS size | ~328 KB | ~341 KB | +13 KB (~6 KB inline × 18 files, less dedup) |
| Published tarball (gzipped) | 155.8 KB | 156.9 KB | **+1.1 KB** (gzip dedupes identical helpers) |
| Files importing tslib | 18 | 0 | −18 |
| \`tslib\` as direct dep | yes | gone | −1 |

Gzip dedupes the 18 identical helper bodies, so the wire-size cost is just **+1.1 KB** for a clean dep removal.

**Caveat**: \`tslib\` is still pulled into \`node_modules\` transitively via \`@salesforce/core → change-case → camel-case\`. SGD source no longer couples to it directly, which is the goal.

**Validation performed locally**:

- \`npm run lint:fix\` — clean
- \`npm test\` (lint + unit + integration + nut + functional) — green (1365 unit tests)
- \`npm run test:perf\` — pipeline benches flat
- \`npm pack\` — builds at 156.9 KB
- \`npx tsc --noEmit\` — clean
- e2e local + validate against worktree binary — **byte-equal ✅**

**Chain status**:

\`\`\`
main
 └── PR 1 ✓ merged (#1309) — drop async
      └── PR 2 ✓ merged (#1310) — drop simple-git
           └── PR 4 ✓ merged (#1311) — drop fs-extra
                └── PR 5 ✓ merged (#1312) — drop fast-equals
                     └── PR 6 ← this PR — drop tslib
                          └── PR 3: pin remaining direct deps to exact versions (final)
\`\`\`

**Stats**: 3 files changed, +1 / −3 lines.