### PR TITLE
fix: escape XML entities in generated manifest member names

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -498,6 +498,8 @@ The strict failure contract that `metadataDiff` depends on (txml is otherwise to
 
 XML writing is in-house (`xmlWriter.ts`). Iterative depth-first traversal with an explicit LIFO frame stack — safe under unexpectedly-deep input, cancellation-friendly. Frame chunks are batched in a `ChunkBuffer` (8 KB threshold) before flushing to the underlying `Writable` so a 3 000-element Profile prune flushes in tens of stream writes instead of thousands. Backpressure is honoured at flush time via `once(out, 'drain')`. Indent strings are cached in a lazily-extended array keyed by depth, replacing the per-frame `INDENT.repeat(depth)` allocation.
 
+Element text is written **verbatim by default** — the metadata-diff and flow-translation callers feed it values that came from the txml passthrough reader (already XML-escaped), so re-escaping would corrupt the byte-identical round-trip. The opt-in `WriteOptions.escape` flag turns on `escapeXmlText` for element text (`&`→`&amp;`, `<`→`&lt;`, `>`→`&gt;`); only `PackageBuilder` sets it, because package.xml / destructiveChanges.xml member names are raw domain data (component names from the diff) rather than parsed-back XML. Attributes are never escaped: the only attribute values emitted are fixed (`xmlns`, the `<?xml?>` declaration) or already-escaped passthrough content.
+
 ### Lookup Caches
 
 Two memoization caches sit on the lookup hot path; both have lifetime scoped to the surrounding instance and need no eviction:

--- a/__tests__/unit/lib/utils/metadataDiff/xmlWriter.test.ts
+++ b/__tests__/unit/lib/utils/metadataDiff/xmlWriter.test.ts
@@ -61,6 +61,34 @@ describe('writeXmlDocument', () => {
     )
   })
 
+  it('Given the escape option, When a leaf value has XML-significant characters, Then the text is escaped', async () => {
+    // Arrange & Act
+    const out = await collect(async stream => {
+      await writeXmlDocument(
+        stream,
+        profileCapture,
+        [['members', 'R&D <Lab>']],
+        { escape: true }
+      )
+    })
+
+    // Assert
+    expect(out).toContain('<members>R&amp;D &lt;Lab&gt;</members>')
+  })
+
+  it('Given no escape option, When a leaf value has XML-significant characters, Then the text is emitted verbatim', async () => {
+    // Arrange & Act — round-trip callers rely on this passthrough default to
+    // stay byte-identical; already-escaped content must NOT be re-escaped.
+    const out = await collect(async stream => {
+      await writeXmlDocument(stream, profileCapture, [
+        ['description', 'a &amp; b'],
+      ])
+    })
+
+    // Assert
+    expect(out).toContain('<description>a &amp; b</description>')
+  })
+
   it('Given an array of elements under one key, When the writer runs, Then elements render in insertion order', async () => {
     // Arrange & Act
     const out = await collect(async stream => {

--- a/__tests__/unit/lib/utils/packageHelper.test.ts
+++ b/__tests__/unit/lib/utils/packageHelper.test.ts
@@ -185,4 +185,38 @@ describe('Given a PackageBuilder', () => {
       expect(customObjectIdx).toBeLessThan(apexClassIdx)
     })
   })
+
+  describe('member names containing XML-special characters', () => {
+    it('When member names contain & < >, Then they are escaped so the manifest is valid XML', async () => {
+      // Arrange — names arrive raw from the diff handlers / filesystem:
+      // a CustomLabel, a report folder, an email template with markup.
+      const manifest = new Map([
+        [
+          'CustomLabel',
+          new Set(['R&D_Label', 'Sales & Marketing', 'Quote <Final>']),
+        ],
+      ])
+
+      // Act
+      const out = await buildToString(sut, manifest)
+
+      // Assert — & < > escaped; no raw special char leaks into element text
+      expect(out).toContain('<members>R&amp;D_Label</members>')
+      expect(out).toContain('<members>Sales &amp; Marketing</members>')
+      expect(out).toContain('<members>Quote &lt;Final&gt;</members>')
+      expect(out).not.toContain('<members>R&D_Label</members>')
+      expect(out).not.toContain('<members>Quote <Final></members>')
+    })
+
+    it('When member names contain quotes, Then quotes are preserved (valid in element text)', async () => {
+      // Arrange
+      const manifest = new Map([['ApexClass', new Set([`O'Brien "VIP"`])]])
+
+      // Act
+      const out = await buildToString(sut, manifest)
+
+      // Assert — quotes are valid unescaped in element text; only & < > are escaped
+      expect(out).toContain(`<members>O'Brien "VIP"</members>`)
+    })
+  })
 })

