### PR TITLE
fix: degrade gracefully when latest API version lookup is unreachable

### DIFF
--- a/.github/linters/.cspell.json
+++ b/.github/linters/.cspell.json
@@ -12,6 +12,8 @@
     "noConfigSearch": true,
     "version": "0.2",
     "words": [
+        "appexchange",
+        "firewalled",
         "\u00c0gain",
         "afile",
         "Backpressure",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -33,7 +33,7 @@ Validates and normalizes user inputs:
 
 - Resolves symbolic git refs (`HEAD`, branch names) to full SHA via `git rev-parse`
 - Validates that `from` and `to` SHAs exist in the repository
-- Defaults `apiVersion` from `sfdx-project.json` or the latest SDR version; caps at the max supported version
+- Defaults `apiVersion` from `sfdx-project.json` or the latest SDR version; caps at the max supported version. The latest-version lookup is a live call to the appexchange org: when it is unreachable (offline/firewalled) a provided `apiVersion` is kept as-is, otherwise a `ConfigError` advises supplying one
 - Sanitizes file paths (output dir, source dirs, ignore files)
 
 Fatal errors (`ConfigError`) at this stage abort the pipeline entirely. This is one of only two places where exceptions propagate to the CLI layer.

--- a/__tests__/unit/lib/utils/configValidator.test.ts
+++ b/__tests__/unit/lib/utils/configValidator.test.ts
@@ -5,6 +5,7 @@ import { SDRMetadataAdapter } from '../../../../src/metadata/sdrMetadataAdapter'
 import type { Work } from '../../../../src/types/work'
 import ConfigValidator from '../../../../src/utils/configValidator'
 import { pathExists, sanitizePath } from '../../../../src/utils/fsUtils'
+import { Logger } from '../../../../src/utils/LoggingService'
 import { getWork } from '../../../__utils__/testWork'
 
 const {
@@ -427,6 +428,70 @@ describe('Given a ConfigValidator', () => {
       })
     })
 
