### PR TITLE
chore: give the scope-verdict fixture its own budget and import vitest.shared with its extension

### DIFF
--- a/__tests__/integration/adapter/repoGitDiffScopeVerdict.test.ts
+++ b/__tests__/integration/adapter/repoGitDiffScopeVerdict.test.ts
@@ -57,7 +57,11 @@ beforeAll(async () => {
   fixtureDir = await trackedTempDir('sgd-scope-verdict-fixture-')
   refs = buildFixtureRepo(fixtureDir)
   globalMetadata = await getDefinition({})
-})
+  // Building the fixture repo plus the SDR registry load is fixture I/O,
+  // not the behaviour under test, and the default 10s hook timeout has a
+  // documented flake of exactly this shape under CPU contention. The
+  // assertions keep the tight default so they stay regression detectors.
+}, 30_000)
 
 afterEach(async () => {
   // Closing after every test drops the cached repo handle and the

--- a/vitest.config.perf.ts
+++ b/vitest.config.perf.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config'
 
-import { oxc } from './vitest.shared'
+import { oxc } from './vitest.shared.ts'
 
 export default defineConfig({
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config'
 
-import { oxc } from './vitest.shared'
+import { oxc } from './vitest.shared.ts'
 
 export default defineConfig({
   test: {

--- a/vitest.functional.config.ts
+++ b/vitest.functional.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 
-import { sharedTestConfig } from './vitest.shared'
+import { sharedTestConfig } from './vitest.shared.ts'
 
 export default mergeConfig(
   sharedTestConfig,

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, mergeConfig } from 'vitest/config'
 
-import { sharedTestConfig } from './vitest.shared'
+import { sharedTestConfig } from './vitest.shared.ts'
 
 export default mergeConfig(
   sharedTestConfig,

--- a/vitest.nut.config.ts
+++ b/vitest.nut.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config'
 
-import { oxc } from './vitest.shared'
+import { oxc } from './vitest.shared.ts'
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Explain your changes

---

Two independent maintenance fixes, one commit each. No production code is touched.

**1. `test(integration)`: give the scope-verdict fixture its own budget**

`__tests__/integration/adapter/repoGitDiffScopeVerdict.test.ts` builds a fixture repo and
loads the SDR registry in a `beforeAll`, against vitest's default 10s `hookTimeout`. That
budget is intermittently too tight: measured on 2026-09-06, 0 failures across 6 clean
full-bucket runs but 1 failure in 4 runs under CPU contention. It is the same latent shape
as the two hooks fixed in #1429.

The hook now carries an explicit `30_000` budget, matching the precedents for identical
fixture work:

| file | hook | budget |
| --- | --- | --- |
| `manifestParityAcrossGenerateDelta.test.ts:187` | `beforeAll` (fixture repo + SDR load) | `30_000` |
| `manifestParityAcrossGenerateDelta.test.ts:581` | `beforeAll` (fixture repo) | `30_000` |
| `gitTestHarnessIsolation.test.ts:50` | `beforeEach` (fixture repos) | `30_000` |
| `streamContentMemory.test.ts:108` | `beforeAll` (large blob commit) | `60_000` |

`testTimeout` is unchanged and no `it` gained a timeout argument — the assertions keep the
tight default so they stay regression detectors. Only the fixture I/O gets headroom.

**2. `build`: import `vitest.shared` with its file extension**

The vitest configs imported `./vitest.shared` with no file extension, which printed this on
every run:

```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is
    planned to become the default in a future major version of Vite:
  - import "./vitest.shared" without a file extension (vitest.config.ts:3:21). Add the file extension
```

Cosmetic today, breaking when native config loading becomes the default. The issue lists
`vitest.config.ts` and `vitest.integration.config.ts`; the same import is in three more
configs, so all five are fixed rather than leaving the warning in place for the functional,
nut and perf buckets:

- `vitest.config.ts`
- `vitest.integration.config.ts`
- `vitest.functional.config.ts`
- `vitest.nut.config.ts`
- `vitest.config.perf.ts`

`.ts` is the correct specifier: `vitest.shared.ts` is the file on disk and Node's native
loader does not remap `.js` to `.ts`. The configs are outside `tsconfig.json`'s `include`,
so `allowImportingTsExtensions` is not needed. Warning confirmed gone.

## Does this close any currently open issues?

---

Item 5 of #1412. The other items on that issue are untouched — in particular the mutation
gate is deliberately left alone, it needs a real decision (upstream fix vs. patching the
runner vs. pinning) rather than a quick win.

- [ ] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

No new tests: change 1 is a timeout budget on an existing test's fixture hook, change 2 is a
build-config import specifier. Neither has new behaviour to assert.

## Any particular element that can be tested locally

---

Every bucket was run on the branch; all green, with the counts unchanged from `main`:

| gate | result |
| --- | --- |
| `npx vitest run --coverage` | 81 files, **1707** passed, 100% thresholds held |
| `npx vitest run --config vitest.integration.config.ts` | 18 files, **417** passed — run 3x |
| `npx vitest run --config vitest.functional.config.ts` | 1 file, **34** passed |
| `npx vitest run --config vitest.nut.config.ts` | 1 file, **14** passed |
| `npx vitest bench --config vitest.config.perf.ts` | config loads, benches run |
| `npx tsc -p . --incremental` | exit 0 |
| `npx @biomejs/biome check --error-on-warnings src __tests__ messages` | 233 files, clean |

The integration bucket was run in full several times rather than single-file: the
scope-verdict test passes in isolation today, so a single-file run would go green
vacuously and prove nothing about the flake.

## Any other comments

---

No `src/` change, so no `DESIGN.md` or `README.md` update is warranted and there is nothing
user-facing to document.
