### PR TITLE
fix: pin @jsforce/jsforce-node to 3.10.16 and revert SDR 12.37.0 to restore node 20 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "4.11.11",
         "@salesforce/core": "8.31.3",
         "@salesforce/sf-plugins-core": "12.2.24",
-        "@salesforce/source-deploy-retrieve": "12.37.0",
+        "@salesforce/source-deploy-retrieve": "12.36.9",
         "ignore": "7.0.5",
         "tar-stream": "3.2.0",
         "txml": "6.0.0",
@@ -3938,9 +3938,9 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "12.37.0",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.37.0.tgz",
-      "integrity": "sha512-t8c+hOG3G8d8SozvZo+HK38R3HkYT8eEO9INi4Aum4LWP0nZDDqt0PbU8j8YLWLPixWfhoaHb+Wzp92xn3RY2A==",
+      "version": "12.36.9",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.9.tgz",
+      "integrity": "sha512-DN71B+eJKobUhoh835zHZluB1FuhUbFixM2ZSNl3/lxZtPIiLYpP1doWjPp+mzg7EuUEvde/MvwoNH0TXTadvg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@salesforce/core": "^8.31.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@oclif/core": "4.11.11",
         "@salesforce/core": "8.31.3",
         "@salesforce/sf-plugins-core": "12.2.24",
-        "@salesforce/source-deploy-retrieve": "12.36.9",
+        "@salesforce/source-deploy-retrieve": "12.36.7",
         "ignore": "7.0.5",
         "tar-stream": "3.2.0",
         "txml": "6.0.0",