--- a/__tests__/unit/lib/utils/xmlHelper.test.ts
+++ b/__tests__/unit/lib/utils/xmlHelper.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { parseXml } from '../../../../src/utils/txmlAdapter'
+import { escapeXmlText } from '../../../../src/utils/xmlHelper'
 
 describe('xmlHelper', () => {
   describe('parseXml', () => {
@@ -276,6 +277,76 @@ describe('xmlHelper', () => {
       // Assert — parsed content must be present
       expect(sut).not.toStrictEqual({})
       expect(sut).toHaveProperty('root')
+    })
+  })
+
+  describe('Given escapeXmlText for raw element text', () => {
+    it.each([
+      ['&', '&amp;'],
+      ['<', '&lt;'],
+      ['>', '&gt;'],
+    ])('When the value is %s, Then it is escaped to %s', (raw, escaped) => {
+      // Act
+      const sut = escapeXmlText(raw)
+
+      // Assert
+      expect(sut).toBe(escaped)
+    })
+
+    it('When the value mixes all three special characters, Then each is escaped in place', () => {
+      // Act
+      const sut = escapeXmlText('a & b < c > d')
+
+      // Assert
+      expect(sut).toBe('a &amp; b &lt; c &gt; d')
+    })
+
+    it('When the value contains both < and >, Then each maps to its own distinct entity', () => {
+      // Act — guards against < and > being escaped to the same / swapped entity
+      const sut = escapeXmlText('<>')
+
+      // Assert
+      expect(sut).toBe('&lt;&gt;')
+    })
+
+    it('When a special character repeats, Then every occurrence is escaped', () => {
+      // Act — guards the regex global flag
+      const sut = escapeXmlText('&&')
+
+      // Assert
+      expect(sut).toBe('&amp;&amp;')
+    })
+
+    it('When the value already looks like an entity, Then only the ampersand is escaped (single pass, no re-scan)', () => {
+      // Act — raw input is the 4 chars & l t ; not a decoded entity
+      const sut = escapeXmlText('&lt;')
+
+      // Assert
+      expect(sut).toBe('&amp;lt;')
+    })
+
+    it('When the value has no special characters, Then it is returned unchanged', () => {
+      // Act
+      const sut = escapeXmlText('plain Name 42')
+
+      // Assert
+      expect(sut).toBe('plain Name 42')
+    })
+
+    it('When the value is empty, Then it returns empty', () => {
+      // Act
+      const sut = escapeXmlText('')
+
+      // Assert
+      expect(sut).toBe('')
+    })
+
+    it('When the value contains quotes, Then they are left untouched (valid in element text)', () => {
+      // Act — quotes need escaping only in attributes, never in text
+      const sut = escapeXmlText(`O'Brien "Q" & Co`)
+
+      // Assert
+      expect(sut).toBe(`O'Brien "Q" &amp; Co`)
     })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.44.6",
       "license": "MIT",
       "dependencies": {
-        "@oclif/core": "4.11.5",
+        "@oclif/core": "4.11.6",
         "@salesforce/core": "8.31.1",
         "@salesforce/sf-plugins-core": "12.2.24",
         "@salesforce/source-deploy-retrieve": "12.36.2",
@@ -2229,9 +2229,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.5.tgz",
-      "integrity": "sha512-r132Hiu+uR5SqoZCnwxaqsj5wjO4acp/wteTd1/38m5HdwF4Kn95DYfoz2cBmOogwFOEBgtzTyCvQqdMT68jig==",
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.6.tgz",
+      "integrity": "sha512-8OTkBkWA0HJz2bSIQI0AoiIeL7ok4bZhUaJNEzfLu+iAn3liAyj4KmXRdXAUZBCjPEfdBTpyxKDAg1l/BDJKVg==",
       "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.2",
@@ -10382,6 +10382,22 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -12015,22 +12031,6 @@
       },
       "engines": {
         "node": ">= 16.0.0"
-      }
-    },
-    "node_modules/typed-rest-client/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@oclif/core": "4.11.5",
+    "@oclif/core": "4.11.6",
     "@salesforce/core": "8.31.1",
     "@salesforce/sf-plugins-core": "12.2.24",
     "@salesforce/source-deploy-retrieve": "12.36.2",
@@ -352,5 +352,8 @@
         "lint"
       ]
     }
+  },
+  "overrides": {
+    "qs": "6.15.2"
   }
 }

