### PR TITLE
feat: add --scope-to-package-directories flag to limit diff to sfdx-project.json package dirs

### DIFF
--- a/__tests__/unit/lib/utils/configValidator.test.ts
+++ b/__tests__/unit/lib/utils/configValidator.test.ts
@@ -1033,6 +1033,109 @@ describe('Given a ConfigValidator', () => {
     })
   })
 
+  describe('_getScopeFromPackageDirectories', () => {
+    it('When scopeToPackageDirectories is false, Then source is unchanged and SfProject is not resolved', async () => {
+      // Arrange
+      work.config.scopeToPackageDirectories = false
+      work.config.source = ['./']
+      const sut = new ConfigValidator(work)
+
+      // Act
+      await sut['_getScopeFromPackageDirectories']()
+
+      // Assert
+      expect(work.config.source).toEqual(['./'])
+      expect(mockSfProjectResolve).not.toHaveBeenCalled()
+    })
+
+    it('When scopeToPackageDirectories is undefined, Then source is unchanged and SfProject is not resolved', async () => {
+      // Arrange
+      work.config.scopeToPackageDirectories = undefined
+      work.config.source = ['./']
+      const sut = new ConfigValidator(work)
+
+      // Act
+      await sut['_getScopeFromPackageDirectories']()
+
+      // Assert
+      expect(work.config.source).toEqual(['./'])
+      expect(mockSfProjectResolve).not.toHaveBeenCalled()
+    })
+
+    it('When scopeToPackageDirectories is true and packageDirectories exist, Then source is set to resolved package directory paths', async () => {
+      // Arrange
+      mockSfProjectResolve.mockResolvedValue({
+        getSfProjectJson: () => ({
+          getContents: () => ({
+            packageDirectories: [{ path: 'force-app' }, { path: 'src' }],
+          }),
+        }),
+      })
+      work.config.scopeToPackageDirectories = true
+      work.config.repo = '.'
+      const sut = new ConfigValidator(work)
+
+      // Act
+      await sut['_getScopeFromPackageDirectories']()
+
+      // Assert
+      expect(work.config.source).toEqual(['force-app', 'src'])
+    })
+
+    it('When scopeToPackageDirectories is true and packageDirectories is empty, Then source is unchanged', async () => {
+      // Arrange
+      mockSfProjectResolve.mockResolvedValue({
+        getSfProjectJson: () => ({
+          getContents: () => ({ packageDirectories: [] }),
+        }),
+      })
+      work.config.scopeToPackageDirectories = true
+      work.config.source = ['./']
+      const sut = new ConfigValidator(work)
+
+      // Act
+      await sut['_getScopeFromPackageDirectories']()
+
+      // Assert
+      expect(work.config.source).toEqual(['./'])
+    })
+
+    it('When scopeToPackageDirectories is true and packageDirectories is undefined, Then source is unchanged', async () => {
+      // Arrange
+      mockSfProjectResolve.mockResolvedValue({
+        getSfProjectJson: () => ({
+          getContents: () => ({}),
+        }),
+      })
+      work.config.scopeToPackageDirectories = true
+      work.config.source = ['./']
+      const sut = new ConfigValidator(work)
+
+      // Act
+      await sut['_getScopeFromPackageDirectories']()
+
+      // Assert
+      expect(work.config.source).toEqual(['./'])
+    })
+
+    it('When scopeToPackageDirectories is true and sfdx-project.json is not found, Then source is unchanged and failure is logged', async () => {
+      // Arrange
+      mockSfProjectResolve.mockRejectedValue(
+        new Error('No sfdx-project.json found')
+      )
+      work.config.scopeToPackageDirectories = true
+      work.config.source = ['./']
+      const sut = new ConfigValidator(work)
+
+      // Act
+      await sut['_getScopeFromPackageDirectories']()
+
+      // Assert
+      expect(work.config.source).toEqual(['./'])
+      expect(Logger.debug).toHaveBeenCalledOnce()
+    })
+  })
+
   describe('changesManifest validation', () => {
     beforeEach(() => {
       mockedPathExists.mockResolvedValue(true as never)

--- a/messages/delta.md
+++ b/messages/delta.md
@@ -64,6 +64,10 @@ generate delta files in [--output-dir] folder
 
 ignore git diff whitespace (space, tab, eol) changes
 
+# flags.scope-to-package-directories.summary
+
+scope the diff to package directories defined in sfdx-project.json
+
 # flags.include.summary
 
 file listing paths to explicitly include for any diff actions

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -108,6 +108,11 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
       char: 'W',
       summary: messages.getMessage('flags.ignore-whitespace.summary'),
     }),
+    'scope-to-package-directories': Flags.boolean({
+      summary: messages.getMessage(
+        'flags.scope-to-package-directories.summary'
+      ),
+    }),
     'api-version': Flags.orgApiVersion({
       char: 'a',
       summary: messages.getMessage('flags.api-version.summary'),
@@ -158,6 +163,7 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
       includeDestructive: flags['include-destructive-file'],
       output: flags['output-dir'],
       repo: flags['repo-dir'],
+      scopeToPackageDirectories: flags['scope-to-package-directories'],
       source: flags['source-dir'],
       to: flags['to'],
     }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -13,4 +13,5 @@ export type Config = {
   includeDestructive?: string | undefined
   additionalMetadataRegistryPath?: string | undefined
   changesManifest?: string | undefined
+  scopeToPackageDirectories?: boolean | undefined
 }

--- a/src/utils/configValidator.ts
+++ b/src/utils/configValidator.ts
@@ -120,6 +120,29 @@ export default class ConfigValidator {
   protected async _handleDefault() {
     await this._getApiVersion()
     await this._apiVersionDefault()
+    await this._getScopeFromPackageDirectories()
+  }
+
+  protected async _getScopeFromPackageDirectories() {
+    if (!this.config.scopeToPackageDirectories) return
+
+    try {
+      const sfProject = await SfProject.resolve(this.config.repo)
+      const packageDirectories = sfProject
+        .getSfProjectJson()
+        .getContents().packageDirectories
+
+      if (!packageDirectories?.length) return
+
+      this.config.source = packageDirectories.map(
+        dir => sanitizePath(join(this.config.repo, dir.path))!
+      )
+    } catch (ex) {
+      Logger.debug(
+        // Stryker disable next-line StringLiteral -- equivalent: lazy log content is observability only
+        lazy`_getScopeFromPackageDirectories: no sfdx-project.json found at '${this.config.repo}': ${ex}`
+      )
+    }
   }
 
   protected async _getApiVersion() {


### PR DESCRIPTION
## Explain your changes

---

Adds a `--scope-to-package-directories` boolean flag that, when set, reads `packageDirectories` from `sfdx-project.json` and uses them as the source paths for the git diff instead of the default `./`. Gated behind a flag so existing behavior is unchanged.

When the flag is set, `_getScopeFromPackageDirectories` resolves the project file, maps each `packageDirectories[*].path` to a source path, and replaces `config.source`. If the project file is missing or `packageDirectories` is empty, source is left unchanged and the failure is debug-logged.

If you choose to accept this solution, I will additionally suggest a follow-on update in the future to include new `--ignore-package-directories` flags to allow users to further scope the diff down to specific package directories over all.

## Does this close any currently open issues?

---

closes #1340

- [x] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

## Any particular element that can be tested locally

---

Pass `--scope-to-package-directories` to any `sgd source delta` invocation in a repo that has files committed outside of `packageDirectories` (e.g. `.claude/`, CI config, scripts). Those files should no longer appear in the generated package output.

## Any other comments

---

I had this idea a while back but held off until a concrete need surfaced. Issue #1340 is that case — files outside declared package directories being incorrectly flagged as added metadata.

Chose to gate behind a flag rather than change the default to avoid a breaking change for projects that intentionally process files outside `packageDirectories`.