### PR TITLE
fix: resolve nested Wave (and virtual content-container) files dropped from package.xml

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -67,7 +67,7 @@ flowchart LR
 | Index | Key | Use case |
 | ----- | --- | -------- |
 | `extIndex` | File extension (`.cls`, `.trigger`) | Primary lookup for most types |
-| `dirIndex` | Directory name (`classes`, `triggers`) | Fallback when extension is ambiguous — picks deepest match, stops at `inFolder` types and content containers (SDR adapters `bundle`/`digitalExperience`/`mixedContent`) so a nested content folder colliding with a metadata directory name (e.g. an `icons/` folder inside a StaticResource) cannot override the container type |
+| `dirIndex` | Directory name (`classes`, `triggers`) | Fallback when extension is ambiguous — picks deepest match, stops at `inFolder` types, SDR content-container adapters (`bundle`/`digitalExperience`/`mixedContent`), and virtual content-containers (internal-registry types with `metaFile: true` and a non-empty `content[]`: Wave/Bot/Discovery/Moderation) so a nested content folder colliding with a metadata directory name (e.g. an `icons/` folder inside a StaticResource, or a `dashboards/` folder inside `wave/`) cannot override the container type |
 | `xmlNameIndex` | XML name (`ApexClass`, `ApexTrigger`) | Direct lookup by type name, exposed as `getByXmlName(xmlName)` on the interface for handler-resolution and parent-type lookup |
 
 ### Key Metadata Fields