+    describe('when the latest version lookup fails (e.g. offline)', () => {
+      beforeEach(() => {
+        vi.spyOn(SDRMetadataAdapter, 'getLatestApiVersion').mockRejectedValue(
+          new Error(
+            'Unable to get a current API version from the appexchange org'
+          )
+        )
+      })
+
+      describe('when apiVersion is provided', () => {
+        it('When the lookup fails, Then the provided apiVersion is kept without warning', async () => {
+          // Arrange
+          work.config.apiVersion = 46
+          const sut = new ConfigValidator(work)
+
+          // Act
+          await sut['_handleDefault']()
+
+          // Assert
+          expect(work.config.apiVersion).toEqual(46)
+          expect(work.warnings).toHaveLength(0)
+        })
+      })
+
+      describe('when apiVersion is not resolvable', () => {
+        it('When the lookup fails and no version is available, Then it throws an actionable ConfigError', async () => {
+          // Arrange
+          mockSfProjectResolve.mockRejectedValue(
+            new Error('No sfdx-project.json found')
+          )
+          work.config.apiVersion = undefined
+          const sut = new ConfigValidator(work)
+
+          // Act & Assert
+          await expect(sut['_handleDefault']()).rejects.toThrow(
+            expect.objectContaining({
+              name: 'ConfigError',
+              message: expect.stringContaining(
+                'error.ApiVersionRetrievalFailed:Unable to get a current API version from the appexchange org'
+              ),
+            })
+          )
+        })
+      })
+
+      describe('when apiVersion is NaN', () => {
+        it('When the lookup fails and apiVersion is NaN, Then it throws an actionable ConfigError', async () => {
+          // Arrange
+          work.config.apiVersion = NaN
+          const sut = new ConfigValidator(work)
+
+          // Act & Assert
+          await expect(sut['_handleDefault']()).rejects.toThrow(
+            expect.objectContaining({
+              name: 'ConfigError',
+              message: expect.stringContaining(
+                'error.ApiVersionRetrievalFailed'
+              ),
+            })
+          )
+        })
+      })
+    })
+
     describe('when apiVersion equals the latest supported version', () => {
       it('When apiVersion equals latestVersion, Then no warning and no override', async () => {
         // Arrange
@@ -495,6 +560,23 @@ describe('Given a ConfigValidator', () => {
         expect(work.warnings[0].message).toContain(
           'warning.ApiVersionDefaulted'
         )
+      })
+    })
+
+    describe('_getApiVersion diagnostic logging', () => {
+      it('When sfdx-project.json resolution fails, Then the failure is logged for diagnostics', async () => {
+        // Arrange
+        mockSfProjectResolve.mockRejectedValue(
+          new Error('No sfdx-project.json found')
+        )
+        work.config.apiVersion = undefined
+        const sut = new ConfigValidator(work)
+
+        // Act
+        await sut['_getApiVersion']()
+
+        // Assert
+        expect(Logger.debug).toHaveBeenCalledOnce()
       })
     })
 

--- a/messages/delta.md
+++ b/messages/delta.md
@@ -104,6 +104,10 @@ API version '%s' is not supported, using '%s' instead
 
 No API version found (no --api-version flag, no sourceApiVersion in sfdx-project.json), using '%s'
 
+# error.ApiVersionRetrievalFailed
+
+Unable to resolve the Salesforce API version. Provide one with --api-version, or set "sourceApiVersion" in sfdx-project.json. Caused by: %s
+
 # warning.MalformedXML
 
 could not process '%s', please ensure it is properly formatted xml in both '%s' and '%s' revision

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "4.11.4",
         "@salesforce/core": "8.31.0",
         "@salesforce/sf-plugins-core": "12.2.22",
-        "@salesforce/source-deploy-retrieve": "12.35.10",
+        "@salesforce/source-deploy-retrieve": "12.36.0",
         "ignore": "7.0.5",
         "tar-stream": "3.2.0",
         "txml": "6.0.0",
@@ -5687,12 +5687,12 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "12.35.10",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.35.10.tgz",
-      "integrity": "sha512-njg3pt0aqwUF5xCleO6wMN45+AIbhpG9xOExWz3io+Qy2uWW75WoHdcj3ZTZFLKqyHBc2NNSfDJc+QYEnJccGg==",
+      "version": "12.36.0",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.0.tgz",
+      "integrity": "sha512-8oy70UqBh6eDfN+AXO31NtGrF+Dpy8JG3BqXTctghVfd5Y/vGjFcrectih3WbtXj9e7WNrrvSdsRJ6aD/sGqmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.30.3",
+        "@salesforce/core": "^8.31.0",
         "@salesforce/kit": "^3.2.4",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/types": "^1.6.0",
@@ -5748,28 +5748,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/fast-xml-parser": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
-      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.2.0",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.3.0",
-        "xml-naming": "^0.1.0"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve/node_modules/get-stream": {
@@ -8823,7 +8801,6 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@oclif/core": "4.11.4",
     "@salesforce/core": "8.31.0",
     "@salesforce/sf-plugins-core": "12.2.22",
-    "@salesforce/source-deploy-retrieve": "12.35.10",
+    "@salesforce/source-deploy-retrieve": "12.36.0",
     "ignore": "7.0.5",
     "tar-stream": "3.2.0",
     "txml": "6.0.0",

--- a/src/utils/configValidator.ts
+++ b/src/utils/configValidator.ts
@@ -134,7 +134,6 @@ export default class ConfigValidator {
         this.config.apiVersion = parseInt(projectApiVersion, 10)
       }
     } catch (ex) {
-      // Stryker disable next-line BlockStatement -- equivalent: catch body is observability-only; emptying the body skips the log call but apiVersion remains undefined either way
       Logger.debug(
         // Stryker disable next-line StringLiteral -- equivalent: lazy log content is observability only
         lazy`_getApiVersion: no sfdx-project.json found at '${this.config.repo}': ${ex}`
@@ -143,7 +142,9 @@ export default class ConfigValidator {
   }
 
   protected async _apiVersionDefault() {
-    const latestVersion = await getLatestSupportedVersion()
+    const latestVersion = await this._resolveLatestSupportedVersion()
+    // Stryker disable next-line ConditionalExpression -- equivalent: undefined signals the lookup failed while a usable apiVersion is already set; flipping the guard would fall through to clamp against an undefined ceiling, which the offline test surface forbids
+    if (latestVersion === undefined) return
 
     // Stryker disable ConditionalExpression,LogicalOperator -- equivalent: this triple-AND gate ensures we only override a numeric, defined, above-latest apiVersion; flipping individual conditions to true falls into the override branch when apiVersion is undefined or NaN, but the second `if (apiVersion === undefined || isNaN())` block immediately resets to latestVersion, producing the same observable apiVersion in both arms (only the warning content differs, which the test surface doesn't disambiguate)
     if (
@@ -172,6 +173,35 @@ export default class ConfigValidator {
             String(latestVersion),
           ])
         )
+      )
+    }
+  }
+
+  // Resolves the latest supported API version, falling back gracefully when the
+  // appexchange lookup is unreachable (offline/firewalled environments).
+  protected async _resolveLatestSupportedVersion(): Promise<
+    number | undefined
+  > {
+    try {
+      return await getLatestSupportedVersion()
+    } catch (ex) {
+      // A usable apiVersion is already set: keep it, we just can't cap it.
+      // Stryker disable ConditionalExpression -- equivalent: the '!== undefined' clause exists only for TS narrowing (isNaN requires a number); !isNaN already returns false for both undefined and NaN, so replacing the left operand with true preserves behavior for every reachable apiVersion
+      if (
+        this.config.apiVersion !== undefined &&
+        !isNaN(this.config.apiVersion)
+      ) {
+        // Stryker restore ConditionalExpression
+        Logger.debug(
+          // Stryker disable next-line StringLiteral -- equivalent: lazy log content is observability only
+          lazy`_resolveLatestSupportedVersion: keeping provided apiVersion, latest version lookup failed: ${ex}`
+        )
+        return undefined
+      }
+      throw new ConfigError(
+        this.message.getMessage('error.ApiVersionRetrievalFailed', [
+          getErrorMessage(ex),
+        ])
       )
     }
   }


