### PR TITLE
build: reinstall dependencies only when package-lock.json changes

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-npm run dependencies:reinstall
+# $1 previous HEAD, $2 new HEAD, $3 1=branch checkout 0=file checkout.
+# --no-ext-diff keeps the exit code trustworthy when an external diff is configured.
+[ "$3" = "1" ] || exit 0
+
+git diff --no-ext-diff --quiet "$1" "$2" -- package-lock.json 2>/dev/null ||
+	npm run dependencies:reinstall

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-npm run dependencies:reinstall
+# Only argument is the squash flag, so the pre-merge revision comes from ORIG_HEAD.
+git diff --no-ext-diff --quiet ORIG_HEAD HEAD -- package-lock.json 2>/dev/null ||
+	npm run dependencies:reinstall

--- a/.husky/post-rewrite
+++ b/.husky/post-rewrite
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-npm run dependencies:reinstall
+# Without ORIG_HEAD there is nothing to compare against, so skip rather than reinstall blindly.
+git rev-parse -q --verify ORIG_HEAD >/dev/null || exit 0
+
+git diff --no-ext-diff --quiet ORIG_HEAD HEAD -- package-lock.json 2>/dev/null ||
+	npm run dependencies:reinstall


### PR DESCRIPTION
## Explain your changes

---

The `post-checkout`, `post-merge` and `post-rewrite` hooks each ran `npm run dependencies:reinstall` (`npm install`) unconditionally, ignoring the arguments git passes them. Two consequences:

- **`git checkout -- some/file.ts` triggered a full `npm install`.** `post-checkout` receives `$3=1` for a branch checkout and `$3=0` for a file checkout; the hook never looked at it.
- **Every branch switch, merge, amend and rebase step reinstalled**, even when dependencies were identical. Beyond the wall-clock cost, each `npm install` is an opportunity for `package-lock.json` to be re-resolved and rewritten as a side effect of an unrelated `git` operation.

Each hook now reinstalls only when `package-lock.json` actually differs between the two revisions:

- `post-checkout` — bails on file checkouts (`$3`), then compares `$1..$2`
- `post-merge` — only argument is the squash flag, so the pre-merge revision comes from `ORIG_HEAD`
- `post-rewrite` — same `ORIG_HEAD` comparison, and skips when `ORIG_HEAD` cannot be resolved rather than reinstalling blindly

`--no-ext-diff` is required on each `git diff`: with an external diff driver configured (e.g. difftastic), `--quiet`'s exit code is otherwise not trustworthy.

Behaviour is unchanged whenever dependencies genuinely change — that path still runs `npm run dependencies:reinstall` exactly as before.

## Any particular element that can be tested locally

---

No new parameters and no runtime behaviour change — this only affects local git hooks.

Verified against this repository's own history:

| Scenario | Expected | Result |
| --- | --- | --- |
| Branch switch, lockfile differs (`af1a7f5c` → `2dbee879`) | reinstall | ✅ reinstalls |
| Branch switch, lockfile identical | skip | ✅ skips |
| `git checkout -- file` (`$3=0`) | skip | ✅ skips |
| Merge of a branch that does not touch the lockfile | skip | ✅ skips |
| Merge of a branch that changes the lockfile | reinstall | ✅ reinstalls |

Switching branches now takes ~0.05s instead of a full `npm install`.

To try it: `git checkout -- README.md` (no install), then switch between two branches whose lockfiles differ (install runs).

## Any other comments

---

Shell-only change — no `src/`, no dependency and no lockfile changes, so `DESIGN.md` and `README.md` are unaffected.

The three sibling repositories that share this husky setup (`tsgit`, `sf-git-merge-driver`, `apex-mutation-testing`, `dataset-loader`) were checked and none define these hooks, so no equivalent change is needed there.