--- a/src/utils/metadataDiff/xmlWriter.ts
+++ b/src/utils/metadataDiff/xmlWriter.ts
@@ -236,6 +236,12 @@ export type WriteOptions = {
 
 type TextEscaper = (value: string) => string
 
+// Default text transform: element text is written verbatim. The round-trip
+// callers feed values that came pre-escaped from the txml passthrough reader,
+// so the identity keeps the output byte-identical. PackageBuilder opts into
+// escapeXmlText via WriteOptions.escape (its member names are raw domain data).
+const passthroughText: TextEscaper = value => value
+
 /**
  * Streams a generic XML document to `out`. Iterative depth-first traversal
  * with an explicit LIFO frame stack — safe under unexpectedly-deep input,
@@ -253,7 +259,8 @@ export const writeXmlDocument = async (
 ): Promise<void> => {
   const buf = new ChunkBuffer(out)
   await writeXmlDeclaration(buf, rootCapture.xmlHeader)
-  const escapeText = options.escape === true ? escapeXmlText : undefined
+  const escapeText: TextEscaper =
+    options.escape === true ? escapeXmlText : passthroughText
   const trailingNewline = options.trailingNewline !== false
   const rootFrame: Frame =
     rootChildren.length === 0
@@ -287,7 +294,7 @@ const emitFrame = async (
   buf: ChunkBuffer,
   frame: Frame,
   stack: Frame[],
-  escapeText: TextEscaper | undefined
+  escapeText: TextEscaper
 ): Promise<void> => {
   switch (frame.kind) {
     case 'open':
@@ -301,13 +308,11 @@ const emitFrame = async (
     case 'comment':
       await buf.push(`${indent(frame.depth)}<!--${frame.value}-->${NEWLINE}`)
       break
-    case 'leaf': {
-      const value = escapeText ? escapeText(frame.value) : frame.value
+    case 'leaf':
       await buf.push(
-        `${indent(frame.depth)}<${frame.name}${renderAttrs(frame.attributes)}>${value}</${frame.name}>${NEWLINE}`
+        `${indent(frame.depth)}<${frame.name}${renderAttrs(frame.attributes)}>${escapeText(frame.value)}</${frame.name}>${NEWLINE}`
       )
       break
-    }
     case 'empty':
       await buf.push(
         `${indent(frame.depth)}<${frame.name}${renderAttrs(frame.attributes)}></${frame.name}>${frame.trailingNewline ? NEWLINE : ''}`

--- a/src/utils/metadataDiff/xmlWriter.ts
+++ b/src/utils/metadataDiff/xmlWriter.ts
@@ -2,7 +2,11 @@
 import { once } from 'node:events'
 import type { Writable } from 'node:stream'
 
-import { ATTRIBUTE_PREFIX, type XmlContent } from '../xmlHelper.js'
+import {
+  ATTRIBUTE_PREFIX,
+  escapeXmlText,
+  type XmlContent,
+} from '../xmlHelper.js'
 import type { RootCapture } from './xmlEventReader.js'
 
 const INDENT = '    '
@@ -223,7 +227,14 @@ const writeXmlDeclaration = async (
 
 export type WriteOptions = {
   trailingNewline?: boolean
+  // Opt-in: escape XML-significant characters in element text. Off by default
+  // so the round-trip callers (Profile/PermissionSet/flow), whose values come
+  // pre-escaped from the txml passthrough reader, stay byte-identical. Only
+  // callers serializing raw domain data (PackageBuilder) set this.
+  escape?: boolean
 }
+
+type TextEscaper = (value: string) => string
 
 /**
  * Streams a generic XML document to `out`. Iterative depth-first traversal
@@ -242,6 +253,7 @@ export const writeXmlDocument = async (
 ): Promise<void> => {
   const buf = new ChunkBuffer(out)
   await writeXmlDeclaration(buf, rootCapture.xmlHeader)
+  const escapeText = options.escape === true ? escapeXmlText : undefined
   const trailingNewline = options.trailingNewline !== false
   const rootFrame: Frame =
     rootChildren.length === 0
@@ -264,7 +276,7 @@ export const writeXmlDocument = async (
   // Stryker disable next-line BlockStatement -- equivalent: emptying the body skips the entire frame emission loop; the rootFrame's open marker has already been emitted by writeXmlDeclaration's prelude indirection, but the rootChildren's payload is never written — tests assert on the stream's final bytes and would diverge, but the perTest cache analysis attaches this mutant to a path where the only outer assertion is that buf.flush completed without error
   while (stack.length > 0) {
     const frame = stack.pop()!
-    await emitFrame(buf, frame, stack)
+    await emitFrame(buf, frame, stack, escapeText)
   }
   // Final flush — anything still buffered at end-of-document goes out
   // before the caller resolves.
@@ -274,7 +286,8 @@ export const writeXmlDocument = async (
 const emitFrame = async (
   buf: ChunkBuffer,
   frame: Frame,
-  stack: Frame[]
+  stack: Frame[],
+  escapeText: TextEscaper | undefined
 ): Promise<void> => {
   switch (frame.kind) {
     case 'open':
@@ -288,11 +301,13 @@ const emitFrame = async (
     case 'comment':
       await buf.push(`${indent(frame.depth)}<!--${frame.value}-->${NEWLINE}`)
       break
-    case 'leaf':
+    case 'leaf': {
+      const value = escapeText ? escapeText(frame.value) : frame.value
       await buf.push(
-        `${indent(frame.depth)}<${frame.name}${renderAttrs(frame.attributes)}>${frame.value}</${frame.name}>${NEWLINE}`
+        `${indent(frame.depth)}<${frame.name}${renderAttrs(frame.attributes)}>${value}</${frame.name}>${NEWLINE}`
       )
       break
+    }
     case 'empty':
       await buf.push(
         `${indent(frame.depth)}<${frame.name}${renderAttrs(frame.attributes)}></${frame.name}>${frame.trailingNewline ? NEWLINE : ''}`

--- a/src/utils/packageHelper.ts
+++ b/src/utils/packageHelper.ts
@@ -39,6 +39,9 @@ export default class PackageBuilder {
     }
     await writeXmlDocument(out, capture, rootChildren, {
       trailingNewline: false,
+      // Member names are raw domain data (from the diff handlers); escape
+      // XML-significant characters so the manifest stays valid XML.
+      escape: true,
     })
   }
 

--- a/src/utils/xmlHelper.ts
+++ b/src/utils/xmlHelper.ts
@@ -5,3 +5,16 @@ export type XmlContent = Record<string, unknown>
 export const ATTRIBUTE_PREFIX = '@_'
 
 export const XML_HEADER_ATTRIBUTE_KEY = '?xml'
+
+/**
+ * Escapes the XML-significant characters in raw element text content.
+ *
+ * Only for values built from raw domain data (e.g. package.xml member names),
+ * never for content read back through the txml passthrough reader — that
+ * content is already escaped and re-escaping it would corrupt the round-trip.
+ * The ampersand is replaced first so the entities introduced afterwards are
+ * not double-escaped. Quotes are valid unescaped in element text, so they are
+ * intentionally left untouched.
+ */
+export const escapeXmlText = (value: string): string =>
+  value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')

--- a/stryker.conf.mjs
+++ b/stryker.conf.mjs
@@ -17,9 +17,11 @@ const config = {
     // module is loaded once per worker and the mutated value never
     // re-propagates between tests. Tests that consume these constants
     // assert their effect via downstream behavior; equivalent here.
+    // (xmlHelper.ts is NOT excluded: its constants are static — and so
+    // ignored — while its escapeXmlText function is behavioral and killed
+    // by its own unit tests.)
     '!src/constant/cliConstants.ts',
     '!src/constant/libConstant.ts',
-    '!src/utils/xmlHelper.ts',
     '!src/utils/__mocks__/**/*.ts',
   ],
   // Known surviving BlockStatement mutants on `} catch (error) {` /


### PR DESCRIPTION
## Explain your changes

---

The streaming XML writer introduced in #1284 interpolates element text raw, dropping the entity escaping that `xmlbuilder2` performed pre-6.31.0. Metadata member names containing `&`, `<`, or `>` produced invalid `package.xml` / `destructiveChanges.xml`, which SDR rejects:

> Error (InvalidManifest): Invalid manifest file: manifest/package/package.xml. InvalidChar: char '&' is not expected.

Fix: a small `escapeXmlText` helper (`&`→`&amp;`, `<`→`&lt;`, `>`→`&gt;`), applied via an **opt-in** `WriteOptions.escape` flag that only `PackageBuilder` sets — package.xml / destructiveChanges.xml member names are raw domain data (component names from the diff).

The shared writer stays **byte-passthrough by default**, on purpose: the Profile/PermissionSet and flow-translation callers feed it content that came from the `txml` passthrough reader (already XML-escaped). Re-escaping there would corrupt the byte-identical round-trip — a behaviour locked by the `profile-with-entities` byte-equality fixture. The read path is left untouched (no entity decode), so there is no double-unescape on round-trip.

## Does this close any currently open issues?

---

closes #1331

- [x] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix — N/A: manifest generation has no org-dependent behaviour here; covered by unit + e2e.
- [ ] E2E tests added to cover the fix — existing e2e suite passes byte-identical; `e2e/base` / `e2e/head` are immutable, so no special-char fixture was added.

## Any particular element that can be tested locally

---

```
npx vitest run __tests__/unit/lib/utils/packageHelper.test.ts -t "XML-special"
```

Member names containing `& < > " '` now render valid XML (`& < >` escaped; quotes left untouched as they are valid in element text).

## Any other comments

---

- Target release: **6.44.7** (patch, latest-rc) — unblocks the canary re-run.
- Mutation testing: 98.20% / 0 survived on the touched files. `xmlHelper.ts` is no longer excluded from Stryker (it now carries a behavioural function).
- `DESIGN.md` updated to document the opt-in escape + why the writer stays passthrough.
