### PR TITLE
build(github-actions): bump checkout, codecov, artifact, fetch-metadata, release-please

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Checkout PR branch
         if: steps.metadata.outputs.package-ecosystem == 'npm_and_yarn' && contains(steps.metadata.outputs.dependency-names, '@salesforce/source-deploy-retrieve')
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/npm-service.yml
+++ b/.github/workflows/npm-service.yml
@@ -28,7 +28,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
@@ -56,7 +56,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -27,7 +27,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -82,7 +82,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # MegaLinter
       - name: MegaLinter
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -32,7 +32,7 @@ jobs:
         run: npm run test:unit
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
@@ -62,7 +62,7 @@ jobs:
         run: git config --global core.autocrlf input
 
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -84,7 +84,7 @@ jobs:
         run: npm run test:integration
 
       - name: Checkout e2e sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: 'e2e/head'
           fetch-depth: 0

--- a/.github/workflows/reusable-perf.yml
+++ b/.github/workflows/reusable-perf.yml
@@ -25,7 +25,7 @@ jobs:
       HUSKY: '0'
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Checkout gh-pages baseline data
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: gh-pages
           path: gh-pages-data
@@ -124,7 +124,7 @@ jobs:
           benchmark-data-dir-path: dev/bench/memory
 
       - name: Upload benchmark report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: perf-report
           path: |

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: 'e2e/head'
           fetch-depth: 0


### PR DESCRIPTION
## Explain your changes

---

Clears the whole open Dependabot backlog in a single PR. All five GitHub Actions major bumps are applied together, superseding #1350, #1349, #1293, #1292 and #1291.

| Action | From | To | Breaking change |
| --- | --- | --- | --- |
| `actions/checkout` | v6 | v7 | ESM rewrite; blocks fork-PR checkout under `pull_request_target` / `workflow_run` |
| `codecov/codecov-action` | v6 | v7 | GPG signing key moved to the `codecovsecops` account |
| `actions/upload-artifact` | v6 | v7 | Runtime bump |
| `dependabot/fetch-metadata` | v2 | v3 | Node 24 runtime |
| `googleapis/release-please-action` | v4 | v5 | Node 24 runtime; release-please 17.3.0 → 17.6.0 |

Why one PR rather than five merges: the individual Dependabot branches predate #1367 and #1368, so their `actions/checkout` patch no longer matches `main` — merging them one by one would conflict and leave stale `@v6` pins behind. This applies all 13 `checkout` call sites present on today's `main`.

**On the `checkout@v7` fork-block:** verified non-applicable — this repo has no `pull_request_target` or `workflow_run` trigger in any workflow. The only PR-head checkout (`dependabot-auto-merge.yml`) runs on plain `pull_request`, and `on-pull-request.yml` already gates on `head.repo.full_name == github.repository`.

`actions/upload-artifact@v7` was already in use in three places on `main`; this bump only aligns the last `@v6` holdout in `reusable-perf.yml`.

## Does this close any currently open issues?

---

Supersedes and closes #1350, #1349, #1293, #1292, #1291.

- [ ] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

CI-only change — no source, test or dependency files touched, so no new test coverage applies. Validation is `actionlint` (clean) plus the CI run on this PR exercising the bumped actions end to end.

## Any particular element that can be tested locally

---

```bash
actionlint
```

Everything else is exercised by this PR's own CI run: `checkout`, `codecov-action` and `upload-artifact` on the build/quality/perf jobs. `fetch-metadata` and `release-please` only run post-merge (Dependabot PRs and pushes to `main` respectively).

## Any other comments

---

Follow-up worth considering: adding a `groups:` key to the `github-actions` entry in `.github/dependabot.yml` so future action bumps arrive as one PR instead of five. Not done here to keep this PR to what Dependabot actually proposed.