@@ -1982,9 +1982,9 @@
       }
     },
     "node_modules/@jsforce/jsforce-node": {
-      "version": "3.10.18",
-      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.18.tgz",
-      "integrity": "sha512-3Nr7ykox18niSpjROR5orfLjuQ+SWoxycx4k6Bu6OTnwT8gjrLSOjkr6qC51ohDnvHGAG75q4h3VCnFrohXjJA==",
+      "version": "3.10.16",
+      "resolved": "https://registry.npmjs.org/@jsforce/jsforce-node/-/jsforce-node-3.10.16.tgz",
+      "integrity": "sha512-Fh5Op3vgyWMmPhjsr0d50AwPj6X9rsUNiJOPqA2OmJmv3HduIRY8tK+nc/IdtkOGdYXDk09q1cu0PG5pGERGgA==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4",
@@ -1993,12 +1993,13 @@
         "csv-stringify": "^6.6.0",
         "faye": "^1.4.0",
         "form-data": "^4.0.4",
+        "https-proxy-agent": "^5.0.0",
         "multistream": "^3.1.0",
-        "undici": "^8.5.0",
+        "node-fetch": "^2.6.1",
         "xml2js": "^0.6.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/@jsonjoy.com/base64": {
@@ -3938,12 +3939,12 @@
       }
     },
     "node_modules/@salesforce/source-deploy-retrieve": {
-      "version": "12.36.9",
-      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.9.tgz",
-      "integrity": "sha512-DN71B+eJKobUhoh835zHZluB1FuhUbFixM2ZSNl3/lxZtPIiLYpP1doWjPp+mzg7EuUEvde/MvwoNH0TXTadvg==",
+      "version": "12.36.7",
+      "resolved": "https://registry.npmjs.org/@salesforce/source-deploy-retrieve/-/source-deploy-retrieve-12.36.7.tgz",
+      "integrity": "sha512-uP2tDBq4DEab+oJ6bi3AVGHZS2VdirpVzJ/Xv0ZEPO+OBbr8XQZqqQ9iulvrLaqpANTqs3UDAWTm8kzm61LQ7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@salesforce/core": "^8.31.4",
+        "@salesforce/core": "^8.31.2",
         "@salesforce/kit": "^3.2.4",
         "@salesforce/ts-types": "^2.0.12",
         "@salesforce/types": "^1.6.0",
@@ -3957,36 +3958,6 @@
         "minimatch": "^9.0.9",
         "proxy-agent": "^6.5.0",
         "yaml": "^2.9.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@salesforce/source-deploy-retrieve/node_modules/@salesforce/core": {
-      "version": "8.31.4",
-      "resolved": "https://registry.npmjs.org/@salesforce/core/-/core-8.31.4.tgz",
-      "integrity": "sha512-G/zgo9ygO+0l2x9gCOnp6BR7q2Rlt8MHDoj4DIpu2utsZznIcH7iNTEoKjul1BMKDPARuBGUp0Tyr0c8dLf32g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jsforce/jsforce-node": "^3.10.17",
-        "@salesforce/kit": "^3.2.4",
-        "@salesforce/ts-types": "^2.0.12",
-        "ajv": "^8.18.0",
-        "change-case": "^4.1.2",
-        "fast-levenshtein": "^3.0.0",
-        "faye": "^1.4.1",
-        "form-data": "^4.0.5",
-        "js2xmlparser": "^4.0.1",
-        "jsonwebtoken": "9.0.3",
-        "jszip": "3.10.1",
-        "memfs": "4.38.1",
-        "pino": "^9.7.0",
-        "pino-abstract-transport": "^1.2.0",
-        "pino-pretty": "^11.3.0",
-        "proper-lockfile": "^4.1.2",
-        "semver": "^7.8.0",
-        "ts-retry-promise": "^0.8.1",
-        "zod": "^4.1.12"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -4794,6 +4765,18 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -7260,6 +7243,19 @@
         "node": ">=10.19.0"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
@@ -9258,6 +9254,26 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -11894,6 +11910,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-dump": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
@@ -12099,15 +12121,6 @@
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
@@ -12458,6 +12471,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
@@ -12479,6 +12498,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "6.45.1",
       "license": "MIT",
       "dependencies": {
+        "@jsforce/jsforce-node": "3.10.16",
         "@oclif/core": "4.11.11",
         "@salesforce/core": "8.31.3",
         "@salesforce/sf-plugins-core": "12.2.24",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@oclif/core": "4.11.11",
     "@salesforce/core": "8.31.3",
     "@salesforce/sf-plugins-core": "12.2.24",
-    "@salesforce/source-deploy-retrieve": "12.36.9",
+    "@salesforce/source-deploy-retrieve": "12.36.7",
     "ignore": "7.0.5",
     "tar-stream": "3.2.0",
     "txml": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@oclif/core": "4.11.11",
     "@salesforce/core": "8.31.3",
     "@salesforce/sf-plugins-core": "12.2.24",
-    "@salesforce/source-deploy-retrieve": "12.37.0",
+    "@salesforce/source-deploy-retrieve": "12.36.9",
     "ignore": "7.0.5",
     "tar-stream": "3.2.0",
     "txml": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@jsforce/jsforce-node": "3.10.16",
     "@oclif/core": "4.11.11",
     "@salesforce/core": "8.31.3",
     "@salesforce/sf-plugins-core": "12.2.24",


### PR DESCRIPTION
## Explain your changes

---

`@jsforce/jsforce-node@3.10.17` (2026-06-25) raised `engines.node` to `>=22` and moved to `undici@8` (Node >=22.19) **in a patch release**. `@salesforce/core`'s caret ranges resolve to it at fresh-install time, so `sf plugins install` on Node 18/20 crashes at CLI load (`TypeError: webidl.util.markAsUncloneable is not a function`). Lockfiles and npm `overrides` do not propagate to plugin installs, so the previous override-based attempt was ineffective.

This PR makes the dependency tree Node 20-safe at fresh-install resolution:

- Revert the SDR 12.37.0 bumps (IdpConfiguration `51e0f9d`, UiWidgetBundle `01c409b`) — SDR 12.37.0 requires `@salesforce/core@^8.31.4`, which requires `@jsforce/jsforce-node@^3.10.17`. Back to SDR 12.36.7 (`core@^8.31.2`, satisfied by our exact-pinned 8.31.3). Those two metadata types will be re-introduced once upstream restores Node compatibility.
- Add `@jsforce/jsforce-node@3.10.16` (last Node 18/20-compatible release) as a direct exact dependency, so fresh installs hoist it and every `@salesforce/core` in the tree dedupes onto it.

Upstream report: the engines contradiction is filed against Salesforce (see linked issue).

## Any particular element that can be tested locally

---

- Fresh-install resolution (simulates `sf plugins install`): `npm pack`, then `npm i <tgz>` in an empty dir → resolves a single `@jsforce/jsforce-node@3.10.16`, `@salesforce/core@8.31.3`, and **no undici@8** anywhere in the tree.
- Local e2e run on Node 20.20.2 (`n 20`): `npm run test:e2e:local && npm run validate` → ✅ byte-equality.

## Any other comments

---

Dependency-only change. The Node 20 e2e legs on this PR are the acceptance proof.