### PR TITLE
ci: split build into quality and os×node platform matrix

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -4,7 +4,9 @@ on:
   workflow_call:
 
 jobs:
-  source:
+  # Platform-independent logic gates: run exactly once, on the reference
+  # environment (ubuntu + .nvmrc node), with wireit GH-Actions caching.
+  quality:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -35,39 +37,27 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
-      - name: Integration test
-        run: npm run test:integration
-
-      - name: Checkout e2e sources
-        uses: actions/checkout@v6
-        with:
-          ref: 'e2e/head'
-          fetch-depth: 0
-          path: ./e2e
-
-      - name: NUT test
-        run: npm run test:nut
-
-      - name: Functional test
-        run: npm run test:functional
-
       - uses: actions/upload-artifact@v7
         with:
           name: coverage-test-report
           path: reports/coverage
 
-  windows:
-    runs-on: windows-latest
+  # Platform-dependent buckets: everything that spawns the compiled CLI or
+  # touches git/filesystem behavior runs on every supported os × node pair.
+  platform:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node: [22, 24, 26]
     defaults:
       run:
         shell: bash
     steps:
-      # The runner's git ships core.autocrlf=true: unset it before checkout
-      # so sources keep LF and the Biome format check sees committed bytes.
+      # The windows runner's git ships core.autocrlf=true: unset it before
+      # checkout so sources keep LF and tools see committed bytes. Harmless
+      # on linux/macos where autocrlf is off anyway.
       - name: Keep LF line endings
         run: git config --global core.autocrlf input
 
@@ -79,7 +69,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # No wireit GitHub-Actions caching here: the cache layer's tar
+      # No wireit GitHub-Actions caching in this job: the cache layer's tar
       # archiving fails on windows runners ("tar error" in every task).
       - name: Setup dependencies, cache and install
         uses: ./.github/actions/install
@@ -110,6 +100,12 @@ jobs:
       - name: Setup e2e dependencies
         working-directory: ./e2e
         run: npm ci
+
+      - name: NUT test
+        run: npm run test:nut
+
+      - name: Functional test
+        run: npm run test:functional
 
       # The e2e suite's scripts invoke `../bin/run.js` shebang-style, which
       # cmd.exe (npm's default script shell on windows) cannot execute; the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,12 @@ Rebuild every time you make a change in the source and need to test locally.
 ## Testing
 
 The test suite is organized into five buckets, each backed by its own
-directory and its own `npm` script. They are cumulative: a typical CI
-build runs them in the order below, and `npm test` aggregates all four
-non-perf buckets.
+directory and its own `npm` script. CI splits them across two build jobs:
+a `quality` job runs the platform-independent gates once on ubuntu (lint,
+build, unit with coverage), while a `platform` matrix job replays the
+platform-sensitive buckets (integration, NUT, functional, then the E2E
+suite) on every supported os (ubuntu, macos, windows) × Node (22, 24, 26)
+pair. Locally, `npm test` aggregates all four non-perf buckets.
 
 | Bucket          | Directory                                  | Vitest config                       | npm script             |
 | --------------- | ------------------------------------------ | ----------------------------------- | ---------------------- |
@@ -335,7 +338,9 @@ git push origin ${feature_branch} --force-with-lease
 
 _note: If your pull request needs more changes, keep working on your feature branch as described above._
 
-CI validates prettifying, linting and tests.
+CI validates formatting, linting and unit tests once on ubuntu (`quality`
+job), and runs the platform-sensitive test buckets on an os × node matrix
+(`platform` job).
 
 ### Collaborate on the pull request
 


### PR DESCRIPTION
## Explain your changes

---

Follow-up to #1367. Restructures `.github/workflows/reusable-build.yml` from `source` + dedicated `windows` jobs into two jobs:

- **`quality`** — ubuntu-latest, Node from `.nvmrc`, wireit GH-Actions caching. Runs the platform-independent gates exactly once: lint, `npm pack`, `test:unit`, codecov upload, coverage artifact upload.
- **`platform`** — matrix `os: [ubuntu-latest, macos-latest, windows-latest] × node: [22, 24, 26]`, `fail-fast: false`, no `needs:` (runs in parallel with `quality`). Per leg: `npm pack` → `test:integration` → e2e checkout (`e2e/head`, then `git fetch origin e2e/base:e2e/base`, `npm ci`) → `test:nut` → `test:functional` → e2e byte-equality. The dedicated `windows` job is deleted — this matrix replaces and extends it (integration/nut/functional/e2e now also run on macos, and nut/functional gain windows coverage for the first time).

Windows accommodations carried over from the deleted `windows` job (kept unconditional where harmless): `core.autocrlf input` before checkout, no wireit GH-Actions caching in the platform job (its tar layer fails on windows runners), `defaults.run.shell: bash`, `npm_config_script_shell: bash` on the e2e step, and `npm pack` before `test:integration` (the lifecycle test spawns the compiled CLI).

CONTRIBUTING.md's test-bucket and PR-CI prose updated to match the new split. README/DESIGN untouched (badge references the unchanged `Main` workflow name).

⚠️ **Before merging**: the `main` ruleset requires the status check context `build / source`, which no longer exists after this rename. Swap it for `build / quality` (and optionally the platform legs), e.g.:

```sh
gh api -X PUT repos/scolladon/sfdx-git-delta/rulesets/4804660 --input <(gh api repos/scolladon/sfdx-git-delta/rulesets/4804660 | jq '.rules |= map(if .type=="required_status_checks" then .parameters.required_status_checks |= map(if .context=="build / source" then .context="build / quality" else . end) else . end) | {name,target,enforcement,conditions,rules,bypass_actors}')
```

## Does this close any currently open issues?

---

No open issue — CI follow-up queued from #1367.

- [ ] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

(no runtime code change — workflow + docs only)

## Any particular element that can be tested locally

---

`actionlint .github/workflows/reusable-build.yml` passes. The real validation is this PR's own CI run: `quality` + 9 `platform` legs.

## Any other comments

---

First run doubles as shakeout: `test:nut` has never run in CI on windows/macos, and `test:functional` byte-equality is new on windows. Any failures will be fixed in workflow/src — never in `e2e/expected` fixtures.