### PR DESCRIPTION
## Explain your changes

---

When SGD needs to resolve the latest Salesforce API version, it calls SDR's `getCurrentApiVersion()`, which performs a **live HTTP request** to `appexchange.salesforce.com`. In offline / firewalled / restricted-CI environments that request throws `Unable to get a current API version from the appexchange org`, and `ConfigValidator._apiVersionDefault()` called it **unconditionally** — so the whole `sf sgd source delta` command aborted, even when the user had already supplied a version via `--api-version` or `sourceApiVersion`.

This PR makes API-version resolution resilient:

- The latest-version lookup is now isolated in `_resolveLatestSupportedVersion()`.
- **Lookup succeeds** → unchanged clamp/default behavior.
- **Lookup fails but a usable `apiVersion` is already set** (`--api-version` flag or `sourceApiVersion` in `sfdx-project.json`) → the provided version is kept as-is (logged at debug); the command proceeds offline.
- **Lookup fails and no version is available** → a clear, actionable `ConfigError` (`error.ApiVersionRetrievalFailed`) is thrown, advising the user to pass `--api-version` or set `sourceApiVersion`, instead of surfacing the cryptic SDR network error.

Also (boy-scout): killed a long-standing surviving mutant in `_getApiVersion` by asserting its diagnostic log fires on `sfdx-project.json` resolution failure, and removed a misplaced Stryker suppression. `configValidator.ts` mutation score is now 100%.

## Does this close any currently open issues?

---

closes #1317

- [x] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

## Any particular element that can be tested locally

---

Run the command in an environment with no network access to `appexchange.salesforce.com`:

```
sf sgd source delta --output-dir changed-sources --generate-delta --from HEAD~1 --to HEAD
```

- With `--api-version 60` (or `sourceApiVersion` set in `sfdx-project.json`) → the delta is generated using that version.
- With no version available → fails fast with an actionable error rather than the raw appexchange network error.

## Any other comments

---

`getCoverage()` (the other network-dependent SDR helper) was reviewed and is **not** reachable from the delta run — SGD only imports `getCurrentApiVersion` and the static `registry` object. No behavior change there.