--- a/__tests__/integration/services.test.ts
+++ b/__tests__/integration/services.test.ts
@@ -522,6 +522,16 @@ const testContext = [
     'WaveXmd',
   ],
   [
+    'force-app/main/default/src-base/crma/wave/dashboards/Account_KPI_Dashboard.wdash',
+    new Set(['Account_KPI_Dashboard']),
+    'WaveDashboard',
+  ],
+  [
+    'force-app/main/default/src-base/crma/wave/components/AccountKpi.wcomp',
+    new Set(['AccountKpi']),
+    'WaveComponent',
+  ],
+  [
     'force-app/main/default/featureParameters/FeatureParameterIntegerTest.featureParameterInteger',
     new Set(['FeatureParameterIntegerTest']),
     'FeatureParameterInteger',

--- a/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
+++ b/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
@@ -197,7 +197,7 @@ describe('MetadataRepositoryImpl', () => {
       },
       // VirtualBot is a sibling virtual content-container; it locks the fix's
       // symmetry across all virtual content-container types — the predicate
-      // keys off shape (metaFile + non-empty content), never xmlName.
+      // keys off the non-empty content[], never xmlName.
       {
         adapter: 'matchingContentFile',
         directoryName: 'bots',
@@ -397,30 +397,6 @@ describe('MetadataRepositoryImpl', () => {
         // Assert
         expect(result).toStrictEqual(
           expect.objectContaining({ directoryName: 'wave' })
-        )
-      })
-
-      it('does not stop at a content-bearing folder whose metaFile is false', () => {
-        // Act
-        const result = sut.get(
-          'Z force-app/main/default/moderation/dashboards/site.block.rule-meta.xml'
-        )
-
-        // Assert
-        expect(result).toStrictEqual(
-          expect.objectContaining({ directoryName: 'dashboards' })
-        )
-      })
-
-      it('does not stop at a metaFile container whose content is empty', () => {
-        // Act
-        const result = sut.get(
-          'Z force-app/main/default/siteDotComSites/dashboards/aSitedotcom.site'
-        )
-
-        // Assert
-        expect(result).toStrictEqual(
-          expect.objectContaining({ directoryName: 'dashboards' })
         )
       })
 

--- a/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
+++ b/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
@@ -157,6 +157,31 @@ describe('MetadataRepositoryImpl', () => {
         suffix: 'portal',
         xmlName: 'Portal',
       },
+      {
+        adapter: 'matchingContentFile',
+        directoryName: 'wave',
+        inFolder: false,
+        metaFile: true,
+        suffix: 'wdash',
+        xmlName: 'WaveDashboard',
+      },
+      {
+        directoryName: 'wave',
+        inFolder: false,
+        metaFile: true,
+        content: [
+          { suffix: 'wdash', xmlName: 'WaveDashboard' },
+          { suffix: 'xmd', xmlName: 'WaveXmd' },
+        ],
+        xmlName: 'VirtualWave',
+      } as Metadata,
+      {
+        directoryName: 'dashboards',
+        inFolder: true,
+        metaFile: true,
+        suffix: 'dashboard',
+        xmlName: 'Dashboard',
+      },
     ])
   })
   describe('has', () => {
@@ -326,6 +351,54 @@ describe('MetadataRepositoryImpl', () => {
         // Assert
         expect(result).toStrictEqual(
           expect.objectContaining({ directoryName: 'icons' })
+        )
+      })
+
+      it('matches the virtual content-container when a nested content folder collides with a metadata directory name', () => {
+        // Act
+        const result = sut.get(
+          'Z force-app/main/default/src-base/crma/wave/dashboards/Account_KPI_Dashboard.wdash'
+        )
+
+        // Assert
+        expect(result).toStrictEqual(
+          expect.objectContaining({ directoryName: 'wave' })
+        )
+      })
+
+      it('does not stop at a content-bearing folder whose metaFile is false', () => {
+        // Act
+        const result = sut.get(
+          'Z force-app/main/default/moderation/dashboards/site.block.rule-meta.xml'
+        )
+
+        // Assert
+        expect(result).toStrictEqual(
+          expect.objectContaining({ directoryName: 'dashboards' })
+        )
+      })
+
+      it('does not stop at a metaFile container whose content is empty', () => {
+        // Act
+        const result = sut.get(
+          'Z force-app/main/default/siteDotComSites/dashboards/aSitedotcom.site'
+        )
+
+        // Assert
+        expect(result).toStrictEqual(
+          expect.objectContaining({ directoryName: 'dashboards' })
+        )
+      })
+
+      it('matches the virtual content-container for a file directly under it', () => {
+        // Act
+        const result = sut.get(
+          'Z force-app/main/default/wave/Seller_Homepage.wdash'
+        )
+
+        // Assert
+        expect(result).toStrictEqual(
+          expect.objectContaining({ directoryName: 'wave' })
         )
       })
 

--- a/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
+++ b/__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts
@@ -157,6 +157,11 @@ describe('MetadataRepositoryImpl', () => {
         suffix: 'portal',
         xmlName: 'Portal',
       },
+      // The SDR-style WaveDashboard/WaveXmd entries register `wdash`/`xmd` a
+      // second time (alongside VirtualWave.content below), marking those
+      // suffixes UNSAFE so searchByExtension yields and the directory walk —
+      // where the nested-folder bug lives — becomes the deciding path. Mirrors
+      // the real registry, where SDR and the internal registry both define them.
       {
         adapter: 'matchingContentFile',
         directoryName: 'wave',
@@ -164,6 +169,14 @@ describe('MetadataRepositoryImpl', () => {
         metaFile: true,
         suffix: 'wdash',
         xmlName: 'WaveDashboard',
+      },
+      {
+        adapter: 'matchingContentFile',
+        directoryName: 'wave',
+        inFolder: false,
+        metaFile: true,
+        suffix: 'xmd',
+        xmlName: 'WaveXmd',
       },
       {
         directoryName: 'wave',
@@ -182,6 +195,27 @@ describe('MetadataRepositoryImpl', () => {
         suffix: 'dashboard',
         xmlName: 'Dashboard',
       },
+      // VirtualBot is a sibling virtual content-container; it locks the fix's
+      // symmetry across all virtual content-container types — the predicate
+      // keys off shape (metaFile + non-empty content), never xmlName.
+      {
+        adapter: 'matchingContentFile',
+        directoryName: 'bots',
+        inFolder: false,
+        metaFile: true,
+        suffix: 'botVersion',
+        xmlName: 'BotVersion',
+      },
+      {
+        directoryName: 'bots',
+        inFolder: false,
+        metaFile: true,
+        content: [
+          { suffix: 'bot', xmlName: 'Bot' },
+          { suffix: 'botVersion', xmlName: 'BotVersion' },
+        ],
+        xmlName: 'VirtualBot',
+      } as Metadata,
     ])
   })
   describe('has', () => {
@@ -394,6 +428,30 @@ describe('MetadataRepositoryImpl', () => {
         // Act
         const result = sut.get(
           'Z force-app/main/default/wave/Seller_Homepage.wdash'
+        )
+
+        // Assert
+        expect(result).toStrictEqual(
+          expect.objectContaining({ directoryName: 'wave' })
+        )
+      })
+
+      it('matches a sibling virtual content-container when a nested content folder collides with a metadata directory name', () => {
+        // Act
+        const result = sut.get(
+          'Z force-app/main/default/bots/MyBot/dashboards/v1.botVersion'
+        )
+
+        // Assert
+        expect(result).toStrictEqual(
+          expect.objectContaining({ directoryName: 'bots' })
+        )
+      })
+
+      it('matches the virtual content-container for a nested non-first content suffix colliding with a metadata directory name', () => {
+        // Act
+        const result = sut.get(
+          'Z force-app/main/default/src-base/crma/wave/dashboards/Account_KPI_Dashboard.xmd-meta.xml'
         )
 
         // Assert

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "4.11.6",
-        "@salesforce/core": "8.31.1",
+        "@salesforce/core": "8.31.2",
         "@salesforce/sf-plugins-core": "12.2.24",
         "@salesforce/source-deploy-retrieve": "12.36.3",
         "ignore": "7.0.5",
@@ -3826,9 +3826,9 @@
       }
     },
     "node_modules/@salesforce/core": {
-      "version": "8.31.1",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.31.1.tgz",
-      "integrity": "sha512-dnBfLI0v/Ucsh/QrpYPGeo39qsvvglWMRSifx1lmAwLc9QAnL3Hhp9zUxJyX5icD9jj1uMftsAtIOGyjC2+KXA==",
+      "version": "8.31.2",
+      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.31.2.tgz",
+      "integrity": "sha512-naqnq7Z+gbl1LdnyNvrGrNUoeMUQtCOsnrS6DfqeuLMJTFqcL9Dq0/od+xcuqi0+l7HTyH0/gU1BQitWpd1rag==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.13",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@oclif/core": "4.11.6",
-    "@salesforce/core": "8.31.1",
+    "@salesforce/core": "8.31.2",
     "@salesforce/sf-plugins-core": "12.2.24",
     "@salesforce/source-deploy-retrieve": "12.36.3",
     "ignore": "7.0.5",

--- a/src/metadata/MetadataRepositoryImpl.ts
+++ b/src/metadata/MetadataRepositoryImpl.ts
@@ -127,16 +127,27 @@ export class MetadataRepositoryImpl implements MetadataRepository {
   }
 
   // A type owns its nested paths when it is folder-organized (`inFolder`, e.g.
-  // Report/Dashboard) or a content container (SDR adapter bundle/
-  // digitalExperience/mixedContent, e.g. LWC/StaticResource). In both cases the
-  // segments below its directory are user-named content, not metadata dirs.
+  // Report/Dashboard), a content container (SDR adapter bundle/
+  // digitalExperience/mixedContent, e.g. LWC/StaticResource), or a virtual
+  // content-container (Wave/Bot/Discovery) whose sub-directories are
+  // user-named content matched by suffix, not metadata directories.
   protected ownsNestedPaths(metadata: Metadata): boolean {
     return (
       metadata.inFolder ||
       // Stryker disable next-line ConditionalExpression -- equivalent: Set.has(undefined) is already false, so the `!== undefined` operand changes no runtime outcome; it exists only to narrow string|undefined → string for the Set<string>.has call under strict mode
       (metadata.adapter !== undefined &&
-        CONTENT_CONTAINER_ADAPTERS.has(metadata.adapter))
+        CONTENT_CONTAINER_ADAPTERS.has(metadata.adapter)) ||
+      this.isVirtualContentContainer(metadata)
     )
+  }
+
+  // A virtual content-container holds several suffix-keyed sub-types in one
+  // directory (Wave/Bot/Discovery/Moderation); the segments below its directory
+  // are user-named content matched by suffix within content[], not metadata
+  // directories, so the walk must stop here. Distinguished from a decomposed
+  // container (CustomObject) by its non-empty content[].
+  private isVirtualContentContainer(metadata: Metadata): boolean {
+    return metadata.metaFile === true && (metadata.content?.length ?? 0) > 0
   }
 
   protected searchByXmlName(xmlName: string): Metadata | undefined {

--- a/src/metadata/MetadataRepositoryImpl.ts
+++ b/src/metadata/MetadataRepositoryImpl.ts
@@ -127,27 +127,36 @@ export class MetadataRepositoryImpl implements MetadataRepository {
   }
 
   // A type owns its nested paths when it is folder-organized (`inFolder`, e.g.
-  // Report/Dashboard), a content container (SDR adapter bundle/
-  // digitalExperience/mixedContent, e.g. LWC/StaticResource), or a virtual
-  // content-container (Wave/Bot/Discovery) whose sub-directories are
-  // user-named content matched by suffix, not metadata directories.
+  // Report/Dashboard), an SDR content container (adapter bundle/
+  // digitalExperience/mixedContent, e.g. LWC/StaticResource), or declares its
+  // own suffix-keyed nested content (Wave/Bot/Discovery/Moderation). In each
+  // case the segments below its directory are user-named content, not metadata
+  // directories.
   protected ownsNestedPaths(metadata: Metadata): boolean {
     return (
       metadata.inFolder ||
       // Stryker disable next-line ConditionalExpression -- equivalent: Set.has(undefined) is already false, so the `!== undefined` operand changes no runtime outcome; it exists only to narrow string|undefined → string for the Set<string>.has call under strict mode
       (metadata.adapter !== undefined &&
         CONTENT_CONTAINER_ADAPTERS.has(metadata.adapter)) ||
-      this.isVirtualContentContainer(metadata)
+      this.declaresNestedContent(metadata)
     )
   }
 
-  // A virtual content-container holds several suffix-keyed sub-types in one
-  // directory (Wave/Bot/Discovery/Moderation); the segments below its directory
-  // are user-named content matched by suffix within content[], not metadata
-  // directories, so the walk must stop here. Distinguished from a decomposed
-  // container (CustomObject) by its non-empty content[].
-  private isVirtualContentContainer(metadata: Metadata): boolean {
-    return metadata.metaFile === true && (metadata.content?.length ?? 0) > 0
+  // A type declares nested content when its `content[]` lists suffix-keyed
+  // sub-types sharing one directory (Wave/Bot/Discovery/Moderation): the
+  // segments below that directory are then user-named content, not metadata
+  // directories, so the walk must stop here. A non-empty `content[]` is the
+  // whole test — it is exactly what separates these containers from a
+  // decomposed `CustomObject`, whose empty `content[]` signals that its
+  // children ARE deeper metadata directories (`fields/`, `listViews/`, …) the
+  // walk must keep descending into. `metaFile` is deliberately not checked:
+  // every registry type carrying a non-empty `content[]` owns its nested paths
+  // (the folder-organized ones — Dashboard/Report/EmailTemplate — also satisfy
+  // it but already stop via the `inFolder` arm above). The "empty content keeps
+  // descending" branch is covered by the existing non-container nested-folder
+  // test (a class file under a colliding `icons/` directory).
+  private declaresNestedContent(metadata: Metadata): boolean {
+    return (metadata.content?.length ?? 0) > 0
   }
 
   protected searchByXmlName(xmlName: string): Metadata | undefined {


### PR DESCRIPTION
## Explain your changes

---

The metadata directory-walk in `MetadataRepositoryImpl.searchByDirectory` resolves a diff path to the **deepest** matching `directoryName`, stopping only at `inFolder` types and SDR content-container adapters (`bundle`/`digitalExperience`/`mixedContent`). Internal **virtual content-containers** — one directory holding several suffix-keyed sub-types (`VirtualWave`, `VirtualBot`, `VirtualDiscovery`, `VirtualModeration`; `metaFile: true` + a non-empty `content[]`) — were not recognised, so the walk descended past `wave/` into a colliding child folder name. A `.wdash` under `…/wave/dashboards/` resolved to the report **`Dashboard`** type, failed the `InFolderHandler` suffix gate (`'dashboard' !== 'wdash'`), and was silently dropped from `package.xml`.

Fix: `ownsNestedPaths` gains a structural arm — `isVirtualContentContainer(m) = m.metaFile === true && (m.content?.length ?? 0) > 0` — so the walk stops at any virtual content-container and returns it (routed to `SharedFolderHandler`, which resolves the concrete type by suffix). It keys off the container **shape**, not an xmlName list, so all four virtual containers are covered and any future one inherits the behaviour. Decomposed `CustomObject` (empty `content[]`) is unaffected and still descends into `fields/`, `listViews/`, etc.

Beyond the reported `wave/dashboards/*.wdash`, this also fixes a second live collision (`wave/components/*.wcomp` → `ApexComponent`) and a latent one (`bots/<Bot>/rules/*` → `Territory2Rule`).

Regression bisected to #1229 (v6.32.4), which changed the walk from "first non-subtype match" to "deepest match"; #1322 (v6.44.5) generalised the stop-condition to content-container adapters but did not cover virtual containers. Last good release: v6.31.0.

## Does this close any currently open issues?

---

closes #1333

- [x] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

## Any particular element that can be tested locally

---

Run `sf sgd source delta` on a repo whose CRM Analytics metadata uses a type-subfoldered layout, e.g.:

```
force-app/main/default/src-base/crma/wave/dashboards/Account_KPI_Dashboard.wdash
force-app/main/default/src-base/crma/wave/components/AccountKpi.wcomp
```

The `WaveDashboard` / `WaveComponent` members now appear in the generated `package.xml` (previously dropped). Covered by:

- unit resolution tests in `__tests__/unit/lib/metadata/MetadataRepositoryImpl.test.ts` (nested collision, sibling Bot symmetry, both predicate conjuncts, flat regression guard);
- integration member-emission rows in `__tests__/integration/services.test.ts` (real registry + `TypeHandlerFactory`).

## Any other comments

---

- NUT/E2E not added: member emission is fully proven at the unit + integration layers; NUT needs a live org and the e2e non-regression fixtures are untouched.
- Mutation score 100% on the touched file (scoped Stryker run).
- `DESIGN.md` "Multi-Index Lookup" updated to document the new stop condition.
- Pre-existing, out of scope: `__tests__/integration/services.test.ts` builds its `work` object with a `diffs` field that no longer matches the `Work` type (`changes`); present on `main`, tolerated by the test runner.
