### PR TITLE
fix: restore npm publish after npm 12 removed the shrinkwrap command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /test
 install-state.gz
 megalinter-reports/
+npm-shrinkwrap.json
 package.tgz
 perf-preview.html
 perf-raw.json

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "postpack": "shx rm -f oclif.manifest.json && shx sed -i 'blob/v[^/]*/' 'blob/main/' README.md",
     "prepack": "wireit",
     "prepare": "husky",
-    "prepublishOnly": "npm shrinkwrap",
+    "prepublishOnly": "shx cp package-lock.json npm-shrinkwrap.json",
     "sync:registry": "TS_NODE_COMPILER_OPTIONS='{\"rootDir\":\".\"}' node --loader ts-node/esm tooling/syncInternalRegistryWithSdr.ts",
     "test:build": "wireit",
     "test:functional": "wireit",


### PR DESCRIPTION
## Explain your changes

The `v7.0.0` release [failed to publish to npm](https://github.com/scolladon/sfdx-git-delta/actions/runs/29254892871). The `publish` job runs `npm install -g npm@latest`, which now pulls **npm 12** — and npm 12 **removed the `shrinkwrap` command**:

```
npm notice run npm shrinkwrap
Unknown command: "shrinkwrap"
npm error command failed
npm error command sh -c npm shrinkwrap
```

So `prepublishOnly: "npm shrinkwrap"` aborts `npm publish` before the tarball is uploaded. Net effect: `v7.0.0` is tagged and has a GitHub release, but npm never received it (`latest`/`latest-rc` are still `6.45.1`).

Only the **command** was removed — the published `npm-shrinkwrap.json` **file** is still fully honored by npm (documented under `package-lock-json`). We keep shipping it: it pins the whole tested dependency tree for `sf plugins install` (reproducible installs, and notably faster installs on Windows). This PR just replaces the removed command with its modern equivalent:

- `prepublishOnly` → `shx cp package-lock.json npm-shrinkwrap.json` (`shx` is already a devDependency and is already used in `postpack`; output is byte-identical to what `npm shrinkwrap` produced).
- Add `npm-shrinkwrap.json` to `.gitignore` — it is a publish-time artifact and has never been tracked.

## Does this close any currently open issues?

---

closes #

- [ ] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

_Release/CI plumbing only — no `src` change, so no automated tests apply. Verified manually (see below)._

## Any particular element that can be tested locally

---

```sh
npm run prepublishOnly
diff -q package-lock.json npm-shrinkwrap.json   # identical
git check-ignore npm-shrinkwrap.json            # ignored
```

Produces a valid `npm-shrinkwrap.json` (`sfdx-git-delta 7.0.0`) byte-identical to `package-lock.json`, on npm 12.

## Any other comments

---

npm has no `7.0.0` (the publish failed before upload). Once this lands, release-please cuts `7.0.1`, which will publish cleanly; npm `latest-rc` goes `6.45.1 → 7.0.1`. The `v7.0.0` GitHub release/tag stays as-is with no npm artifact.
