### PR TITLE
test: close the harness gaps that let checks report success without checking

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -149,10 +149,11 @@ jobs:
           name: mutation-report
           path: reports/mutation
 
-  # Separate job on purpose: it is the only one holding a write scope for
-  # mutation feedback, and it checks out nothing and runs no repository
-  # code — mutation-testing above runs `npm ci` and the pull request's own
-  # tests under Stryker, which is not where a PR-comment token belongs.
+  # Separate job on purpose: it isolates the write scope mutation feedback
+  # needs from the job that runs `npm ci` and the pull request's own tests
+  # under Stryker, keeping a PR-comment token out of that untrusted-code
+  # path — not a repo-wide rule (the perf job's own comment step runs from a
+  # job that does check out and run PR code; see reusable-perf.yml).
   # continue-on-error on mutation-testing masks a guard failure (today's
   # normal outcome on the unpatched runner) as a "success" needs.result,
   # but that masking is exactly why this job cannot rely on the implicit
@@ -171,13 +172,19 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      # Neither an empty scope nor a failure before the script writes
+      # (checkout, setup-node, npm ci, Stryker OOM) leaves a mutation-report
+      # artifact behind — download-artifact hard-errors on a missing
+      # artifact, so this step must not be allowed to fail the job on top.
       - name: Download mutation report
         uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           name: mutation-report
           path: reports/mutation
 
       - name: Comment mutation report
+        if: hashFiles('reports/mutation/comment.md') != ''
         uses: thollander/actions-comment-pull-request@v3
         with:
           file-path: reports/mutation/comment.md

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -122,6 +122,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     if: contains(github.event.pull_request.labels.*.name, 'mutation-testing')
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
@@ -140,6 +142,10 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Run incremental mutation testing
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: npm run test:mutation:incremental
 
       - name: Upload mutation report

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -122,8 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     if: contains(github.event.pull_request.labels.*.name, 'mutation-testing')
-    permissions:
-      pull-requests: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
@@ -142,10 +140,6 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Run incremental mutation testing
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: npm run test:mutation:incremental
 
       - name: Upload mutation report
@@ -154,6 +148,41 @@ jobs:
         with:
           name: mutation-report
           path: reports/mutation
+
+  # Separate job on purpose: it is the only one holding a write scope for
+  # mutation feedback, and it checks out nothing and runs no repository
+  # code — mutation-testing above runs `npm ci` and the pull request's own
+  # tests under Stryker, which is not where a PR-comment token belongs.
+  # continue-on-error on mutation-testing masks a guard failure (today's
+  # normal outcome on the unpatched runner) as a "success" needs.result,
+  # but that masking is exactly why this job cannot rely on the implicit
+  # success() gate a plain `needs:` gets: always() removes that gate, so
+  # this job still fires whether mutation-testing measured a score or hit
+  # the vacuity guard. It only skips when mutation-testing itself never
+  # ran (no label — result is 'skipped', not masked) or for fork pull
+  # requests, whose token is read-only regardless.
+  mutation-comment:
+    needs: [mutation-testing]
+    if: |
+      always() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      needs.mutation-testing.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download mutation report
+        uses: actions/download-artifact@v7
+        with:
+          name: mutation-report
+          path: reports/mutation
+
+      - name: Comment mutation report
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          file-path: reports/mutation/comment.md
+          comment-tag: incremental-mutation-testing
+          mode: recreate
 
   build:
     uses: ./.github/workflows/reusable-build.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,10 +244,26 @@ Then execute:
 ```bash
 # remove expected content
 npm run clean
-# run the test
-sf sgd source delta --from "e2e/base" --to "e2e/head" --output "expected" --generate-delta
+# run the test — prefer the package script, which already carries every flag
+npm run test:e2e:local
 # check expected is back to normal
-npm run test:e2e
+npm run validate
+```
+
+Run it through the package script rather than by hand. The scripts in
+`e2e/package.json` carry flags the baseline depends on — in particular
+`--source-dir test`, which keeps the committed `expected/` tree out of the diff
+model rather than filtering it back out afterwards. Invoking the CLI directly
+without that flag regenerates `expected/` from a diff that contains `expected/`
+itself, and the copy it produces is what `npm run validate` then fails on. The
+equivalent long form, if you do need to run it by hand:
+
+```bash
+sf sgd source delta --from "e2e/base" --to "e2e/head" --output-dir "expected" \
+  --generate-delta --repo-dir . --source-dir test \
+  --include-file .sgdinclude --include-destructive-file .sgdincludeDestructive \
+  --ignore-file .sgdignore --ignore-destructive-file .sgdignoreDestructive \
+  --ignore-whitespace
 ```
 
 `e2e/.sgdignore` keeps its `/expected` line on purpose: `--source-dir test` is what scopes the diff away from the baseline, and the ignore line stays as live `--ignore-file` coverage against a real, populated directory, so do not delete it as redundant.
@@ -255,7 +271,8 @@ npm run test:e2e
 Note: you may want to execute the local plugin using `node` if you have not linked the folder used to develop locally with the plugin.
 
 ```bash
-node path/to/sfdx-git-delta/bin/run sgd:source:delta --from "e2e/base" --to "e2e/head" --output "expected" -d
+node path/to/sfdx-git-delta/bin/run.js sgd source delta --from "e2e/base" --to "e2e/head" \
+  --output-dir "expected" --generate-delta --repo-dir . --source-dir test
 ```
 
 ## Editor Configurations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,6 +238,7 @@ Base scenarios are implemented in the `e2e/base` branch.
 Updates to the metadata are implemented in `e2e/head`.
 
 To run the E2E tests locally, clone the repository in another folder and checkout the branch `e2e/head`.
+If your own checkout also has local branches named `e2e/base` or `e2e/head` (for example a worktree of this same repository), those are decoys: the E2E commands only ever read the branches inside the cloned folder, so always run git commands there with `git -C e2e …` and compare against `git -C e2e ls-remote origin` before trusting what a ref points to.
 Then execute:
 
 ```bash
@@ -248,6 +249,8 @@ sf sgd source delta --from "e2e/base" --to "e2e/head" --output "expected" --gene
 # check expected is back to normal
 npm run test:e2e
 ```
+
+`e2e/.sgdignore` keeps its `/expected` line on purpose: `--source-dir test` is what scopes the diff away from the baseline, and the ignore line stays as live `--ignore-file` coverage against a real, populated directory, so do not delete it as redundant.
 
 Note: you may want to execute the local plugin using `node` if you have not linked the folder used to develop locally with the plugin.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,8 +199,12 @@ npm run test:perf
 ### Mutation Testing
 
 Mutation testing runs via Stryker against the unit-test bucket. The
-configured thresholds are `break: 90`, `low: 90`, `high: 95`; CI fails
-when the mutation score drops below 90%.
+configured thresholds are `break: 90`, `low: 90`, `high: 95`. The CI job
+is opt-in via the `mutation-testing` label and advisory
+(`continue-on-error: true`) — a low score never blocks a PR, but a run
+that executes no tests against a covered mutant is reported as an
+**error**, never as a score: a runner defect must not be mistaken for a
+regression.
 
 ```bash
 npm run test:mutation              # full run (~6 min)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,8 +188,9 @@ then discards all 50 series for that commit.
 
 The `name` is the `bench()` registration name and the join key for
 `compareBaseline.mjs`, `preview.mjs` and the gh-pages history, so renaming a
-bench orphans its history. A throwing bench body fails the run and nothing is
-written; a `-t` filter writes partial files.
+bench orphans its history, and is reported under *Benchmarks missing from
+this run*. A throwing bench body fails the run and nothing is written; a
+`-t` filter writes partial files.
 
 ```bash
 npm run test:perf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,12 @@ Performance benchmarks live in `__tests__/perf/`. Each bench is a vitest
 test that calls the `bench` fixture through
 `__tests__/perf/harness/perfBench.ts`, which pins the sample budget
 (`time: 1000`, `iterations: 64`, `warmupTime: 250`, `warmupIterations: 16`).
+`perfBench(name, fn, hooks?)` takes its hooks as one named object —
+`{ beforeEach?, afterRun? }` — never positionally. `beforeEach` runs before
+every iteration, warmup included, outside the timed window, so it is the
+place to build a sample's inputs (or a per-iteration cold registry) without
+that setup counting toward the measured cost; `afterRun` runs once after
+every sample is in, for a budget assertion over the whole run.
 `__tests__/perf/perfReporter.ts` writes `perf-runtime.json`
 (`{name, unit: 'ops/sec', value: round(1000 / latency.mean), range: '±rme%'}`)
 and `perf-memory.json` (`{name, unit: 'ms', value: latency.mean to 4 dp,

--- a/__tests__/__utils__/gitFixtureRepo.ts
+++ b/__tests__/__utils__/gitFixtureRepo.ts
@@ -560,6 +560,8 @@ export type IgnoreFixtureRefs = {
   // the bundle's two other files stay where they are — a stale ignored copy
   // of a component that is still alive.
   staleCopy: string
+  // From `root`: the class pair removed outright, nothing re-added.
+  deleted: string
 }
 
 export const IGNORE_SOURCE_CLASS =
@@ -650,7 +652,17 @@ export const buildIgnoreFixtureRepo = (dir: string): IgnoreFixtureRefs => {
     ]
   )
 
-  return { root, moved, staleCopy }
+  // `staleCopy` above left the index holding its own tree, not `root`'s —
+  // re-seed it from `root` so this sibling commit branches off `root`
+  // instead of continuing from `staleCopy`.
+  runGit(['read-tree', root], { cwd: dir })
+
+  const deleted = makeCommit(dir, root, 'delete the class pair', [
+    { kind: 'delete', path: IGNORE_SOURCE_CLASS },
+    { kind: 'delete', path: IGNORE_SOURCE_CLASS_META },
+  ])
+
+  return { root, moved, staleCopy, deleted }
 }
 
 export type LiveContainerFixtureRefs = {

--- a/__tests__/integration/adapter/gitAdapterLifecycle.test.ts
+++ b/__tests__/integration/adapter/gitAdapterLifecycle.test.ts
@@ -29,10 +29,16 @@ const trackedTempDir = async (prefix: string): Promise<string> => {
   return dir
 }
 
+// Building the fixture repo is fixture I/O, not the behaviour under test,
+// and the default 10s hook timeout has a documented flake of exactly this
+// shape on a cold Windows runner. The assertions keep the tight default so
+// they stay regression detectors.
+const FIXTURE_HOOK_BUDGET_MS = 30_000
+
 beforeAll(async () => {
   fixtureDir = await trackedTempDir('sgd-lifecycle-fixture-')
   refs = buildFixtureRepo(fixtureDir)
-})
+}, FIXTURE_HOOK_BUDGET_MS)
 
 afterAll(async () => {
   await Promise.all(

--- a/__tests__/integration/adapter/repoGitDiffIgnoreCancellation.test.ts
+++ b/__tests__/integration/adapter/repoGitDiffIgnoreCancellation.test.ts
@@ -47,6 +47,7 @@ import { sourceDirs } from '../../__utils__/sourceDirs'
 let fixtureDir: string
 let ignorePatternPath: string
 let unrelatedDestructivePatternPath: string
+let sourceClassesPatternPath: string
 let refs: IgnoreFixtureRefs
 let globalMetadata: MetadataRepository
 
@@ -94,6 +95,8 @@ beforeAll(async () => {
   await writeFile(ignorePatternPath, 'force-app/recycle-bin/\n')
   unrelatedDestructivePatternPath = join(fixtureDir, '.sgdignore-unrelated')
   await writeFile(unrelatedDestructivePatternPath, 'nothing-here/\n')
+  sourceClassesPatternPath = join(fixtureDir, '.sgdignore-source-classes')
+  await writeFile(sourceClassesPatternPath, 'force-app/main/default/classes/\n')
 })
 
 afterEach(async () => {
@@ -204,5 +207,43 @@ describe('Given one bundle file moved into an ignored directory while the bundle
 
     // Assert
     expect(result).toEqual([`A\t${IGNORE_BUNDLE_STALE_MARKUP}`])
+  })
+})
+
+describe('Given a class deleted outright', () => {
+  it('When --ignore-destructive-file covers its path, Then the deletion is dropped', async () => {
+    // Arrange — a deletion consults only the destructive set, so a
+    // destructive pattern covering the deleted class's path suppresses it.
+    const config = makeConfig({
+      to: refs.deleted,
+      ignoreDestructive: sourceClassesPatternPath,
+    })
+    const sut = new RepoGitDiff(config, globalMetadata)
+
+    // Act
+    const result = await collect(sut.getLines())
+
+    // Assert
+    expect(result).toEqual([])
+  })
+
+  it('When only --ignore-file covers the same path, Then the deletion survives', async () => {
+    // Arrange — the global ignore never gates a deletion line, so the same
+    // pattern applied there leaves the deletion untouched. An unrelated
+    // destructive pattern is set explicitly: buildIgnore falls back to
+    // ignorePath for the destructive set when ignoreDestructive is empty,
+    // and that fallback would otherwise smuggle the global pattern back in.
+    const config = makeConfig({
+      to: refs.deleted,
+      ignore: sourceClassesPatternPath,
+      ignoreDestructive: unrelatedDestructivePatternPath,
+    })
+    const sut = new RepoGitDiff(config, globalMetadata)
+
+    // Act
+    const result = await collect(sut.getLines())
+
+    // Assert
+    expect(result).toEqual(SOURCE_DELETION_SURVIVES)
   })
 })

--- a/__tests__/integration/perf/compareBaselineReconciliation.test.ts
+++ b/__tests__/integration/perf/compareBaselineReconciliation.test.ts
@@ -1,0 +1,133 @@
+'use strict'
+import { spawnSync } from 'node:child_process'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { createTempDir } from '../../__utils__/gitTestHarness'
+
+// Resolved relative to this file's own URL, never process.cwd(): the
+// spawned script must be locatable regardless of which directory the test
+// runner itself was launched from.
+const SCRIPT_ENTRY = fileURLToPath(
+  new URL('../../perf/compareBaseline.mjs', import.meta.url)
+)
+
+const writeJson = (path: string, entries: unknown) =>
+  writeFile(path, JSON.stringify(entries))
+
+let cwd: string
+let report: string
+let exitCode: number | null
+
+beforeAll(async () => {
+  cwd = await createTempDir('sgd-perf-reconciliation-')
+
+  // Arrange: two series (runtime, memory) each carrying a renamed bench
+  // (b -> b-renamed), a deleted bench (c), a new bench (d), a stable bench
+  // (a), and a bench (e) that is stable in runtime but absent from the PR
+  // memory file only — a partial run disagreeing between the two series.
+  await Promise.all([
+    writeJson(join(cwd, 'perf-runtime-base.json'), [
+      { name: 'a', unit: 'ops/sec', value: 100, range: '±1.00%' },
+      { name: 'b', unit: 'ops/sec', value: 100, range: '±1.00%' },
+      { name: 'c', unit: 'ops/sec', value: 100, range: '±1.00%' },
+      { name: 'e', unit: 'ops/sec', value: 100, range: '±1.00%' },
+    ]),
+    writeJson(join(cwd, 'perf-runtime.json'), [
+      { name: 'a', unit: 'ops/sec', value: 100, range: '±1.00%' },
+      { name: 'b-renamed', unit: 'ops/sec', value: 100, range: '±1.00%' },
+      { name: 'd', unit: 'ops/sec', value: 100, range: '±1.00%' },
+      { name: 'e', unit: 'ops/sec', value: 100, range: '±1.00%' },
+    ]),
+    writeJson(join(cwd, 'perf-memory-base.json'), [
+      { name: 'a', unit: 'ms', value: 10, range: '±1.00%' },
+      { name: 'b', unit: 'ms', value: 10, range: '±1.00%' },
+      { name: 'c', unit: 'ms', value: 10, range: '±1.00%' },
+      { name: 'e', unit: 'ms', value: 10, range: '±1.00%' },
+    ]),
+    writeJson(join(cwd, 'perf-memory.json'), [
+      { name: 'a', unit: 'ms', value: 10, range: '±1.00%' },
+      { name: 'b-renamed', unit: 'ms', value: 10, range: '±1.00%' },
+      { name: 'd', unit: 'ms', value: 10, range: '±1.00%' },
+    ]),
+  ])
+
+  // Act: spawn the real script with an explicit, stripped env — the
+  // integration bucket runs in CI where GITHUB_TOKEN and GITHUB_REPOSITORY
+  // are set, and an inherited env would make this attempt a real GitHub
+  // API call.
+  const sut = spawnSync(process.execPath, [SCRIPT_ENTRY], {
+    cwd,
+    encoding: 'utf8',
+    env: { PATH: process.env.PATH ?? '' },
+  })
+  exitCode = sut.status
+
+  report = await readFile(join(cwd, 'perf-comparison.md'), 'utf-8')
+})
+
+afterAll(async () => {
+  await rm(cwd, { recursive: true, force: true })
+})
+
+const missingSection = () =>
+  report.split('## Benchmarks missing from this run')[1]?.split('##')[0] ?? ''
+const newSection = () =>
+  report.split('## Benchmarks new in this run')[1]?.split('##')[0] ?? ''
+const stableSection = () => report.split('## Stable')[1]?.split('##')[0] ?? ''
+
+describe('Given a PR run reconciled against a base run', () => {
+  describe('When a benchmark was renamed between base and PR', () => {
+    it('Then its old name is reported missing in both series', () => {
+      expect(missingSection()).toContain('| b | runtime | 100 |')
+      expect(missingSection()).toContain('| b | memory | 10ms |')
+    })
+
+    it('Then its new name is reported new in both series', () => {
+      expect(newSection()).toContain('| b-renamed | runtime | 100 |')
+      expect(newSection()).toContain('| b-renamed | memory | 10ms |')
+    })
+  })
+
+  describe('When a benchmark was deleted from the PR run', () => {
+    it('Then it is reported missing in both series and never as new', () => {
+      expect(missingSection()).toContain('| c | runtime | 100 |')
+      expect(missingSection()).toContain('| c | memory | 10ms |')
+      expect(newSection()).not.toContain('| c |')
+    })
+  })
+
+  describe('When a benchmark exists only in the PR run', () => {
+    it('Then it is reported new in both series and never as missing', () => {
+      expect(newSection()).toContain('| d | runtime | 100 |')
+      expect(newSection()).toContain('| d | memory | 10ms |')
+      expect(missingSection()).not.toContain('| d |')
+    })
+  })
+
+  describe('When a benchmark is unchanged between base and PR', () => {
+    it('Then it stays under Stable and is never reported missing or new', () => {
+      expect(stableSection()).toContain('| a | 100 | 100 |')
+      expect(stableSection()).toContain('| a (mean) | 10ms | 10ms |')
+      expect(missingSection()).not.toContain('| a |')
+      expect(newSection()).not.toContain('| a |')
+    })
+  })
+
+  describe('When a benchmark is present in both runtime files but absent from the PR memory file only', () => {
+    it('Then it stays Stable under runtime and is reported missing under memory alone', () => {
+      expect(stableSection()).toContain('| e | 100 | 100 |')
+      expect(missingSection()).toContain('| e | memory | 10ms |')
+      expect(missingSection()).not.toContain('| e | runtime |')
+    })
+  })
+
+  describe('When the run contains reconciliation rows to report', () => {
+    it('Then the script still exits 0, staying advisory', () => {
+      expect(exitCode).toBe(0)
+    })
+  })
+})

--- a/__tests__/integration/perf/compareBaselineReconciliation.test.ts
+++ b/__tests__/integration/perf/compareBaselineReconciliation.test.ts
@@ -20,6 +20,7 @@ const writeJson = (path: string, entries: unknown) =>
 
 let cwd: string
 let report: string
+let stdout: string
 let exitCode: number | null
 
 beforeAll(async () => {
@@ -55,17 +56,24 @@ beforeAll(async () => {
     ]),
   ])
 
-  // Act: spawn the real script with an explicit, stripped env — the
+  // Act: spawn the real script with only the GitHub variables removed — the
   // integration bucket runs in CI where GITHUB_TOKEN and GITHUB_REPOSITORY
   // are set, and an inherited env would make this attempt a real GitHub
-  // API call.
+  // API call. The rest of the environment is kept deliberately: a bare
+  // { PATH } also strips SystemRoot, which a Node child needs to start at
+  // all on the windows leg of the matrix.
+  const childEnv = { ...process.env }
+  delete childEnv.GITHUB_TOKEN
+  delete childEnv.GITHUB_REPOSITORY
+  delete childEnv.PR_NUMBER
   const sut = spawnSync(process.execPath, [SCRIPT_ENTRY], {
     cwd,
     encoding: 'utf8',
-    env: { PATH: process.env.PATH ?? '' },
+    env: childEnv,
   })
   exitCode = sut.status
 
+  stdout = sut.stdout
   report = await readFile(join(cwd, 'perf-comparison.md'), 'utf-8')
 })
 
@@ -128,6 +136,23 @@ describe('Given a PR run reconciled against a base run', () => {
   describe('When the run contains reconciliation rows to report', () => {
     it('Then the script still exits 0, staying advisory', () => {
       expect(exitCode).toBe(0)
+    })
+
+    // The annotation counts benchmark NAMES, while the tables above count
+    // (name, series) rows: b and c are missing from both series and e from
+    // memory alone, so the rows number five and the names three. Without the
+    // dedupe the annotation would double-count, and nothing else here would
+    // notice.
+    it('Then the missing annotation counts names once, not once per series', () => {
+      expect(stdout).toContain(
+        '::warning::3 benchmark(s) missing from this run: b, c, e'
+      )
+    })
+
+    it('Then the new-benchmark annotation is a notice, counted the same way', () => {
+      expect(stdout).toContain(
+        '::notice::2 new benchmark(s) in this run: b-renamed, d'
+      )
     })
   })
 })

--- a/__tests__/perf/cancellationKey.bench.ts
+++ b/__tests__/perf/cancellationKey.bench.ts
@@ -11,10 +11,10 @@ import { perfBench } from './harness/perfBench.js'
 // Pins the cost of deriving a cancellation key on a COLD registry — the
 // worst case getLines() actually pays once per sgd() invocation. It
 // deliberately does not reuse:
-//  - phase.bench.ts: one MetadataRepository built at module load and reused
-//    across every sample, over paths pre-stripped of their diff-status
-//    prefix. Both choices are exactly what a registry-lookup or line-shape
-//    regression would hide behind: warm pathCache, no prefix to strip.
+//  - phase.bench.ts: its cold benches already rebuild a fresh registry and
+//    fresh lines per iteration, but over MetadataRepository lookups, not
+//    the cancellation-key derivation this file measures — a different seam
+//    entirely, not a blindness to route around here.
 //  - gitAdapter.bench.ts: diffs this very repository's own `HEAD~20..HEAD`,
 //    which grows with every commit landed on a feature branch and is
 //    self-referential rather than a stable ceiling.

--- a/__tests__/perf/cancellationKey.bench.ts
+++ b/__tests__/perf/cancellationKey.bench.ts
@@ -15,9 +15,10 @@ import { perfBench } from './harness/perfBench.js'
 //    fresh lines per iteration, but over MetadataRepository lookups, not
 //    the cancellation-key derivation this file measures — a different seam
 //    entirely, not a blindness to route around here.
-//  - gitAdapter.bench.ts: diffs this very repository's own `HEAD~20..HEAD`,
-//    which grows with every commit landed on a feature branch and is
-//    self-referential rather than a stable ceiling.
+//  - gitAdapter.bench.ts: benches GitAdapter's own git IO (resolveCommit,
+//    streamDiffLines, getBufferContent, buildTreeIndex) against a fixed
+//    synthetic repository — a different seam entirely, not the
+//    key-derivation logic this file measures over synthetic diff lines.
 // Comparing this bench's number against the same file run over `main` (no
 // such file exists there, so the comparison happens in a throwaway checkout)
 // is what evidences the key-derivation budget.

--- a/__tests__/perf/cancellationKey.bench.ts
+++ b/__tests__/perf/cancellationKey.bench.ts
@@ -5,6 +5,7 @@ import { getDefinition } from '../../src/metadata/metadataManager.js'
 import type { Config } from '../../src/types/config.js'
 import RepoGitDiff from '../../src/utils/repoGitDiff.js'
 import { sourceDirs } from '../__utils__/sourceDirs.js'
+import { ROUND_COUNTER_PAD } from './fixtures/generateFixtures.js'
 import { buildPath, SHAPES, type Shape } from './fixtures/registryShapes.js'
 import { perfBench } from './harness/perfBench.js'
 
@@ -41,9 +42,6 @@ class CancellationKeyProbe extends RepoGitDiff {
 // tenth or less), so a regression in the key reads at close to its true
 // multiple instead of being diluted — without abandoning a cold registry.
 const LINES_PER_ROUND = 1500
-// Wide enough that the counter never outgrows its padding over a whole
-// benchmark run, so every sample keys a path of constant length.
-const ROUND_COUNTER_PAD = 7
 
 // Encapsulates the round counter so freshness is an invariant of this one
 // generator rather than a module-level mutable a later edit could read out

--- a/__tests__/perf/compareBaseline.mjs
+++ b/__tests__/perf/compareBaseline.mjs
@@ -33,15 +33,20 @@ const namesOf = entries => new Set(entries.map(entry => entry.name))
 // skipped, or produced no row. Skipping it would report the remaining rows as
 // a complete comparison, turning a vanished benchmark into a clean bill of
 // health — the same silence the missing-file guard above refuses.
-const missingFromRun = (base, pr) =>
-  base.filter(entry => !namesOf(pr).has(entry.name))
-const newInRun = (base, pr) =>
-  pr.filter(entry => !namesOf(base).has(entry.name))
+const missingFromRun = (base, prNames) =>
+  base.filter(entry => !prNames.has(entry.name))
+const newInRun = (pr, baseNames) =>
+  pr.filter(entry => !baseNames.has(entry.name))
 
-const missingRuntime = missingFromRun(baseRuntime, prRuntime)
-const newRuntime = newInRun(baseRuntime, prRuntime)
-const missingMemory = missingFromRun(baseMemory, prMemory)
-const newMemory = newInRun(baseMemory, prMemory)
+const prRuntimeNames = namesOf(prRuntime)
+const baseRuntimeNames = namesOf(baseRuntime)
+const prMemoryNames = namesOf(prMemory)
+const baseMemoryNames = namesOf(baseMemory)
+
+const missingRuntime = missingFromRun(baseRuntime, prRuntimeNames)
+const newRuntime = newInRun(prRuntime, baseRuntimeNames)
+const missingMemory = missingFromRun(baseMemory, prMemoryNames)
+const newMemory = newInRun(prMemory, baseMemoryNames)
 
 const regressions = []
 const improvements = []
@@ -131,7 +136,10 @@ if (missingRows.length > 0) {
   lines.push('')
 }
 
-if (missingRows.length > 0 || newRows.length > 0) {
+// A "new" row with no "missing" section above it has nothing to be a rename
+// counterpart to — the legend only makes sense once a benchmark actually
+// vanished from the base series.
+if (missingRows.length > 0) {
   lines.push(RENAME_LEGEND)
   lines.push('')
 }

--- a/__tests__/perf/compareBaseline.mjs
+++ b/__tests__/perf/compareBaseline.mjs
@@ -28,6 +28,21 @@ const toMap = entries =>
 const baseRuntimeMap = toMap(baseRuntime)
 const baseMemoryMap = toMap(baseMemory)
 
+const namesOf = entries => new Set(entries.map(entry => entry.name))
+// A base row with no PR counterpart is a benchmark that was renamed, deleted,
+// skipped, or produced no row. Skipping it would report the remaining rows as
+// a complete comparison, turning a vanished benchmark into a clean bill of
+// health — the same silence the missing-file guard above refuses.
+const missingFromRun = (base, pr) =>
+  base.filter(entry => !namesOf(pr).has(entry.name))
+const newInRun = (base, pr) =>
+  pr.filter(entry => !namesOf(base).has(entry.name))
+
+const missingRuntime = missingFromRun(baseRuntime, prRuntime)
+const newRuntime = newInRun(baseRuntime, prRuntime)
+const missingMemory = missingFromRun(baseMemory, prMemory)
+const newMemory = newInRun(baseMemory, prMemory)
+
 const regressions = []
 const improvements = []
 const stable = []
@@ -72,6 +87,27 @@ const tableRow = r =>
   `| ${r.name} | ${r.base} | ${r.pr} | ${r.ratio} | ${r.change} |`
 const tableHeader = '| Benchmark | Base | PR | Ratio | Change |\n|-|-|-|-|-|'
 
+const formatValue = entry =>
+  entry.unit === 'ms' ? `${entry.value}ms` : entry.value
+const reconciliationRow = (entry, series) =>
+  `| ${entry.name} | ${series} | ${formatValue(entry)} |`
+const reconciliationHeader = column =>
+  `| Benchmark | Series | ${column} |\n|-|-|-|`
+const RENAME_LEGEND =
+  'A renamed benchmark appears here under its old name and under "new" ' +
+  'below with its new name; a deleted or skipped benchmark, or one that ' +
+  'produced no row, appears only here. The tables below are not a ' +
+  'complete comparison.'
+
+const missingRows = [
+  ...missingRuntime.map(entry => reconciliationRow(entry, 'runtime')),
+  ...missingMemory.map(entry => reconciliationRow(entry, 'memory')),
+]
+const newRows = [
+  ...newRuntime.map(entry => reconciliationRow(entry, 'runtime')),
+  ...newMemory.map(entry => reconciliationRow(entry, 'memory')),
+]
+
 const lines = ['# Performance Comparison (same runner)\n']
 
 if (regressions.length > 0) {
@@ -88,6 +124,25 @@ if (improvements.length > 0) {
   lines.push('')
 }
 
+if (missingRows.length > 0) {
+  lines.push('## Benchmarks missing from this run\n')
+  lines.push(reconciliationHeader('Base'))
+  missingRows.forEach(r => lines.push(r))
+  lines.push('')
+}
+
+if (missingRows.length > 0 || newRows.length > 0) {
+  lines.push(RENAME_LEGEND)
+  lines.push('')
+}
+
+if (newRows.length > 0) {
+  lines.push('## Benchmarks new in this run\n')
+  lines.push(reconciliationHeader('PR'))
+  newRows.forEach(r => lines.push(r))
+  lines.push('')
+}
+
 lines.push('## Stable\n')
 lines.push(tableHeader)
 stable.forEach(r => lines.push(tableRow(r)))
@@ -96,8 +151,7 @@ lines.push('')
 const report = lines.join('\n')
 writeFileSync('perf-comparison.md', report)
 
-// biome-ignore lint/suspicious/noConsole: CI output
-console.info(report)
+console.log(report)
 
 // Post PR comment when running in CI
 const token = process.env.GITHUB_TOKEN
@@ -142,11 +196,32 @@ if (token && repo && prNumber) {
 // reusable-perf.yml `continue-on-error` + job comment). Emit a ::warning::
 // so regressions surface in the Actions summary, then exit 0.
 if (regressions.length > 0) {
-  // biome-ignore lint/suspicious/noConsole: CI output
-  console.warn(
+  console.log(
     `\n::warning::${regressions.length} performance regression(s) detected (runtime threshold: ${RUNTIME_THRESHOLD}x, latency threshold: ${MEMORY_THRESHOLD}x) — see PR comment for details`
   )
 } else {
-  // biome-ignore lint/suspicious/noConsole: CI output
-  console.info('No regressions detected.')
+  console.log('No regressions detected.')
+}
+
+// A missing benchmark can mean a rename, a deletion, a skip, or a crash —
+// the direction most likely to hide a real failure, so it is named in full,
+// not just counted. A benchmark missing from both series is one name, not
+// two rows, so the count and the name list dedupe across series; the table
+// above keeps the per-series detail. A new benchmark is comparatively
+// low-risk (nothing regressed against it yet), so it gets a ::notice::
+// rather than a ::warning::.
+const uniqueNames = entries => [...new Set(entries.map(entry => entry.name))]
+
+const missingNames = uniqueNames([...missingRuntime, ...missingMemory])
+if (missingNames.length > 0) {
+  console.log(
+    `\n::warning::${missingNames.length} benchmark(s) missing from this run: ${missingNames.join(', ')}`
+  )
+}
+
+const newNames = uniqueNames([...newRuntime, ...newMemory])
+if (newNames.length > 0) {
+  console.log(
+    `\n::notice::${newNames.length} new benchmark(s) in this run: ${newNames.join(', ')}`
+  )
 }

--- a/__tests__/perf/fixtures/generateFixtures.ts
+++ b/__tests__/perf/fixtures/generateFixtures.ts
@@ -16,7 +16,7 @@ const CHANGE_KIND_BY_GIT: Record<string, AddKind> = {
   [DELETION]: ChangeKind.Delete,
 }
 
-type FixtureSize = 'small' | 'medium' | 'large'
+export type FixtureSize = 'small' | 'medium' | 'large'
 
 interface SizeConfig {
   readonly classes: number
@@ -52,53 +52,49 @@ const SIZE_CONFIGS: Record<FixtureSize, SizeConfig> = {
 
 const pad = (n: number): string => String(n).padStart(4, '0')
 
-const generateDiffLines = (config: SizeConfig): string[] => {
+const DEFAULT_ROOT = 'force-app/main/default'
+
+const generateDiffLines = (config: SizeConfig, root: string): string[] => {
   const lines: string[] = []
 
   for (let i = 0; i < config.classes; i++) {
     const changeType =
       i % 3 === 0 ? ADDITION : i % 3 === 1 ? MODIFICATION : DELETION
-    lines.push(
-      `${changeType}\tforce-app/main/default/classes/MyClass${pad(i)}.cls`
-    )
-    lines.push(
-      `${changeType}\tforce-app/main/default/classes/MyClass${pad(i)}.cls-meta.xml`
-    )
+    lines.push(`${changeType}\t${root}/classes/MyClass${pad(i)}.cls`)
+    lines.push(`${changeType}\t${root}/classes/MyClass${pad(i)}.cls-meta.xml`)
   }
 
   for (let i = 0; i < config.triggers; i++) {
+    lines.push(`${ADDITION}\t${root}/triggers/MyTrigger${pad(i)}.trigger`)
     lines.push(
-      `${ADDITION}\tforce-app/main/default/triggers/MyTrigger${pad(i)}.trigger`
-    )
-    lines.push(
-      `${ADDITION}\tforce-app/main/default/triggers/MyTrigger${pad(i)}.trigger-meta.xml`
+      `${ADDITION}\t${root}/triggers/MyTrigger${pad(i)}.trigger-meta.xml`
     )
   }
 
   for (let i = 0; i < config.lwcComponents; i++) {
     lines.push(
-      `${MODIFICATION}\tforce-app/main/default/lwc/myComponent${pad(i)}/myComponent${pad(i)}.js`
+      `${MODIFICATION}\t${root}/lwc/myComponent${pad(i)}/myComponent${pad(i)}.js`
     )
     lines.push(
-      `${MODIFICATION}\tforce-app/main/default/lwc/myComponent${pad(i)}/myComponent${pad(i)}.html`
+      `${MODIFICATION}\t${root}/lwc/myComponent${pad(i)}/myComponent${pad(i)}.html`
     )
     lines.push(
-      `${MODIFICATION}\tforce-app/main/default/lwc/myComponent${pad(i)}/myComponent${pad(i)}.js-meta.xml`
+      `${MODIFICATION}\t${root}/lwc/myComponent${pad(i)}/myComponent${pad(i)}.js-meta.xml`
     )
   }
 
   for (let i = 0; i < config.customObjects; i++) {
     lines.push(
-      `${MODIFICATION}\tforce-app/main/default/objects/CustomObj${pad(i)}__c/CustomObj${pad(i)}__c.object-meta.xml`
+      `${MODIFICATION}\t${root}/objects/CustomObj${pad(i)}__c/CustomObj${pad(i)}__c.object-meta.xml`
     )
     lines.push(
-      `${ADDITION}\tforce-app/main/default/objects/CustomObj${pad(i)}__c/fields/NewField__c.field-meta.xml`
+      `${ADDITION}\t${root}/objects/CustomObj${pad(i)}__c/fields/NewField__c.field-meta.xml`
     )
   }
 
   for (let i = 0; i < config.profiles; i++) {
     lines.push(
-      `${MODIFICATION}\tforce-app/main/default/profiles/Admin${pad(i)}.profile-meta.xml`
+      `${MODIFICATION}\t${root}/profiles/Admin${pad(i)}.profile-meta.xml`
     )
   }
 
@@ -108,8 +104,38 @@ const generateDiffLines = (config: SizeConfig): string[] => {
 export const generateDiffFixtures = (
   size: FixtureSize
 ): { readonly lines: string[] } => ({
-  lines: generateDiffLines(SIZE_CONFIGS[size]),
+  lines: generateDiffLines(SIZE_CONFIGS[size], DEFAULT_ROOT),
 })
+
+export type DiffLineSource = () => readonly string[]
+
+// Wide enough that the counter never outgrows its padding over a whole
+// benchmark run, so every generated line keeps a constant length across
+// samples (mirrors cancellationKey.bench.ts's ROUND_COUNTER_PAD).
+const ROUND_COUNTER_PAD = 7
+
+// Distinct content every call: a `round<N>` directory segment rides between
+// `force-app/` and `main/`, so every line is a registry miss on any
+// registry and the round counter never matches a registry directory name.
+export const createDistinctRoundLines = (size: FixtureSize): DiffLineSource => {
+  let round = 0
+  return (): readonly string[] => {
+    round += 1
+    const n = String(round).padStart(ROUND_COUNTER_PAD, '0')
+    return generateDiffLines(
+      SIZE_CONFIGS[size],
+      `force-app/round${n}/main/default`
+    )
+  }
+}
+
+// Same content every call, new string objects every call: what a second sgd
+// run over the same paths pays — the Map lookup must hash a string V8 has
+// never seen, instead of reading a hash cached on a reused object.
+export const createSameContentLines = (size: FixtureSize): DiffLineSource => {
+  return (): readonly string[] =>
+    generateDiffLines(SIZE_CONFIGS[size], DEFAULT_ROOT)
+}
 
 export const generateManifestElements = (
   size: FixtureSize

--- a/__tests__/perf/fixtures/generateFixtures.ts
+++ b/__tests__/perf/fixtures/generateFixtures.ts
@@ -111,8 +111,13 @@ export type DiffLineSource = () => readonly string[]
 
 // Wide enough that the counter never outgrows its padding over a whole
 // benchmark run, so every generated line keeps a constant length across
-// samples (mirrors cancellationKey.bench.ts's ROUND_COUNTER_PAD).
-const ROUND_COUNTER_PAD = 7
+// samples. Exported so cancellationKey.bench.ts — same per-round scale — can
+// import this exact declaration instead of re-declaring its own copy.
+// ignoredAdditionProbe.bench.ts declares its own, wider ROUND_COUNTER_PAD:
+// its per-round scale (up to 50,000 paths, versus the 1,500 lines/round this
+// value is sized for) can outgrow 7 digits sooner, so that one is not a
+// candidate for unifying onto this value.
+export const ROUND_COUNTER_PAD = 7
 
 // Distinct content every call: a `round<N>` directory segment rides between
 // `force-app/` and `main/`, so every line is a registry miss on any

--- a/__tests__/perf/fixtures/historyRepoFixture.ts
+++ b/__tests__/perf/fixtures/historyRepoFixture.ts
@@ -107,8 +107,10 @@ const commitBlock = (revision: number, message: string): string =>
  * HEAD~20..HEAD shape so the four gitAdapter benches keep their scale. Built
  * with one `git fast-import` stream carrying fixed author/committer
  * timestamps — same input, same OIDs, on every machine and every run
- * (measured: 39/41/43 ms, 3 spawns total for the whole build, identical
- * `HEAD`/`HEAD~20` OIDs across repeated builds). fast-import writes
+ * (measured: 58-100 ms across three runs on a dev machine, load-dependent,
+ * not a promised bound; 4 spawns total for the whole build — init,
+ * fast-import, symbolic-ref, repack — identical `HEAD`/`HEAD~20` OIDs across
+ * repeated builds). fast-import writes
  * `refs/heads/main` directly; `HEAD` still follows the runner's
  * `init.defaultBranch` until pointed there explicitly. Finished with
  * `repack -adq` so the bench reads one pack, the way a real clone or CI

--- a/__tests__/perf/fixtures/historyRepoFixture.ts
+++ b/__tests__/perf/fixtures/historyRepoFixture.ts
@@ -1,0 +1,180 @@
+'use strict'
+import { initRepo } from '../../__utils__/gitFixtureRepo.js'
+import { runGit } from '../../__utils__/gitTestHarness.js'
+
+export type HistoryRepoRefs = Readonly<{
+  from: string
+  to: string
+  blobPaths: readonly string[]
+}>
+
+// resolveCommit walks this many parents, exactly as it does against the
+// worktree's own history today — kept symbolic so the bench still exercises
+// a real parent walk, not a literal OID.
+export const HISTORY_DEPTH = 20
+
+const BRANCH_REF = 'refs/heads/main'
+const IDENTITY = 'sgd-test <sgd-test@example.com>'
+// A stray digit of wall-clock time would still make every OID a pure
+// function of this file's own logic, but a literal constant makes that
+// obvious on read rather than requiring the reader to trust it.
+const BASE_EPOCH_SECONDS = 1_700_000_000
+const MODE = '100644'
+
+const TYPE_NAMES = [
+  'classes',
+  'objects',
+  'layouts',
+  'flows',
+  'permissionsets',
+  'staticresources',
+  'lwc',
+  'aura',
+  'triggers',
+  'pages',
+] as const
+const DIR_COUNT = 20
+// Root + churn lands the shape at sgd's own scale: 364 root files, 400
+// tracked at HEAD (364 - 7 deleted + 43 added), 193 changed paths across
+// the 20-commit range (143 M = 141 regular + the 2 blobs below, 43 A, 7 D) —
+// the same order of magnitude as HEAD~20..HEAD on the sgd checkout itself
+// (358 tracked files; 193 paths, 43 A / 7 D / 143 M).
+const REGULAR_FILE_COUNT = 362
+const MODIFY_COUNT = 141
+const DELETE_COUNT = 7
+const NEW_FILE_COUNT = 43
+const BLOB_SIZE_BYTES = 9 * 1024
+
+const BLOB_PATH_A = 'force-app/main/default/classes/LargeBlobA.cls'
+const BLOB_PATH_B = 'force-app/main/default/classes/LargeBlobB.cls'
+
+const regularPath = (dirIndex: number, fileIndex: number): string =>
+  `force-app/main/default/${TYPE_NAMES[dirIndex % TYPE_NAMES.length]}/dir${dirIndex}/file${fileIndex}.txt`
+
+const buildRegularPaths = (count: number): string[] => {
+  const paths: string[] = []
+  let dirIndex = 0
+  let fileIndex = 0
+  while (paths.length < count) {
+    paths.push(regularPath(dirIndex, fileIndex))
+    dirIndex += 1
+    if (dirIndex === DIR_COUNT) {
+      dirIndex = 0
+      fileIndex += 1
+    }
+  }
+  return paths
+}
+
+// Spreads `total` as evenly as possible over `buckets`, front-loading the
+// remainder so every bucket's count is deterministic from its index alone.
+const distribute = (total: number, buckets: number): number[] => {
+  const base = Math.floor(total / buckets)
+  const remainder = total % buckets
+  return Array.from({ length: buckets }, (_, index) =>
+    index < remainder ? base + 1 : base
+  )
+}
+
+const fileContent = (path: string, revision: number): string =>
+  `${path} rev${revision}\n`
+
+// Fixed length regardless of `revision`'s digit count, so every blob write
+// is the same ~9 KB getBufferContent is meant to cost.
+const blobContent = (label: string, revision: number): string => {
+  const line = `${label}-rev${revision}-`
+  const repeated = line.repeat(Math.ceil(BLOB_SIZE_BYTES / line.length))
+  return `${repeated.slice(0, BLOB_SIZE_BYTES - 1)}\n`
+}
+
+const dataBlock = (content: string): string =>
+  `data ${Buffer.byteLength(content, 'utf8')}\n${content}`
+
+const modifyLine = (path: string, content: string): string =>
+  `M ${MODE} inline ${path}\n${dataBlock(content)}`
+
+const deleteLine = (path: string): string => `D ${path}\n`
+
+const commitBlock = (revision: number, message: string): string =>
+  `commit ${BRANCH_REF}\n` +
+  `author ${IDENTITY} ${BASE_EPOCH_SECONDS + revision} +0000\n` +
+  `committer ${IDENTITY} ${BASE_EPOCH_SECONDS + revision} +0000\n` +
+  dataBlock(`${message}\n`)
+
+/**
+ * Builds a self-contained, deterministic history in `dir` (already an empty
+ * directory): a root commit plus HISTORY_DEPTH commits, sized to sgd's own
+ * HEAD~20..HEAD shape so the four gitAdapter benches keep their scale. Built
+ * with one `git fast-import` stream carrying fixed author/committer
+ * timestamps — same input, same OIDs, on every machine and every run
+ * (measured: 39/41/43 ms, 3 spawns total for the whole build, identical
+ * `HEAD`/`HEAD~20` OIDs across repeated builds). fast-import writes
+ * `refs/heads/main` directly; `HEAD` still follows the runner's
+ * `init.defaultBranch` until pointed there explicitly. Finished with
+ * `repack -adq` so the bench reads one pack, the way a real clone or CI
+ * checkout does — an unpacked fixture would bench tsgit's loose-object
+ * reader instead of sgd. Plumbing only: no working-tree checkout, no
+ * symlinks, no executable bits, so it builds on the Windows legs too.
+ */
+export const buildHistoryRepo = (dir: string): HistoryRepoRefs => {
+  initRepo(dir)
+
+  const regularPaths = buildRegularPaths(REGULAR_FILE_COUNT)
+  const modifyPaths = regularPaths.slice(0, MODIFY_COUNT)
+  const deletePaths = regularPaths.slice(
+    MODIFY_COUNT,
+    MODIFY_COUNT + DELETE_COUNT
+  )
+
+  const chunks: string[] = []
+
+  chunks.push(commitBlock(0, 'root'))
+  for (const path of regularPaths) {
+    chunks.push(modifyLine(path, fileContent(path, 0)))
+  }
+  chunks.push(modifyLine(BLOB_PATH_A, blobContent('blob-a', 0)))
+  chunks.push(modifyLine(BLOB_PATH_B, blobContent('blob-b', 0)))
+
+  const modifyCounts = distribute(MODIFY_COUNT, HISTORY_DEPTH)
+  const deleteCounts = distribute(DELETE_COUNT, HISTORY_DEPTH)
+  const newCounts = distribute(NEW_FILE_COUNT, HISTORY_DEPTH)
+  let modifyCursor = 0
+  let deleteCursor = 0
+  let newCursor = 0
+
+  for (let commitIndex = 0; commitIndex < HISTORY_DEPTH; commitIndex++) {
+    const revision = commitIndex + 1
+    chunks.push(commitBlock(revision, `history ${revision}`))
+    chunks.push(modifyLine(BLOB_PATH_A, blobContent('blob-a', revision)))
+    chunks.push(modifyLine(BLOB_PATH_B, blobContent('blob-b', revision)))
+
+    for (let i = 0; i < modifyCounts[commitIndex]; i++) {
+      const path = modifyPaths[modifyCursor]
+      modifyCursor += 1
+      chunks.push(modifyLine(path, fileContent(path, revision)))
+    }
+    for (let i = 0; i < deleteCounts[commitIndex]; i++) {
+      const path = deletePaths[deleteCursor]
+      deleteCursor += 1
+      chunks.push(deleteLine(path))
+    }
+    for (let i = 0; i < newCounts[commitIndex]; i++) {
+      const path = `force-app/main/default/added/newFile${newCursor}.txt`
+      newCursor += 1
+      chunks.push(modifyLine(path, fileContent(path, revision)))
+    }
+  }
+
+  runGit(['fast-import', '--quiet', '--date-format=raw'], {
+    cwd: dir,
+    input: Buffer.from(chunks.join(''), 'utf8'),
+  })
+  runGit(['symbolic-ref', 'HEAD', BRANCH_REF], { cwd: dir })
+  runGit(['repack', '-adq'], { cwd: dir })
+
+  return {
+    from: `HEAD~${HISTORY_DEPTH}`,
+    to: 'HEAD',
+    blobPaths: [BLOB_PATH_A, BLOB_PATH_B],
+  }
+}

--- a/__tests__/perf/gitAdapter.bench.ts
+++ b/__tests__/perf/gitAdapter.bench.ts
@@ -1,32 +1,58 @@
+import { rm } from 'node:fs/promises'
 import { afterAll, describe } from 'vitest'
 import GitAdapter from '../../src/adapter/GitAdapter.js'
 import type { Config } from '../../src/types/config.js'
 import type { FileGitRef } from '../../src/types/git.js'
+import { createTempDir } from '../__utils__/gitTestHarness.js'
 import { sourceDirs } from '../__utils__/sourceDirs.js'
-import { assertMeanWithinCeiling, perfBench } from './harness/perfBench.js'
+import { buildHistoryRepo } from './fixtures/historyRepoFixture.js'
+import {
+  assertMeanWithinCeiling,
+  perfBench,
+  RUNNER_NOISE_FACTOR,
+} from './harness/perfBench.js'
 
-// Regression bench over the sgd repo's OWN history (HEAD~20..HEAD): a
-// lightweight per-run sanity check that a future @scolladon/tsgit upgrade
-// (or an adapter change) has not silently reintroduced an order-of-magnitude
-// slowdown (e.g. a materialize-everything code path). Ceilings are
-// deliberately generous — shared CI runners are noisy (±40% run-to-run
-// variance is normal, see docs/plans/tsgit-bench/README.md) — so these exist
-// to catch real regressions, not to police ordinary variance.
-const REPO_ROOT = process.cwd()
-const FROM = 'HEAD~20'
-const TO = 'HEAD'
+// Regression bench over a FIXED synthetic history (historyRepoFixture.ts),
+// never over this repository's own commits: a lightweight per-run sanity
+// check that a future @scolladon/tsgit upgrade (or an adapter change) has
+// not silently reintroduced an order-of-magnitude slowdown (e.g. a
+// materialize-everything code path). The fixture is rebuilt from a fixed
+// `git fast-import` stream on every run, so what these four ceilings bound
+// is GitAdapter's own cost, never how many commits have landed on the
+// branch under test. Ceilings are deliberately generous — shared CI runners
+// are noisy (±40% run-to-run variance is normal, see
+// docs/plans/tsgit-bench/README.md) — so these exist to catch real
+// regressions, not to police ordinary variance.
+const REPO_ROOT = await createTempDir('sgd-bench-history-')
+const { from: FROM, to: TO, blobPaths } = buildHistoryRepo(REPO_ROOT)
 
-const RESOLVE_COMMIT_CEILING_MS = 200
-const BUILD_TREE_INDEX_CEILING_MS = 1_000
-const STREAM_DIFF_LINES_CEILING_MS = 500
-const BLOB_READ_CEILING_MS = 200
+const deriveCeilingMs = (worstMeanMs: number): number =>
+  Math.ceil((worstMeanMs * RUNNER_NOISE_FACTOR) / 100) * 100
 
-const BLOB_REFS: FileGitRef[] = [
-  { path: 'package.json', oid: FROM },
-  { path: 'src/main.ts', oid: FROM },
-  { path: 'package.json', oid: TO },
-  { path: 'src/main.ts', oid: TO },
-]
+// Re-derived against the fixture above (worst-of-three measured means, ms):
+//   resolveCommit:    0.5614 / 0.5494 / 0.5526
+//   streamDiffLines:  1.6279 / 1.6010 / 1.5901
+//   getBufferContent: 0.0214 / 0.0213 / 0.0214
+//   buildTreeIndex:   6.3120 / 6.1365 / 6.1487
+// Ceiling is the worst mean × RUNNER_NOISE_FACTOR, rounded up to the next
+// 100ms (the pipeline.bench.ts convention).
+const RESOLVE_COMMIT_WORST_MEAN_MS = 0.5614
+const STREAM_DIFF_LINES_WORST_MEAN_MS = 1.6279
+const BLOB_READ_WORST_MEAN_MS = 0.0214
+const BUILD_TREE_INDEX_WORST_MEAN_MS = 6.312
+
+const RESOLVE_COMMIT_CEILING_MS = deriveCeilingMs(RESOLVE_COMMIT_WORST_MEAN_MS)
+const BUILD_TREE_INDEX_CEILING_MS = deriveCeilingMs(
+  BUILD_TREE_INDEX_WORST_MEAN_MS
+)
+const STREAM_DIFF_LINES_CEILING_MS = deriveCeilingMs(
+  STREAM_DIFF_LINES_WORST_MEAN_MS
+)
+const BLOB_READ_CEILING_MS = deriveCeilingMs(BLOB_READ_WORST_MEAN_MS)
+
+const BLOB_REFS: FileGitRef[] = [FROM, TO].flatMap(oid =>
+  blobPaths.map(path => ({ path, oid }))
+)
 
 const baseConfig: Config = {
   to: TO,
@@ -41,6 +67,7 @@ const baseConfig: Config = {
 
 afterAll(async () => {
   await GitAdapter.closeAll()
+  await rm(REPO_ROOT, { recursive: true, force: true })
 })
 
 describe('gitAdapter-history-resolveCommit', () => {
@@ -49,7 +76,7 @@ describe('gitAdapter-history-resolveCommit', () => {
   const elapsedMs: number[] = []
 
   perfBench(
-    'resolveCommit-HEAD~20-and-HEAD',
+    'resolveCommit-fixture-HEAD~20-and-HEAD',
     async () => {
       const start = performance.now()
       await adapter.resolveCommit(FROM)
@@ -73,7 +100,7 @@ describe('gitAdapter-history-streamDiffLines', () => {
   const elapsedMs: number[] = []
 
   perfBench(
-    'streamDiffLines-HEAD~20..HEAD',
+    'streamDiffLines-fixture-HEAD~20..HEAD',
     async () => {
       const start = performance.now()
       const verdict = { changesSeen: 0, linesYielded: 0 }
@@ -109,7 +136,7 @@ describe('gitAdapter-history-blobReads', () => {
   const elapsedMs: number[] = []
 
   perfBench(
-    'getBufferContent-HEAD~20-and-HEAD',
+    'getBufferContent-fixture-HEAD~20-and-HEAD',
     async () => {
       const start = performance.now()
       for (const ref of BLOB_REFS) {
@@ -137,7 +164,7 @@ describe('gitAdapter-history-buildTreeIndex', () => {
   const elapsedMs: number[] = []
 
   perfBench(
-    'buildTreeIndex-HEAD-cold',
+    'buildTreeIndex-fixture-HEAD-cold',
     async () => {
       await GitAdapter.closeAll()
       const adapter = GitAdapter.getInstance(baseConfig)

--- a/__tests__/perf/gitAdapter.bench.ts
+++ b/__tests__/perf/gitAdapter.bench.ts
@@ -56,12 +56,14 @@ describe('gitAdapter-history-resolveCommit', () => {
       await adapter.resolveCommit(TO)
       elapsedMs.push(performance.now() - start)
     },
-    () =>
-      assertMeanWithinCeiling(
-        'resolveCommit',
-        elapsedMs,
-        RESOLVE_COMMIT_CEILING_MS
-      )
+    {
+      afterRun: () =>
+        assertMeanWithinCeiling(
+          'resolveCommit',
+          elapsedMs,
+          RESOLVE_COMMIT_CEILING_MS
+        ),
+    }
   )
 })
 
@@ -90,12 +92,14 @@ describe('gitAdapter-history-streamDiffLines', () => {
       }
       elapsedMs.push(performance.now() - start)
     },
-    () =>
-      assertMeanWithinCeiling(
-        'streamDiffLines',
-        elapsedMs,
-        STREAM_DIFF_LINES_CEILING_MS
-      )
+    {
+      afterRun: () =>
+        assertMeanWithinCeiling(
+          'streamDiffLines',
+          elapsedMs,
+          STREAM_DIFF_LINES_CEILING_MS
+        ),
+    }
   )
 })
 
@@ -113,12 +117,14 @@ describe('gitAdapter-history-blobReads', () => {
       }
       elapsedMs.push(performance.now() - start)
     },
-    () =>
-      assertMeanWithinCeiling(
-        'getBufferContent',
-        elapsedMs,
-        BLOB_READ_CEILING_MS
-      )
+    {
+      afterRun: () =>
+        assertMeanWithinCeiling(
+          'getBufferContent',
+          elapsedMs,
+          BLOB_READ_CEILING_MS
+        ),
+    }
   )
 })
 
@@ -139,11 +145,13 @@ describe('gitAdapter-history-buildTreeIndex', () => {
       await adapter.buildTreeIndex(TO, ['.'])
       elapsedMs.push(performance.now() - start)
     },
-    () =>
-      assertMeanWithinCeiling(
-        'buildTreeIndex',
-        elapsedMs,
-        BUILD_TREE_INDEX_CEILING_MS
-      )
+    {
+      afterRun: () =>
+        assertMeanWithinCeiling(
+          'buildTreeIndex',
+          elapsedMs,
+          BUILD_TREE_INDEX_CEILING_MS
+        ),
+    }
   )
 })

--- a/__tests__/perf/gitAdapter.bench.ts
+++ b/__tests__/perf/gitAdapter.bench.ts
@@ -33,18 +33,31 @@ const { from: FROM, to: TO, blobPaths } = buildHistoryRepo(REPO_ROOT)
 // one commit that FROM or TO is about to be measured on.
 const HANDLE_OPEN_REF = 'HEAD~1'
 
-// Provisional. This fixture is new AND, as of this change, measures cold
-// reads (closeAll + getInstance + one untimed open per sample — see the
-// beforeEach hooks below), so no gh-pages CI history exists yet for any of
-// these four (contrast pipeline.bench.ts, which has 48 CI runs to derive
-// from — see the CI-sourced comment there). Ceiling = local cold worst-of-
-// three mean × ~3.2 (the CI/local ratio measured independently on
-// pipeline.bench.ts's own benches) × RUNNER_NOISE_FACTOR (3), rounded to the
-// nearest whole ms via a one-decimal (3-significant-figure) intermediate —
-// not deriveCeilingMs's measured-worst-mean formula, since there is no
-// CI-measured worst mean to feed it yet. Re-seed all four from this branch's
-// first CI perf run and switch back to deriveCeilingMs(ciWorstMeanMs) once
-// that history exists.
+// Seeded locally, then CONFIRMED against ubuntu-latest — the runner that
+// evaluates them. A ceiling compared against a CI number must be built from
+// CI numbers, so these were provisional until a CI run existed for this
+// fixture (it is new, and as of this change measures cold reads: closeAll +
+// getInstance + one untimed open per sample, see the beforeEach hooks below).
+//
+// First CI perf run of this branch measured, in ms:
+//   resolveCommit    4.59   (ceiling 20, headroom 4.4x)
+//   streamDiffLines 15.63   (ceiling 53, headroom 3.4x)
+//   getBufferContent 17.86  (ceiling 71, headroom 4.0x)
+//   buildTreeIndex  12.05   (ceiling 58, headroom 4.8x)
+// All four held. The values are deliberately NOT tightened to the ~3x these
+// measurements alone would give (14/47/54/37): that would be a re-derivation
+// from a single observation, and the same run showed pipeline-100 at 25.67ms
+// against a base of 33.18ms — a 22.7% swing with no relevant code change.
+// Tightening four ceilings against demonstrated +/-22% run-to-run variance
+// manufactures the flake this rule exists to avoid. Re-derive properly with
+// deriveCeilingMs(ciWorstMeanMs) once the gh-pages series holds three or more
+// points for these names.
+//
+// The local derivation that produced the current values, kept because it is
+// what the numbers still are: local cold worst-of-three mean x ~3.2 (the
+// CI/local ratio measured independently on pipeline.bench.ts's own benches)
+// x RUNNER_NOISE_FACTOR (3), rounded to the nearest whole ms via a
+// one-decimal (3-significant-figure) intermediate.
 //
 // Local cold worst-of-three measured means, ms (three `vitest bench` runs
 // against this exact beforeEach implementation, each averaging ~140-750

--- a/__tests__/perf/gitAdapter.bench.ts
+++ b/__tests__/perf/gitAdapter.bench.ts
@@ -8,8 +8,8 @@ import { sourceDirs } from '../__utils__/sourceDirs.js'
 import { buildHistoryRepo } from './fixtures/historyRepoFixture.js'
 import {
   assertMeanWithinCeiling,
+  deriveCeilingMs,
   perfBench,
-  RUNNER_NOISE_FACTOR,
 } from './harness/perfBench.js'
 
 // Regression bench over a FIXED synthetic history (historyRepoFixture.ts),
@@ -19,23 +19,19 @@ import {
 // materialize-everything code path). The fixture is rebuilt from a fixed
 // `git fast-import` stream on every run, so what these four ceilings bound
 // is GitAdapter's own cost, never how many commits have landed on the
-// branch under test. Ceilings are deliberately generous — shared CI runners
-// are noisy (±40% run-to-run variance is normal, see
-// docs/plans/tsgit-bench/README.md) — so these exist to catch real
-// regressions, not to police ordinary variance.
+// branch under test. Shared CI runners are noisy (±40% run-to-run variance
+// is normal, see docs/plans/tsgit-bench/README.md) — these ceilings exist
+// to catch real regressions, not to police ordinary variance.
 const REPO_ROOT = await createTempDir('sgd-bench-history-')
 const { from: FROM, to: TO, blobPaths } = buildHistoryRepo(REPO_ROOT)
-
-const deriveCeilingMs = (worstMeanMs: number): number =>
-  Math.ceil((worstMeanMs * RUNNER_NOISE_FACTOR) / 100) * 100
 
 // Re-derived against the fixture above (worst-of-three measured means, ms):
 //   resolveCommit:    0.5614 / 0.5494 / 0.5526
 //   streamDiffLines:  1.6279 / 1.6010 / 1.5901
 //   getBufferContent: 0.0214 / 0.0213 / 0.0214
 //   buildTreeIndex:   6.3120 / 6.1365 / 6.1487
-// Ceiling is the worst mean × RUNNER_NOISE_FACTOR, rounded up to the next
-// 100ms (the pipeline.bench.ts convention).
+// Ceiling is the worst mean × RUNNER_NOISE_FACTOR, rounded up to two
+// significant figures (see deriveCeilingMs).
 const RESOLVE_COMMIT_WORST_MEAN_MS = 0.5614
 const STREAM_DIFF_LINES_WORST_MEAN_MS = 1.6279
 const BLOB_READ_WORST_MEAN_MS = 0.0214

--- a/__tests__/perf/gitAdapter.bench.ts
+++ b/__tests__/perf/gitAdapter.bench.ts
@@ -6,45 +6,65 @@ import type { FileGitRef } from '../../src/types/git.js'
 import { createTempDir } from '../__utils__/gitTestHarness.js'
 import { sourceDirs } from '../__utils__/sourceDirs.js'
 import { buildHistoryRepo } from './fixtures/historyRepoFixture.js'
-import {
-  assertMeanWithinCeiling,
-  deriveCeilingMs,
-  perfBench,
-} from './harness/perfBench.js'
+import { assertMeanWithinCeiling, perfBench } from './harness/perfBench.js'
 
 // Regression bench over a FIXED synthetic history (historyRepoFixture.ts),
 // never over this repository's own commits: a lightweight per-run sanity
 // check that a future @scolladon/tsgit upgrade (or an adapter change) has
-// not silently reintroduced an order-of-magnitude slowdown (e.g. a
-// materialize-everything code path). The fixture is rebuilt from a fixed
-// `git fast-import` stream on every run, so what these four ceilings bound
-// is GitAdapter's own cost, never how many commits have landed on the
-// branch under test. Shared CI runners are noisy (±40% run-to-run variance
-// is normal, see docs/plans/tsgit-bench/README.md) — these ceilings exist
-// to catch real regressions, not to police ordinary variance.
+// not silently reintroduced an order-of-magnitude slowdown. A
+// materialize-everything code path is one instance buildTreeIndex is built
+// to catch; the other three below catch a lost deltaCache hit or any other
+// per-object cold-read regression — a different failure mode, not that one.
+// The fixture is rebuilt from a fixed `git fast-import` stream on every run,
+// so what these four ceilings bound is GitAdapter's own cost, never how many
+// commits have landed on the branch under test. Shared CI runners are noisy
+// (±40% run-to-run variance is normal, see docs/plans/tsgit-bench/README.md)
+// — these ceilings exist to catch real regressions, not to police ordinary
+// variance.
 const REPO_ROOT = await createTempDir('sgd-bench-history-')
 const { from: FROM, to: TO, blobPaths } = buildHistoryRepo(REPO_ROOT)
 
-// Re-derived against the fixture above (worst-of-three measured means, ms):
-//   resolveCommit:    0.5614 / 0.5494 / 0.5526
-//   streamDiffLines:  1.6279 / 1.6010 / 1.5901
-//   getBufferContent: 0.0214 / 0.0213 / 0.0214
-//   buildTreeIndex:   6.3120 / 6.1365 / 6.1487
-// Ceiling is the worst mean × RUNNER_NOISE_FACTOR, rounded up to two
-// significant figures (see deriveCeilingMs).
-const RESOLVE_COMMIT_WORST_MEAN_MS = 0.5614
-const STREAM_DIFF_LINES_WORST_MEAN_MS = 1.6279
-const BLOB_READ_WORST_MEAN_MS = 0.0214
-const BUILD_TREE_INDEX_WORST_MEAN_MS = 6.312
+// A ref distinct from both FROM ('HEAD~20') and TO ('HEAD'): resolving it in
+// a beforeEach hook pays tsgit's one-time repo-open cost (openRepository,
+// pack index parsing — lazily paid on a handle's first read, see
+// GitAdapter#getRepo) without warming the deltaCache entry that FROM or TO
+// is about to be measured on.
+const HANDLE_OPEN_REF = 'HEAD~1'
 
-const RESOLVE_COMMIT_CEILING_MS = deriveCeilingMs(RESOLVE_COMMIT_WORST_MEAN_MS)
-const BUILD_TREE_INDEX_CEILING_MS = deriveCeilingMs(
-  BUILD_TREE_INDEX_WORST_MEAN_MS
-)
-const STREAM_DIFF_LINES_CEILING_MS = deriveCeilingMs(
-  STREAM_DIFF_LINES_WORST_MEAN_MS
-)
-const BLOB_READ_CEILING_MS = deriveCeilingMs(BLOB_READ_WORST_MEAN_MS)
+// Provisional. This fixture is new AND, as of this change, measures cold
+// reads (closeAll + getInstance + one untimed open per sample — see the
+// beforeEach hooks below), so no gh-pages CI history exists yet for any of
+// these four (contrast pipeline.bench.ts, which has 48 CI runs to derive
+// from — see the CI-sourced comment there). Ceiling = local cold worst-of-
+// three mean × ~3.2 (the CI/local ratio measured independently on
+// pipeline.bench.ts's own benches) × RUNNER_NOISE_FACTOR (3), rounded to the
+// nearest whole ms — not deriveCeilingMs's measured-worst-mean formula,
+// since there is no CI-measured worst mean to feed it yet. Re-seed all four
+// from this branch's first CI perf run and switch back to
+// deriveCeilingMs(ciWorstMeanMs) once that history exists.
+//
+// Local cold worst-of-three measured means, ms (three `vitest bench` runs
+// against this exact beforeEach implementation, each averaging ~140-750
+// fresh-handle samples):
+//   resolveCommit:    2.0283 / 1.6642 / 1.3358  (worst × 9.6 = 19.5 -> 20)
+//   streamDiffLines:  5.5584 / 5.3818 / 4.7968  (worst × 9.6 = 53.4 -> 53)
+//   getBufferContent: 7.1166 / 7.3443 / 6.4534  (worst × 9.6 = 70.5 -> 71)
+//   buildTreeIndex:   5.9972 / 4.6063 / 6.0402  (worst × 9.6 = 58.0 -> 58,
+//     unchanged bench body — see its own describe)
+//
+// getBufferContent disagrees sharply with a design-doc estimate of 2.6ms:
+// measured here it is the single most expensive read of the four, not the
+// cheapest. Isolated follow-up (one blob, one revision, same beforeEach)
+// still cost 3.06ms (FROM) / 4.36ms (TO) per single cold read — this
+// fixture's ~9KB blobs are packed as delta chains against every prior
+// revision (historyRepoFixture writes both BLOB_PATH_A/B on all 21 commits),
+// so a cold read walks that chain; a Map-lookup-cheap estimate does not hold
+// here. Ceiling below is derived from the measurement actually reproduced on
+// this fixture, not the estimate.
+const RESOLVE_COMMIT_CEILING_MS = 20
+const STREAM_DIFF_LINES_CEILING_MS = 53
+const BLOB_READ_CEILING_MS = 71
+const BUILD_TREE_INDEX_CEILING_MS = 58
 
 const BLOB_REFS: FileGitRef[] = [FROM, TO].flatMap(oid =>
   blobPaths.map(path => ({ path, oid }))
@@ -66,10 +86,14 @@ afterAll(async () => {
   await rm(REPO_ROOT, { recursive: true, force: true })
 })
 
+// A fresh handle per sample (closeAll + getInstance in beforeEach, which
+// tinybench runs outside the timed window — see perfBench's PerfBenchHooks
+// doc) so every timed resolveCommit call below hits an empty deltaCache —
+// the cost a real sgd() invocation always pays, since it opens exactly one
+// handle per run and resolves --from/--to on it exactly once.
 describe('gitAdapter-history-resolveCommit', () => {
-  const adapter = GitAdapter.getInstance(baseConfig)
-
   const elapsedMs: number[] = []
+  let adapter: GitAdapter
 
   perfBench(
     'resolveCommit-fixture-HEAD~20-and-HEAD',
@@ -80,6 +104,11 @@ describe('gitAdapter-history-resolveCommit', () => {
       elapsedMs.push(performance.now() - start)
     },
     {
+      beforeEach: async () => {
+        await GitAdapter.closeAll()
+        adapter = GitAdapter.getInstance(baseConfig)
+        await adapter.resolveCommit(HANDLE_OPEN_REF)
+      },
       afterRun: () =>
         assertMeanWithinCeiling(
           'resolveCommit',
@@ -91,9 +120,8 @@ describe('gitAdapter-history-resolveCommit', () => {
 })
 
 describe('gitAdapter-history-streamDiffLines', () => {
-  const adapter = GitAdapter.getInstance(baseConfig)
-
   const elapsedMs: number[] = []
+  let adapter: GitAdapter
 
   perfBench(
     'streamDiffLines-fixture-HEAD~20..HEAD',
@@ -116,6 +144,11 @@ describe('gitAdapter-history-streamDiffLines', () => {
       elapsedMs.push(performance.now() - start)
     },
     {
+      beforeEach: async () => {
+        await GitAdapter.closeAll()
+        adapter = GitAdapter.getInstance(baseConfig)
+        await adapter.resolveCommit(HANDLE_OPEN_REF)
+      },
       afterRun: () =>
         assertMeanWithinCeiling(
           'streamDiffLines',
@@ -127,9 +160,8 @@ describe('gitAdapter-history-streamDiffLines', () => {
 })
 
 describe('gitAdapter-history-blobReads', () => {
-  const adapter = GitAdapter.getInstance(baseConfig)
-
   const elapsedMs: number[] = []
+  let adapter: GitAdapter
 
   perfBench(
     'getBufferContent-fixture-HEAD~20-and-HEAD',
@@ -141,6 +173,11 @@ describe('gitAdapter-history-blobReads', () => {
       elapsedMs.push(performance.now() - start)
     },
     {
+      beforeEach: async () => {
+        await GitAdapter.closeAll()
+        adapter = GitAdapter.getInstance(baseConfig)
+        await adapter.resolveCommit(HANDLE_OPEN_REF)
+      },
       afterRun: () =>
         assertMeanWithinCeiling(
           'getBufferContent',
@@ -155,7 +192,9 @@ describe('gitAdapter-history-blobReads', () => {
 // revision on the adapter instance, so a shared instance would measure a
 // cache hit (a Map lookup) on every sample after the first. Closing and
 // re-acquiring the singleton each iteration forces a genuine cold tree walk
-// every time — the same cost a fresh CLI invocation pays exactly once.
+// every time — the same cost a fresh CLI invocation pays exactly once. This
+// was already cold before this change and its in-sample closeAll() is
+// settled: left exactly as it is.
 describe('gitAdapter-history-buildTreeIndex', () => {
   const elapsedMs: number[] = []
 

--- a/__tests__/perf/gitAdapter.bench.ts
+++ b/__tests__/perf/gitAdapter.bench.ts
@@ -27,8 +27,10 @@ const { from: FROM, to: TO, blobPaths } = buildHistoryRepo(REPO_ROOT)
 // A ref distinct from both FROM ('HEAD~20') and TO ('HEAD'): resolving it in
 // a beforeEach hook pays tsgit's one-time repo-open cost (openRepository,
 // pack index parsing — lazily paid on a handle's first read, see
-// GitAdapter#getRepo) without warming the deltaCache entry that FROM or TO
-// is about to be measured on.
+// GitAdapter#getRepo). It does still warm HEAD and HEAD~1 (2 of ~21 commit
+// objects in the timed walk) — resolving 'HEAD~1' must peel HEAD to reach
+// its parent — but no ref in this linear fixture can avoid warming at least
+// one commit that FROM or TO is about to be measured on.
 const HANDLE_OPEN_REF = 'HEAD~1'
 
 // Provisional. This fixture is new AND, as of this change, measures cold
@@ -38,14 +40,17 @@ const HANDLE_OPEN_REF = 'HEAD~1'
 // from — see the CI-sourced comment there). Ceiling = local cold worst-of-
 // three mean × ~3.2 (the CI/local ratio measured independently on
 // pipeline.bench.ts's own benches) × RUNNER_NOISE_FACTOR (3), rounded to the
-// nearest whole ms — not deriveCeilingMs's measured-worst-mean formula,
-// since there is no CI-measured worst mean to feed it yet. Re-seed all four
-// from this branch's first CI perf run and switch back to
-// deriveCeilingMs(ciWorstMeanMs) once that history exists.
+// nearest whole ms via a one-decimal (3-significant-figure) intermediate —
+// not deriveCeilingMs's measured-worst-mean formula, since there is no
+// CI-measured worst mean to feed it yet. Re-seed all four from this branch's
+// first CI perf run and switch back to deriveCeilingMs(ciWorstMeanMs) once
+// that history exists.
 //
 // Local cold worst-of-three measured means, ms (three `vitest bench` runs
 // against this exact beforeEach implementation, each averaging ~140-750
-// fresh-handle samples):
+// fresh-handle samples). The one-decimal intermediate is why resolveCommit's
+// raw 19.47 lands on 20 rather than the 19 a single direct rounding would
+// give — the other three raw products round the same way either way:
 //   resolveCommit:    2.0283 / 1.6642 / 1.3358  (worst × 9.6 = 19.5 -> 20)
 //   streamDiffLines:  5.5584 / 5.3818 / 4.7968  (worst × 9.6 = 53.4 -> 53)
 //   getBufferContent: 7.1166 / 7.3443 / 6.4534  (worst × 9.6 = 70.5 -> 71)

--- a/__tests__/perf/harness/perfBench.ts
+++ b/__tests__/perf/harness/perfBench.ts
@@ -34,12 +34,12 @@ export type PerfBenchHooks = Readonly<{
 export const perfBench = (
   name: string,
   fn: () => unknown,
-  hooks: PerfBenchHooks | (() => void) = {}
+  hooks: PerfBenchHooks = {}
 ): void => {
   // __tests__ is not type-checked, so a call site regressed to the old
   // positional `afterRun` function reads `hooks.afterRun` as undefined and
   // its budget assertion silently stops running. Refuse it at runtime.
-  if (typeof hooks === 'function') {
+  if (typeof (hooks as unknown) === 'function') {
     throw new Error(
       `perfBench("${name}") received a function as its third argument; pass { afterRun } instead of the old positional afterRun callback`
     )

--- a/__tests__/perf/harness/perfBench.ts
+++ b/__tests__/perf/harness/perfBench.ts
@@ -2,8 +2,10 @@ import { test } from 'vitest'
 
 // Shared runners are noisy (±40% run-to-run is normal); ceilings exist to
 // catch an order-of-magnitude regression, not to police variance. A ceiling
-// bounds the worst-of-three measured mean × this factor, rounded up to the
-// next 100ms.
+// bounds the worst-of-three measured mean × this factor, rounded up to two
+// significant figures (see deriveCeilingMs) — scaling with the measurement
+// rather than flooring at a round number, so a ceiling stays capable of
+// failing even when the measured cost is well under 100ms.
 export const RUNNER_NOISE_FACTOR = 3
 
 // tinybench 6 defaults, stated so a future tinybench bump cannot move the
@@ -44,6 +46,31 @@ export const perfBench = (
     await task.run(RUN_OPTIONS)
     hooks.afterRun?.()
   })
+}
+
+// "Two significant figures" arithmetically means: locate the order of
+// magnitude one digit below raw's leading digit, then round up to a
+// multiple of it — e.g. a 6.312ms worst mean × 3 = 18.936 rounds up to 19,
+// not 18.936 verbatim or a flattened 20.
+const TWO_SIGNIFICANT_FIGURES_OFFSET = 1
+// Math.log10/Math.ceil can leave float noise on the result (e.g.
+// 1.7000000000000002 instead of 1.7); a coarse display precision strips
+// that noise without touching the two significant figures above.
+const CEILING_DISPLAY_PRECISION = 10
+
+// A ceiling scales with what it bounds: a fixed 100ms floor is degenerate
+// for any worst mean below ~33ms (RUNNER_NOISE_FACTOR × mean never reaches
+// the floor), which is exactly why perfBench ceilings used to sit 10x-4600x
+// above their real cost. Deriving the ceiling from the measurement itself —
+// rounded up to two significant figures rather than flattened to a round
+// number — keeps it capable of catching an order-of-magnitude regression at
+// any scale.
+export const deriveCeilingMs = (worstMeanMs: number): number => {
+  const raw = worstMeanMs * RUNNER_NOISE_FACTOR
+  const step =
+    10 ** Math.floor(Math.log10(raw) - TWO_SIGNIFICANT_FIGURES_OFFSET)
+  const ceiling = Math.ceil(raw / step) * step
+  return Number(ceiling.toPrecision(CEILING_DISPLAY_PRECISION))
 }
 
 // The window a budget covers is usually narrower than the whole bench body

--- a/__tests__/perf/harness/perfBench.ts
+++ b/__tests__/perf/harness/perfBench.ts
@@ -34,8 +34,16 @@ export type PerfBenchHooks = Readonly<{
 export const perfBench = (
   name: string,
   fn: () => unknown,
-  hooks: PerfBenchHooks = {}
+  hooks: PerfBenchHooks | (() => void) = {}
 ): void => {
+  // __tests__ is not type-checked, so a call site regressed to the old
+  // positional `afterRun` function reads `hooks.afterRun` as undefined and
+  // its budget assertion silently stops running. Refuse it at runtime.
+  if (typeof hooks === 'function') {
+    throw new Error(
+      `perfBench("${name}") received a function as its third argument; pass { afterRun } instead of the old positional afterRun callback`
+    )
+  }
   test(name, async ({ bench }) => {
     // tinybench crashes reading a property off an `undefined` options
     // object, so a hookless bench must call the two-argument overload
@@ -66,6 +74,14 @@ const CEILING_DISPLAY_PRECISION = 10
 // number — keeps it capable of catching an order-of-magnitude regression at
 // any scale.
 export const deriveCeilingMs = (worstMeanMs: number): number => {
+  // Math.log10(0) is -Infinity, so a zero (or negative, or non-finite)
+  // worstMeanMs would otherwise flow through to a NaN step and a ceiling
+  // that can never be exceeded — a ceiling that silently cannot fail.
+  if (!Number.isFinite(worstMeanMs) || worstMeanMs <= 0) {
+    throw new Error(
+      `deriveCeilingMs requires a finite, positive worstMeanMs; got ${worstMeanMs}`
+    )
+  }
   const raw = worstMeanMs * RUNNER_NOISE_FACTOR
   const step =
     10 ** Math.floor(Math.log10(raw) - TWO_SIGNIFICANT_FIGURES_OFFSET)

--- a/__tests__/perf/harness/perfBench.ts
+++ b/__tests__/perf/harness/perfBench.ts
@@ -16,20 +16,33 @@ const RUN_OPTIONS = {
   warmupIterations: 16,
 } as const
 
-// Runs once after the samples are in, so a budget assertion can be a statistic
-// over the whole run rather than a max over however many samples the budget
-// happened to draw. A per-sample assertion is a max-over-N: raising the sample
-// count raises the breach rate without the measured cost changing at all.
-type AfterRun = () => void
+export type PerfBenchHooks = Readonly<{
+  // Runs before every iteration, warmup included, outside the timed window
+  // (tinybench times only `fn`): the place to build inputs a sample must not
+  // pay for, and the only place a per-iteration cold state can be made.
+  beforeEach?: () => void | Promise<void>
+  // Runs once after the samples are in, so a budget assertion can be a
+  // statistic over the whole run rather than a max over however many
+  // samples the budget happened to draw. A per-sample assertion is a
+  // max-over-N: raising the sample count raises the breach rate without the
+  // measured cost changing at all.
+  afterRun?: () => void
+}>
 
 export const perfBench = (
   name: string,
   fn: () => unknown,
-  afterRun?: AfterRun
+  hooks: PerfBenchHooks = {}
 ): void => {
   test(name, async ({ bench }) => {
-    await bench(name, fn).run(RUN_OPTIONS)
-    afterRun?.()
+    // tinybench crashes reading a property off an `undefined` options
+    // object, so a hookless bench must call the two-argument overload
+    // rather than pass `undefined` where `{ beforeEach }` would go.
+    const task = hooks.beforeEach
+      ? bench(name, { beforeEach: hooks.beforeEach }, fn)
+      : bench(name, fn)
+    await task.run(RUN_OPTIONS)
+    hooks.afterRun?.()
   })
 }
 

--- a/__tests__/perf/ignoredAdditionProbe.bench.ts
+++ b/__tests__/perf/ignoredAdditionProbe.bench.ts
@@ -139,12 +139,14 @@ describe('ignored-addition-probe-cold-registry', () => {
         await probe.visible(candidates, ignoreHelper)
         elapsedMs.push(performance.now() - start)
       },
-      () =>
-        assertMeanWithinCeiling(
-          `visibility pass over ${size} paths`,
-          elapsedMs,
-          ceilingMs(size)
-        )
+      {
+        afterRun: () =>
+          assertMeanWithinCeiling(
+            `visibility pass over ${size} paths`,
+            elapsedMs,
+            ceilingMs(size)
+          ),
+      }
     )
   }
 })

--- a/__tests__/perf/ignoredAdditionProbe.bench.ts
+++ b/__tests__/perf/ignoredAdditionProbe.bench.ts
@@ -19,11 +19,11 @@ import {
 // over every in-scope file at `to`, doing a registry-membership check plus
 // key derivation per path, and an ignore check only on candidate hits. This
 // bench deliberately does not reuse gitAdapter.bench.ts's approach of
-// diffing this very repository's own history — that grows with every commit
-// landed on a feature branch and is self-referential rather than a stable
-// ceiling. It walks a synthetic listing instead: no repository, no tsgit
-// flatten, no trie — those are GitAdapter's own costs and are bounded by
-// gitAdapter.bench.ts on a real repository.
+// diffing a real repository — that pays git IO and tsgit tree-walk costs
+// this bench exists to isolate away from. It walks a synthetic listing
+// instead: no repository, no tsgit flatten, no trie — those are GitAdapter's
+// own costs and are bounded by gitAdapter.bench.ts on a fixed synthetic
+// repository.
 
 // The seam under measurement: the visibility pass over a `to` listing,
 // reached through `protected` from a subclass that replaces the one git

--- a/__tests__/perf/perfReporter.ts
+++ b/__tests__/perf/perfReporter.ts
@@ -36,9 +36,13 @@ const toLatencyEntry = (task: BenchTask): Entry => ({
 
 // A test either contributed samples or is broken; partitioning once keeps the
 // two sides from having to be re-narrowed (and re-checked) further down.
+// `hasTolerableFailure` records whether any of those samples came from a
+// test that ultimately failed (e.g. a ceiling breach in `afterRun`) — the
+// only kind of run-level failure the report is allowed to publish through.
 type Partitioned = {
   readonly brokenNames: readonly string[]
   readonly tasks: readonly BenchTask[]
+  readonly hasTolerableFailure: boolean
 }
 
 const tasksOf = (testCase: TestCase): BenchTask[] =>
@@ -57,17 +61,39 @@ const allTestsInOrder = (modules: readonly TestModule[]): TestCase[] =>
     ...testModule.children.allTests(),
   ])
 
+// A ceiling breach (or any other failure raised after bench() already
+// collected samples) is reported, not fatal: readers get a named, actionable
+// warning instead of the whole report going unpublished over one slow bench.
+const warnBreach = (testCase: TestCase): void => {
+  const result = testCase.result()
+  if (result.state !== 'failed') return
+  for (const error of result.errors) {
+    console.log(`::warning::${testCase.name}: ${error.message}`)
+  }
+}
+
 const partition = (modules: readonly TestModule[]): Partitioned => {
   const brokenNames: string[] = []
   const tasks: BenchTask[] = []
+  let hasTolerableFailure = false
   for (const testCase of allTestsInOrder(modules)) {
     const state = testCase.result().state
     if (state === 'skipped') continue
     const own = tasksOf(testCase)
-    if (state === 'passed' && own.length > 0) tasks.push(...own)
-    else brokenNames.push(testCase.name)
+    // brokenNames keeps its narrow meaning: a bench that produced NO
+    // SAMPLES at all (body threw, never ran, never called bench). Anything
+    // that produced samples is published, whether or not it went on to fail.
+    if (own.length === 0) {
+      brokenNames.push(testCase.name)
+      continue
+    }
+    tasks.push(...own)
+    if (state !== 'passed') {
+      hasTolerableFailure = true
+      warnBreach(testCase)
+    }
   }
-  return { brokenNames, tasks }
+  return { brokenNames, tasks, hasTolerableFailure }
 }
 
 const assertNoBrokenTests = (brokenNames: readonly string[]): void => {
@@ -81,9 +107,15 @@ const assertNoBrokenTests = (brokenNames: readonly string[]): void => {
 // sets a non-zero exit code on its own path — so a run can arrive here as
 // 'passed' while having failed. Writing then would publish a series built from
 // an incomplete run.
+//
+// `reason` is 'failed' whenever any test failed — including a tolerated
+// ceiling breach, which already published its samples with a warning. Only a
+// failure with no such explanation (e.g. a hook failing outside every
+// TestCase) still blocks the write.
 const assertRunPassed = (
   reason: TestRunEndReason,
-  unhandledErrors: ReadonlyArray<unknown>
+  unhandledErrors: ReadonlyArray<unknown>,
+  hasTolerableFailure: boolean
 ): void => {
   if (unhandledErrors.length > 0) {
     throw new Error(
@@ -91,6 +123,7 @@ const assertRunPassed = (
     )
   }
   if (reason === 'passed') return
+  if (reason === 'failed' && hasTolerableFailure) return
   throw new Error(
     `Benchmark run did not pass; ${RUNTIME_PATH} and ${LATENCY_PATH} not written`
   )
@@ -155,9 +188,9 @@ const report = (
     logInterrupted()
     return
   }
-  const { brokenNames, tasks } = partition(testModules)
+  const { brokenNames, tasks, hasTolerableFailure } = partition(testModules)
   assertNoBrokenTests(brokenNames)
-  assertRunPassed(reason, unhandledErrors)
+  assertRunPassed(reason, unhandledErrors, hasTolerableFailure)
   assertHasTasks(tasks)
   assertNonEmptyNames(tasks)
   assertUniqueNames(tasks)

--- a/__tests__/perf/perfReporter.ts
+++ b/__tests__/perf/perfReporter.ts
@@ -96,6 +96,25 @@ const partition = (modules: readonly TestModule[]): Partitioned => {
   return { brokenNames, tasks, hasTolerableFailure }
 }
 
+// hasTolerableFailure is a run-level boolean: once any bench both produced
+// samples and failed, assertRunPassed would otherwise wave through every
+// OTHER cause of a failed run too, including a module that failed during
+// collection (a syntax error, say) and so contributed zero TestCases —
+// no brokenNames entry, no task, nothing for assertNoBrokenTests to name.
+// This check runs independently of hasTolerableFailure so that combination
+// still refuses to publish.
+const assertNoCollectionErrors = (
+  testModules: ReadonlyArray<TestModule>
+): void => {
+  const brokenModuleIds = testModules
+    .filter(testModule => testModule.errors().length > 0)
+    .map(testModule => testModule.relativeModuleId)
+  if (brokenModuleIds.length === 0) return
+  throw new Error(
+    `Test module(s) failed to collect: ${brokenModuleIds.join(', ')}`
+  )
+}
+
 const assertNoBrokenTests = (brokenNames: readonly string[]): void => {
   if (brokenNames.length === 0) return
   throw new Error(
@@ -188,6 +207,7 @@ const report = (
     logInterrupted()
     return
   }
+  assertNoCollectionErrors(testModules)
   const { brokenNames, tasks, hasTolerableFailure } = partition(testModules)
   assertNoBrokenTests(brokenNames)
   assertRunPassed(reason, unhandledErrors, hasTolerableFailure)

--- a/__tests__/perf/perfReporter.ts
+++ b/__tests__/perf/perfReporter.ts
@@ -98,20 +98,23 @@ const partition = (modules: readonly TestModule[]): Partitioned => {
 
 // hasTolerableFailure is a run-level boolean: once any bench both produced
 // samples and failed, assertRunPassed would otherwise wave through every
-// OTHER cause of a failed run too, including a module that failed during
-// collection (a syntax error, say) and so contributed zero TestCases —
-// no brokenNames entry, no task, nothing for assertNoBrokenTests to name.
-// This check runs independently of hasTolerableFailure so that combination
-// still refuses to publish.
-const assertNoCollectionErrors = (
-  testModules: ReadonlyArray<TestModule>
-): void => {
+// OTHER cause of a failed run too, including a module that errored outside
+// its test cases and so contributed none — no brokenNames entry, no task,
+// nothing for assertNoBrokenTests to name. This check runs independently of
+// hasTolerableFailure so that combination still refuses to publish.
+//
+// errors() is task.result.errors, which carries both collection failures (a
+// syntax error, say) and module-scope hook failures — a file-level afterAll
+// that throws lands here too, and this file's benches have one. Either way
+// the run cannot be trusted to have produced every series, so the message
+// names the channel rather than guessing which of the two occurred.
+const assertNoModuleErrors = (testModules: ReadonlyArray<TestModule>): void => {
   const brokenModuleIds = testModules
     .filter(testModule => testModule.errors().length > 0)
     .map(testModule => testModule.relativeModuleId)
   if (brokenModuleIds.length === 0) return
   throw new Error(
-    `Test module(s) failed to collect: ${brokenModuleIds.join(', ')}`
+    `Test module(s) reported module-level errors (collection or module-scope hook): ${brokenModuleIds.join(', ')}`
   )
 }
 
@@ -207,7 +210,7 @@ const report = (
     logInterrupted()
     return
   }
-  assertNoCollectionErrors(testModules)
+  assertNoModuleErrors(testModules)
   const { brokenNames, tasks, hasTolerableFailure } = partition(testModules)
   assertNoBrokenTests(brokenNames)
   assertRunPassed(reason, unhandledErrors, hasTolerableFailure)

--- a/__tests__/perf/phase.bench.ts
+++ b/__tests__/perf/phase.bench.ts
@@ -1,13 +1,23 @@
 import { describe } from 'vitest'
-import { GIT_DIFF_TYPE_REGEX } from '../../src/constant/gitConstants.js'
 import type { MetadataRepository } from '../../src/metadata/MetadataRepository.js'
 import { getDefinition } from '../../src/metadata/metadataManager.js'
-import { generateDiffFixtures } from './fixtures/generateFixtures.js'
+import {
+  createDistinctRoundLines,
+  createSameContentLines,
+  type FixtureSize,
+} from './fixtures/generateFixtures.js'
 import { perfBench } from './harness/perfBench.js'
 
-const metadata: MetadataRepository = await getDefinition({})
-
-const sizes = ['small', 'medium', 'large'] as const
+// Replaces a bench that hid three regressions behind a warm instance: one
+// MetadataRepository built at module load and reused across every sample
+// (the pathCache is warm after the first sample, so the miss path is never
+// measured), paths pre-stripped of their diff-status prefix (asFilePath is
+// never exercised), and the same string objects reused on every iteration
+// (V8's cached string hash means the Map lookup never hashes a string it
+// has not seen before). This file rebuilds both halves of that blindness
+// per iteration: cold benches build a fresh registry in `beforeEach`, and
+// every bench renders a fresh set of lines carrying their diff-status
+// prefix, so a miss-path or line-shape regression has somewhere to show up.
 
 describe('phase-metadata-loading', () => {
   perfBench('metadata-registry-load', async () => {
@@ -15,31 +25,93 @@ describe('phase-metadata-loading', () => {
   })
 })
 
-for (const size of sizes) {
-  const { lines } = generateDiffFixtures(size)
-  const paths = lines.map(line => line.replace(GIT_DIFF_TYPE_REGEX, ''))
+const warmSizes: readonly FixtureSize[] = ['small', 'medium', 'large']
 
-  describe(`phase-metadata-lookup-${size}`, () => {
-    perfBench(`metadata-lookup-${size}`, () => {
-      for (const path of paths) {
-        metadata.get(path)
+describe('phase-metadata-lookup-cold', () => {
+  const nextLines = createDistinctRoundLines('large')
+  let metadata: MetadataRepository
+  let lines: readonly string[]
+
+  perfBench(
+    'metadata-lookup-cold-large',
+    () => {
+      for (const line of lines) {
+        metadata.get(line)
       }
-    })
+    },
+    {
+      // Registry AND lines are rebuilt here, outside the timed window: a
+      // cold sample must pay only for the lookup loop, never for the setup
+      // that makes it cold.
+      beforeEach: async () => {
+        metadata = await getDefinition({})
+        lines = nextLines()
+      },
+    }
+  )
+})
+
+describe('phase-fqn-resolution-cold', () => {
+  const nextLines = createDistinctRoundLines('large')
+  let metadata: MetadataRepository
+  let lines: readonly string[]
+
+  perfBench(
+    'fqn-resolution-cold-large',
+    () => {
+      for (const line of lines) {
+        metadata.getFullyQualifiedName(line)
+      }
+    },
+    {
+      beforeEach: async () => {
+        metadata = await getDefinition({})
+        lines = nextLines()
+      },
+    }
+  )
+})
+
+for (const size of warmSizes) {
+  const metadata: MetadataRepository = await getDefinition({})
+
+  describe(`phase-metadata-lookup-warm-${size}`, () => {
+    const nextLines = createSameContentLines(size)
+    let lines: readonly string[]
+
+    perfBench(
+      `metadata-lookup-warm-${size}`,
+      () => {
+        for (const line of lines) {
+          metadata.get(line)
+        }
+      },
+      {
+        // Only the lines are rebuilt here: the registry stays warm across
+        // every sample, which is the whole point of this variant.
+        beforeEach: () => {
+          lines = nextLines()
+        },
+      }
+    )
   })
 
-  describe(`phase-metadata-has-${size}`, () => {
-    perfBench(`metadata-has-${size}`, () => {
-      for (const path of paths) {
-        metadata.has(path)
-      }
-    })
-  })
+  describe(`phase-fqn-resolution-warm-${size}`, () => {
+    const nextLines = createSameContentLines(size)
+    let lines: readonly string[]
 
-  describe(`phase-fqn-resolution-${size}`, () => {
-    perfBench(`fqn-resolution-${size}`, () => {
-      for (const path of paths) {
-        metadata.getFullyQualifiedName(path)
+    perfBench(
+      `fqn-resolution-warm-${size}`,
+      () => {
+        for (const line of lines) {
+          metadata.getFullyQualifiedName(line)
+        }
+      },
+      {
+        beforeEach: () => {
+          lines = nextLines()
+        },
       }
-    })
+    )
   })
 }

--- a/__tests__/perf/pipeline.bench.ts
+++ b/__tests__/perf/pipeline.bench.ts
@@ -13,8 +13,8 @@ import {
 import { buildLwcDiffRepo } from './fixtures/lwcRepoFixture.js'
 import {
   assertMeanWithinCeiling,
+  deriveCeilingMs,
   perfBench,
-  RUNNER_NOISE_FACTOR,
 } from './harness/perfBench.js'
 
 const metadata = await getDefinition({})
@@ -48,12 +48,10 @@ vi.mock('../../src/metadata/metadataManager.js', async importOriginal => ({
 
 const BUNDLE_COUNTS = [100, 1_000] as const
 
-const deriveCeilingMs = (worstMeanMs: number): number =>
-  Math.ceil((worstMeanMs * RUNNER_NOISE_FACTOR) / 100) * 100
-
 // Measured over three runs against the packed fixture (worst-of-three means):
 // 100 bundles 9.61/9.60/9.46ms, 1000 bundles 53.00/50.71/50.10ms. Ceiling is
-// the worst mean × RUNNER_NOISE_FACTOR, rounded up to the next 100ms.
+// the worst mean × RUNNER_NOISE_FACTOR, rounded up to two significant
+// figures (see deriveCeilingMs).
 const WORST_MEAN_MS: Record<(typeof BUNDLE_COUNTS)[number], number> = {
   100: 9.61,
   1_000: 53.0036,

--- a/__tests__/perf/pipeline.bench.ts
+++ b/__tests__/perf/pipeline.bench.ts
@@ -95,12 +95,14 @@ for (const count of BUNDLE_COUNTS) {
         await sgd(input)
         elapsedMs.push(performance.now() - start)
       },
-      () =>
-        assertMeanWithinCeiling(
-          `sgd-no-delta-${count}-bundles`,
-          elapsedMs,
-          SGD_NO_DELTA_CEILING_MS[count]
-        )
+      {
+        afterRun: () =>
+          assertMeanWithinCeiling(
+            `sgd-no-delta-${count}-bundles`,
+            elapsedMs,
+            SGD_NO_DELTA_CEILING_MS[count]
+          ),
+      }
     )
   })
 }

--- a/__tests__/perf/pipeline.bench.ts
+++ b/__tests__/perf/pipeline.bench.ts
@@ -48,13 +48,21 @@ vi.mock('../../src/metadata/metadataManager.js', async importOriginal => ({
 
 const BUNDLE_COUNTS = [100, 1_000] as const
 
-// Measured over three runs against the packed fixture (worst-of-three means):
-// 100 bundles 9.61/9.60/9.46ms, 1000 bundles 53.00/50.71/50.10ms. Ceiling is
-// the worst mean × RUNNER_NOISE_FACTOR, rounded up to two significant
-// figures (see deriveCeilingMs).
+// Derived from the live gh-pages series (dev/bench/runtime, 48 runs on
+// ubuntu-latest, the runner assertMeanWithinCeiling actually runs on) rather
+// than a developer machine: a local Apple M3 mean under-measures this bench
+// by 3.0-3.45x relative to CI, which alone consumed all of
+// RUNNER_NOISE_FACTOR's headroom and made the old dev-machine-derived
+// ceilings breach on CI 3 of 4 times. CI-observed means for
+// pipeline-100-bundles: 26.88/31.56/33.30/33.18ms (max 33.30); for
+// pipeline-1000-bundles: 140.46/160.29/166.77/167.90ms (max 167.90). Ceiling
+// is the CI max × RUNNER_NOISE_FACTOR, rounded up to two significant figures
+// (see deriveCeilingMs). Rule: re-derive this from the gh-pages series, never
+// from a developer machine — a local mean is not a stand-in for what CI
+// actually measures.
 const WORST_MEAN_MS: Record<(typeof BUNDLE_COUNTS)[number], number> = {
-  100: 9.61,
-  1_000: 53.0036,
+  100: 33.3,
+  1_000: 167.9,
 }
 
 const SGD_NO_DELTA_CEILING_MS: Record<(typeof BUNDLE_COUNTS)[number], number> =

--- a/__tests__/unit/lib/utils/repoGitDiff.test.ts
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.ts
@@ -89,8 +89,6 @@ vi.mock('../../../../src/utils/ignoreHelper', () => ({
 }))
 mockKeep.mockReturnValue(true)
 
-const FORCEIGNORE_MOCK_PATH = '__mocks__/.forceignore'
-
 const TAB = '\t'
 
 const TO = 'sha-to'
@@ -128,7 +126,6 @@ describe('Given a RepoGitDiff', () => {
   it('Given empty diff and ignoreWhitespace, When getLines, Then returns empty', async () => {
     // Arrange
     mockGetDiffLines.mockReturnValue([])
-    config.ignore = FORCEIGNORE_MOCK_PATH
     config.ignoreWhitespace = true
     const sut = new RepoGitDiff(config, globalMetadata)
 
@@ -137,12 +134,16 @@ describe('Given a RepoGitDiff', () => {
 
     // Assert
     expect(result).toStrictEqual([])
+    expect(mockStreamDiffLinesCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: expect.objectContaining({ ignoreWhitespace: true }),
+      })
+    )
   })
 
   it('Given empty diff without ignoreWhitespace, When getLines, Then returns empty', async () => {
     // Arrange
     mockGetDiffLines.mockReturnValue([])
-    config.ignore = FORCEIGNORE_MOCK_PATH
     const sut = new RepoGitDiff(config, globalMetadata)
 
     // Act
@@ -157,7 +158,6 @@ describe('Given a RepoGitDiff', () => {
     const filePath =
       'force-app/main/default/objects/Account/fields/awesome.field-meta.xml'
     mockGetDiffLines.mockReturnValue([`${DELETION}${TAB}${filePath}`])
-    config.ignore = FORCEIGNORE_MOCK_PATH
     const sut = new RepoGitDiff(config, globalMetadata)
 
     // Act
@@ -193,101 +193,6 @@ describe('Given a RepoGitDiff', () => {
 
     // Assert
     expect(result).toStrictEqual([`${MODIFICATION}${TAB}${filePath}`])
-  })
-
-  it('Given ignored file, When getLines, Then filters it out', async () => {
-    // Arrange
-    mockKeep.mockReturnValueOnce(false)
-    mockGetDiffLines.mockReturnValue([
-      `${ADDITION}${TAB}force-app/main/default/pages/test.page-meta.xml`,
-    ])
-    config.ignore = FORCEIGNORE_MOCK_PATH
-    const sut = new RepoGitDiff(config, globalMetadata)
-
-    // Act
-    const result = await collect(sut.getLines())
-
-    // Assert
-    expect(result).toStrictEqual([])
-  })
-
-  it('Given ignored destructive file, When getLines, Then filters it out', async () => {
-    // Arrange
-    mockKeep.mockReturnValueOnce(false)
-    mockGetDiffLines.mockReturnValue([
-      `${ADDITION}${TAB}force-app/main/default/pages/test.page-meta.xml`,
-    ])
-    config.ignoreDestructive = FORCEIGNORE_MOCK_PATH
-    const sut = new RepoGitDiff(config, globalMetadata)
-
-    // Act
-    const result = await collect(sut.getLines())
-
-    // Assert
-    expect(result).toStrictEqual([])
-  })
-
-  it('Given both ignore and ignoreDestructive, When getLines, Then filters matching files', async () => {
-    // Arrange
-    mockKeep.mockReturnValueOnce(false)
-    mockGetDiffLines.mockReturnValue([
-      `${ADDITION}${TAB}force-app/main/default/lwc/jsconfig.json`,
-    ])
-    config.ignore = FORCEIGNORE_MOCK_PATH
-    config.ignoreDestructive = FORCEIGNORE_MOCK_PATH
-    const sut = new RepoGitDiff(config, globalMetadata)
-
-    // Act
-    const result = await collect(sut.getLines())
-
-    // Assert
-    expect(result).toStrictEqual([])
-  })
-
-  it('Given ignore set, When file matches ignore, Then filters it out', async () => {
-    // Arrange
-    mockKeep.mockReturnValueOnce(false)
-    mockGetDiffLines.mockReturnValue([
-      `${ADDITION}${TAB}force-app/main/default/pages/test.page-meta.xml`,
-    ])
-    config.ignore = FORCEIGNORE_MOCK_PATH
-    const sut = new RepoGitDiff(config, globalMetadata)
-
-    // Act
-    const result = await collect(sut.getLines())
-
-    // Assert
-    expect(result).toStrictEqual([])
-  })
-
-  it('Given only ignoreDestructive set, When non-deletion added, Then keeps it', async () => {
-    // Arrange
-    const filePath = 'force-app/main/default/pages/test.page-meta.xml'
-    mockGetDiffLines.mockReturnValue([`${ADDITION}${TAB}${filePath}`])
-    config.ignoreDestructive = FORCEIGNORE_MOCK_PATH
-    const sut = new RepoGitDiff(config, globalMetadata)
-
-    // Act
-    const result = await collect(sut.getLines())
-
-    // Assert
-    expect(result).toStrictEqual([`${ADDITION}${TAB}${filePath}`])
-  })
-
-  it('Given ignored subfolder files, When getLines, Then filters them out', async () => {
-    // Arrange
-    mockKeep.mockReturnValueOnce(false)
-    mockGetDiffLines.mockReturnValue([
-      `${ADDITION}${TAB}force-app/main/default/pages/test.page-meta.xml`,
-    ])
-    config.ignore = FORCEIGNORE_MOCK_PATH
-    const sut = new RepoGitDiff(config, globalMetadata)
-
-    // Act
-    const result = await collect(sut.getLines())
-
-    // Assert
-    expect(result).toStrictEqual([])
   })
 
   it('Given moved file (same name different folder), When getLines, Then filters deletion and keeps addition', async () => {

--- a/__tests__/unit/perf/harness/perfBench.test.ts
+++ b/__tests__/unit/perf/harness/perfBench.test.ts
@@ -1,0 +1,212 @@
+'use strict'
+import { describe, expect, it, vi } from 'vitest'
+
+const { mockTest } = vi.hoisted(() => ({
+  mockTest: vi.fn(),
+}))
+
+vi.mock('vitest', async () => {
+  const actual: typeof import('vitest') = await vi.importActual('vitest')
+  return { ...actual, test: mockTest }
+})
+
+import type { PerfBenchHooks } from '../../../perf/harness/perfBench'
+import {
+  assertMeanWithinCeiling,
+  deriveCeilingMs,
+  perfBench,
+  RUNNER_NOISE_FACTOR,
+} from '../../../perf/harness/perfBench'
+
+const RUN_OPTIONS = {
+  time: 1000,
+  iterations: 64,
+  warmupTime: 250,
+  warmupIterations: 16,
+} as const
+
+// perfBench registers its work through vitest's own `test()`, which is
+// mocked above so this suite can invoke the captured callback directly
+// against a bench double — exercising perfBench's own branching without
+// paying for a real tinybench run.
+const invokeRegisteredCallback = async (run: ReturnType<typeof vi.fn>) => {
+  const callback = mockTest.mock.calls.at(-1)?.[1] as (ctx: {
+    bench: ReturnType<typeof vi.fn>
+  }) => Promise<void>
+  const mockBench = vi.fn().mockReturnValue({ run })
+  await callback({ bench: mockBench })
+  return mockBench
+}
+
+describe('Given perfBench', () => {
+  it('When hooks is passed as a bare function, Then it throws before registering a test', () => {
+    // Arrange
+    const sut = perfBench
+    const legacyPositionalAfterRun = (() =>
+      undefined) as unknown as PerfBenchHooks
+
+    // Act
+    const act = () =>
+      sut('legacy-call-site', () => undefined, legacyPositionalAfterRun)
+
+    // Assert
+    expect(act).toThrow(/function as its third argument/)
+    expect(mockTest).not.toHaveBeenCalled()
+  })
+
+  it('When called without hooks, Then the registered test runs bench with the two-argument overload', async () => {
+    // Arrange
+    const sut = perfBench
+    const fn = vi.fn()
+    const run = vi.fn().mockResolvedValue(undefined)
+
+    // Act
+    sut('no-hooks-bench', fn)
+    const mockBench = await invokeRegisteredCallback(run)
+
+    // Assert
+    expect(mockBench).toHaveBeenCalledWith('no-hooks-bench', fn)
+    expect(run).toHaveBeenCalledWith(RUN_OPTIONS)
+  })
+
+  it('When called with a beforeEach hook, Then the registered test runs bench with the three-argument overload', async () => {
+    // Arrange
+    const sut = perfBench
+    const fn = vi.fn()
+    const beforeEach = vi.fn()
+    const run = vi.fn().mockResolvedValue(undefined)
+
+    // Act
+    sut('before-each-bench', fn, { beforeEach })
+    const mockBench = await invokeRegisteredCallback(run)
+
+    // Assert
+    expect(mockBench).toHaveBeenCalledWith(
+      'before-each-bench',
+      { beforeEach },
+      fn
+    )
+  })
+
+  it('When called with an afterRun hook, Then it is invoked once the run resolves', async () => {
+    // Arrange
+    const sut = perfBench
+    const fn = vi.fn()
+    const afterRun = vi.fn()
+    const run = vi.fn().mockResolvedValue(undefined)
+
+    // Act
+    sut('after-run-bench', fn, { afterRun })
+    await invokeRegisteredCallback(run)
+
+    // Assert
+    expect(afterRun).toHaveBeenCalledOnce()
+  })
+
+  it('When called without an afterRun hook, Then the run resolves without error', async () => {
+    // Arrange
+    const sut = perfBench
+    const fn = vi.fn()
+    const run = vi.fn().mockResolvedValue(undefined)
+    sut('no-after-run-bench', fn)
+
+    // Act
+    const act = () => invokeRegisteredCallback(run)
+
+    // Assert
+    await expect(act()).resolves.toBeDefined()
+  })
+})
+
+describe('Given deriveCeilingMs', () => {
+  it.each([
+    [0.5614, 1.7],
+    [1.6279, 4.9],
+    [0.0214, 0.065],
+    [6.312, 19],
+    [9.61, 29],
+    [53.0036, 160],
+    [10 / 3, 10],
+    [0.033, 0.099],
+  ])(
+    'When the worst mean is %fms, Then the ceiling rounds up to two significant figures of the noise-scaled value (%fms)',
+    (worstMeanMs, expected) => {
+      // Arrange
+      const sut = deriveCeilingMs
+
+      // Act
+      const result = sut(worstMeanMs)
+
+      // Assert
+      expect(result).toBe(expected)
+    }
+  )
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])(
+    'When the worst mean is %s, Then it throws instead of returning a vacuous ceiling',
+    (_label, worstMeanMs) => {
+      // Arrange
+      const sut = deriveCeilingMs
+
+      // Act
+      const act = () => sut(worstMeanMs)
+
+      // Assert
+      expect(act).toThrow(/worstMeanMs/)
+    }
+  )
+})
+
+describe('Given assertMeanWithinCeiling', () => {
+  it('When no samples were recorded, Then it throws naming the label', () => {
+    // Arrange
+    const sut = assertMeanWithinCeiling
+
+    // Act
+    const act = () => sut('resolveCommit', [], 10)
+
+    // Assert
+    expect(act).toThrow(
+      'resolveCommit recorded no samples to check against its ceiling'
+    )
+  })
+
+  it('When the mean exceeds the ceiling, Then it throws naming the mean and the ceiling', () => {
+    // Arrange
+    const sut = assertMeanWithinCeiling
+
+    // Act
+    const act = () => sut('resolveCommit', [10, 20], 10)
+
+    // Assert
+    expect(act).toThrow(
+      'resolveCommit averaged 15.00ms over 2 samples, exceeding the 10ms noise-tolerant ceiling'
+    )
+  })
+
+  it('When the mean is within the ceiling, Then it does not throw', () => {
+    // Arrange
+    const sut = assertMeanWithinCeiling
+
+    // Act
+    const act = () => sut('resolveCommit', [5, 5], 10)
+
+    // Assert
+    expect(act).not.toThrow()
+  })
+})
+
+describe('Given RUNNER_NOISE_FACTOR', () => {
+  it('When read, Then it is 3', () => {
+    // Arrange
+    const sut = RUNNER_NOISE_FACTOR
+
+    // Assert
+    expect(sut).toBe(3)
+  })
+})

--- a/__tests__/unit/perf/perfReporter.test.ts
+++ b/__tests__/unit/perf/perfReporter.test.ts
@@ -28,11 +28,12 @@ const taskDouble = (name: string, mean: number, rme: number) => ({
 const testDouble = (
   name: string,
   state: 'passed' | 'failed' | 'skipped' | 'pending',
-  tasks: ReturnType<typeof taskDouble>[]
+  tasks: ReturnType<typeof taskDouble>[],
+  errors: { message: string }[] = []
 ) =>
   ({
     name,
-    result: () => ({ state }),
+    result: () => ({ state, errors }),
     benchmarks: () =>
       tasks.length ? [{ name: `group > ${name}`, tasks }] : [],
   }) as unknown as TestCase
@@ -305,6 +306,90 @@ describe('Given a benchmark reporter', () => {
     ) as { name: string }[]
     expect(runtimeWritten).toHaveLength(1)
     expect(runtimeWritten[0]!.name).toBe('sample-bench')
+  })
+
+  it('When a bench fails after producing samples (a ceiling breach), Then it still writes those samples and logs a ::warning:: naming the failure', () => {
+    // Arrange
+    const task = taskDouble('resolveCommit-fixture', 2, 1)
+    const breachTest = testDouble(
+      'gitAdapter-history-resolveCommit',
+      'failed',
+      [task],
+      [
+        {
+          message:
+            'resolveCommit averaged 20.15ms over 5 samples, exceeding the 16ms noise-tolerant ceiling',
+        },
+      ]
+    )
+    const testModule = moduleDouble('__tests__/perf/gitAdapter.bench.ts', [
+      breachTest,
+    ])
+
+    // Act
+    const act = () => sut.onTestRunEnd([testModule], [], 'failed')
+
+    // Assert
+    expect(act).not.toThrow()
+    const runtimeWritten = JSON.parse(
+      mockWriteFileSync.mock.calls[0]![1] as string
+    ) as { name: string }[]
+    expect(runtimeWritten.map(entry => entry.name)).toEqual([
+      'resolveCommit-fixture',
+    ])
+    expect(console.log).toHaveBeenCalledWith(
+      '::warning::gitAdapter-history-resolveCommit: resolveCommit averaged 20.15ms over 5 samples, exceeding the 16ms noise-tolerant ceiling'
+    )
+  })
+
+  it('When a non-failed, non-passed test somehow carries samples, Then it is still published and nothing is logged for it', () => {
+    // Arrange
+    const task = taskDouble('sample-bench', 1, 1)
+    const pendingWithSamples = testDouble('carrier', 'pending', [task])
+    const testModule = moduleDouble('__tests__/perf/sample.bench.ts', [
+      pendingWithSamples,
+    ])
+
+    // Act
+    sut.onTestRunEnd([testModule], [], 'passed')
+
+    // Assert
+    const runtimeWritten = JSON.parse(
+      mockWriteFileSync.mock.calls[0]![1] as string
+    ) as { name: string }[]
+    expect(runtimeWritten.map(entry => entry.name)).toEqual(['sample-bench'])
+    expect(console.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('::warning::')
+    )
+  })
+
+  it('When a bench fails after producing samples alongside a bench that produced none, Then it still throws naming only the sample-less one and writes nothing', () => {
+    // Arrange
+    const task = taskDouble('resolveCommit-fixture', 2, 1)
+    const breachTest = testDouble(
+      'gitAdapter-history-resolveCommit',
+      'failed',
+      [task],
+      [{ message: 'resolveCommit exceeded its ceiling' }]
+    )
+    const noSamplesTest = testDouble(
+      'gitAdapter-history-blobReads',
+      'failed',
+      []
+    )
+    const testModule = moduleDouble('__tests__/perf/gitAdapter.bench.ts', [
+      breachTest,
+      noSamplesTest,
+    ])
+
+    // Act
+    const act = () => sut.onTestRunEnd([testModule], [], 'failed')
+
+    // Assert
+    expect(act).toThrow(
+      'Benchmarks produced no samples (body threw, never ran, or never called bench): gitAdapter-history-blobReads'
+    )
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
   })
 
   it('When every test passed with tasks but the run reason is failed, Then it throws a generic run error and writes nothing', () => {

--- a/__tests__/unit/perf/perfReporter.test.ts
+++ b/__tests__/unit/perf/perfReporter.test.ts
@@ -347,7 +347,7 @@ describe('Given a benchmark reporter', () => {
     )
   })
 
-  it('When a module failed to collect while another bench has a tolerated breach, Then it throws naming the module and writes nothing', () => {
+  it('When a module reports a module-level error while another bench has a tolerated breach, Then it throws naming the module and writes nothing', () => {
     // Arrange
     const task = taskDouble('resolveCommit-fixture', 2, 1)
     const breachTest = testDouble(
@@ -371,7 +371,7 @@ describe('Given a benchmark reporter', () => {
 
     // Assert
     expect(act).toThrow(
-      'Test module(s) failed to collect: __tests__/perf/broken.bench.ts'
+      'Test module(s) reported module-level errors (collection or module-scope hook): __tests__/perf/broken.bench.ts'
     )
     expect(mockWriteFileSync).not.toHaveBeenCalled()
   })

--- a/__tests__/unit/perf/perfReporter.test.ts
+++ b/__tests__/unit/perf/perfReporter.test.ts
@@ -49,10 +49,15 @@ const multiBenchTestDouble = (
       benchmarks.map((tasks, index) => ({ name: `group > ${index}`, tasks })),
   }) as unknown as TestCase
 
-const moduleDouble = (relativeModuleId: string, tests: TestCase[]) =>
+const moduleDouble = (
+  relativeModuleId: string,
+  tests: TestCase[],
+  errors: { message: string }[] = []
+) =>
   ({
     relativeModuleId,
     children: { allTests: () => tests.values() },
+    errors: () => errors,
   }) as unknown as TestModule
 
 describe('Given a benchmark reporter', () => {
@@ -340,6 +345,35 @@ describe('Given a benchmark reporter', () => {
     expect(console.log).toHaveBeenCalledWith(
       '::warning::gitAdapter-history-resolveCommit: resolveCommit averaged 20.15ms over 5 samples, exceeding the 16ms noise-tolerant ceiling'
     )
+  })
+
+  it('When a module failed to collect while another bench has a tolerated breach, Then it throws naming the module and writes nothing', () => {
+    // Arrange
+    const task = taskDouble('resolveCommit-fixture', 2, 1)
+    const breachTest = testDouble(
+      'gitAdapter-history-resolveCommit',
+      'failed',
+      [task],
+      [{ message: 'resolveCommit exceeded its ceiling' }]
+    )
+    const toleratedModule = moduleDouble('__tests__/perf/gitAdapter.bench.ts', [
+      breachTest,
+    ])
+    const brokenModule = moduleDouble(
+      '__tests__/perf/broken.bench.ts',
+      [],
+      [{ message: 'Unexpected token' }]
+    )
+
+    // Act
+    const act = () =>
+      sut.onTestRunEnd([toleratedModule, brokenModule], [], 'failed')
+
+    // Assert
+    expect(act).toThrow(
+      'Test module(s) failed to collect: __tests__/perf/broken.bench.ts'
+    )
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
   })
 
   it('When a non-failed, non-passed test somehow carries samples, Then it is still published and nothing is logged for it', () => {

--- a/__tests__/unit/tooling/mutationVerdict.test.ts
+++ b/__tests__/unit/tooling/mutationVerdict.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyRun,
+  type MutationReport,
+} from '../../../tooling/mutationVerdict.ts'
+
+type MutantFixture = Readonly<{
+  status: string
+  coveredBy?: readonly string[]
+  testsCompleted?: number
+}>
+
+const buildReport = (mutants: readonly MutantFixture[]): MutationReport => ({
+  files: {
+    'some/file.ts': {
+      mutants,
+    },
+  },
+})
+
+describe('Given a mutation report', () => {
+  describe('When the report is absent', () => {
+    it('Then the verdict is absent', () => {
+      const sut = classifyRun
+
+      const result = sut(null)
+
+      expect(result).toBe('absent')
+    })
+  })
+
+  describe('When no remaining mutant has a non-empty coveredBy', () => {
+    it('Then the verdict is no-coverage', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'NoCoverage', coveredBy: [] },
+        { status: 'NoCoverage' },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('no-coverage')
+    })
+  })
+
+  describe('When the mutant set is empty', () => {
+    it('Then the verdict is no-coverage', () => {
+      const sut = classifyRun
+      const report = buildReport([])
+
+      const result = sut(report)
+
+      expect(result).toBe('no-coverage')
+    })
+  })
+
+  describe('When mutants are covered but none ran (testsCompleted is 0)', () => {
+    it('Then the verdict is vacuous', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'Survived', coveredBy: ['test A'], testsCompleted: 0 },
+        { status: 'Survived', coveredBy: ['test B'], testsCompleted: 0 },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('vacuous')
+    })
+  })
+
+  describe('When mutants are covered but none ran (testsCompleted is undefined)', () => {
+    it('Then the verdict is vacuous', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'Survived', coveredBy: ['test A'] },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('vacuous')
+    })
+  })
+
+  describe('When the only Killed mutant is Ignored', () => {
+    it('Then the verdict is vacuous, not measured', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'Ignored', coveredBy: ['test A'], testsCompleted: 1 },
+        { status: 'Survived', coveredBy: ['test B'], testsCompleted: 0 },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('vacuous')
+    })
+  })
+
+  describe('When at least one mutant is Killed', () => {
+    it('Then the verdict is measured', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'Killed', coveredBy: ['test A'], testsCompleted: 1 },
+        { status: 'Survived', coveredBy: ['test B'], testsCompleted: 0 },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('measured')
+    })
+  })
+
+  describe('When at least one mutant timed out', () => {
+    it('Then the verdict is measured', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'Timeout', coveredBy: ['test A'], testsCompleted: 1 },
+        { status: 'Survived', coveredBy: ['test B'], testsCompleted: 0 },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('measured')
+    })
+  })
+
+  describe('When no mutant is Killed or Timeout but one completed tests', () => {
+    it('Then the verdict is measured', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'Survived', coveredBy: ['test A'], testsCompleted: 3 },
+        { status: 'Survived', coveredBy: ['test B'], testsCompleted: 0 },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('measured')
+    })
+  })
+})

--- a/__tests__/unit/tooling/mutationVerdict.test.ts
+++ b/__tests__/unit/tooling/mutationVerdict.test.ts
@@ -45,13 +45,27 @@ describe('Given a mutation report', () => {
   })
 
   describe('When the mutant set is empty', () => {
-    it('Then the verdict is no-coverage', () => {
+    it('Then the verdict is no-mutants', () => {
       const sut = classifyRun
       const report = buildReport([])
 
       const result = sut(report)
 
-      expect(result).toBe('no-coverage')
+      expect(result).toBe('no-mutants')
+    })
+  })
+
+  describe('When every mutant is Ignored', () => {
+    it('Then the verdict is no-mutants', () => {
+      const sut = classifyRun
+      const report = buildReport([
+        { status: 'Ignored', coveredBy: ['test A'], testsCompleted: 1 },
+        { status: 'Ignored' },
+      ])
+
+      const result = sut(report)
+
+      expect(result).toBe('no-mutants')
     })
   })
 

--- a/__tests__/unit/tooling/mutationVerdict.test.ts
+++ b/__tests__/unit/tooling/mutationVerdict.test.ts
@@ -96,8 +96,8 @@ describe('Given a mutation report', () => {
     })
   })
 
-  describe('When the only Killed mutant is Ignored', () => {
-    it('Then the verdict is vacuous, not measured', () => {
+  describe('When an Ignored mutant is the only one that completed tests', () => {
+    it('Then it does not rescue the run from vacuous', () => {
       const sut = classifyRun
       const report = buildReport([
         { status: 'Ignored', coveredBy: ['test A'], testsCompleted: 1 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@salesforce/dev-config": "4.3.3",
         "@stryker-mutator/core": "10.0.0",
         "@stryker-mutator/vitest-runner": "10.0.0",
-        "@types/node": "26.4.1",
+        "@types/node": "26.5.0",
         "@vitest/coverage-v8": "5.0.0",
         "husky": "9.1.7",
         "knip": "6.34.0",
@@ -5341,12 +5341,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~8.9.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -14710,9 +14710,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@salesforce/dev-config": "4.3.3",
     "@stryker-mutator/core": "10.0.0",
     "@stryker-mutator/vitest-runner": "10.0.0",
-    "@types/node": "26.4.1",
+    "@types/node": "26.5.0",
     "@vitest/coverage-v8": "5.0.0",
     "husky": "9.1.7",
     "knip": "6.34.0",

--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
       "files": [
         "src/**/*.ts",
         "__tests__/**/*.ts",
+        "tooling/**/*.ts",
         "messages/**",
         "**/tsconfig.json",
         "package.json",
@@ -331,10 +332,11 @@
       ]
     },
     "test:mutation:incremental": {
-      "command": "FILES=$(git --no-pager diff --name-only --diff-filter=AM --merge-base origin/main src | grep '.ts$' | paste -sd ',' -); if [ -n \"$FILES\" ]; then stryker run --mutate \"$FILES\"; else echo 'No source files changed — skipping mutation testing'; fi",
+      "command": "node tooling/mutationIncremental.ts",
       "files": [
         "src/**/*.ts",
         "__tests__/**/*.ts",
+        "tooling/**/*.ts",
         "messages/**",
         "**/tsconfig.json",
         "package.json",

--- a/package.json
+++ b/package.json
@@ -327,7 +327,8 @@
         "package-lock.json"
       ],
       "output": [
-        ".stryker-tmp/**"
+        ".stryker-tmp/**",
+        "reports/mutation/**"
       ],
       "dependencies": [
         "lint"
@@ -346,7 +347,8 @@
         "package-lock.json"
       ],
       "output": [
-        ".stryker-tmp/**"
+        ".stryker-tmp/**",
+        "reports/mutation/**"
       ],
       "dependencies": [
         "lint"

--- a/package.json
+++ b/package.json
@@ -174,8 +174,9 @@
       ]
     },
     "lint": {
-      "command": "npx @biomejs/biome check --error-on-warnings src __tests__ messages",
+      "command": "npx @biomejs/biome check --error-on-warnings tooling src __tests__ messages",
       "files": [
+        "tooling/**",
         "src/**",
         "__tests__/**/*.ts",
         "messages/**",
@@ -319,6 +320,7 @@
         "src/**/*.ts",
         "__tests__/**/*.ts",
         "tooling/**/*.ts",
+        "stryker.conf.mjs",
         "messages/**",
         "**/tsconfig.json",
         "package.json",
@@ -337,6 +339,7 @@
         "src/**/*.ts",
         "__tests__/**/*.ts",
         "tooling/**/*.ts",
+        "stryker.conf.mjs",
         "messages/**",
         "**/tsconfig.json",
         "package.json",

--- a/tooling/mutationIncremental.ts
+++ b/tooling/mutationIncremental.ts
@@ -33,6 +33,9 @@ const reportPath = strykerConfig.jsonReporter.fileName
 
 const NOT_RUN_MESSAGE =
   'Mutation testing not run: no mutable source changed against origin/main'
+const NO_MUTANTS_MESSAGE =
+  'Mutation testing not run: every mutant in the scoped diff was ignored'
+const NO_TEST_COVERS_MESSAGE = 'No test covers the changed code'
 const VACUOUS_MESSAGE =
   'Mutation run executed no tests against any covered mutant — the test runner did not run, the score above is not a measurement'
 const ABSENT_MESSAGE =
@@ -44,7 +47,7 @@ const PR_COMMENT_MARKER = '<!-- incremental-mutation-testing -->'
 // -- Reporting surfaces: console annotation, step summary, PR comment ----
 
 const appendStepSummary = (text: string): void => {
-  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  const summaryPath = process.env['GITHUB_STEP_SUMMARY']
   if (!summaryPath) return
   appendFileSync(summaryPath, `${text}\n`)
 }
@@ -54,10 +57,20 @@ const findMarkedComment = (
 ): GithubComment | undefined =>
   comments.find(comment => comment.body?.includes(PR_COMMENT_MARKER))
 
+const isGithubCommentArray = (
+  value: unknown
+): value is readonly GithubComment[] => Array.isArray(value)
+
+// Never log the response body or headers here: the body can carry
+// GitHub's own diagnostic text and the headers carry the bearer token.
+const logHttpFailure = (action: string, res: Response, url: string): void => {
+  console.log(`::error::${action} failed: ${res.status} ${url}`)
+}
+
 const postPrComment = async (body: string): Promise<void> => {
-  const token = process.env.GITHUB_TOKEN
-  const repo = process.env.GITHUB_REPOSITORY
-  const prNumber = process.env.PR_NUMBER
+  const token = process.env['GITHUB_TOKEN']
+  const repo = process.env['GITHUB_REPOSITORY']
+  const prNumber = process.env['PR_NUMBER']
   if (!token || !repo || !prNumber) return
 
   const [owner, repoName] = repo.split('/')
@@ -69,22 +82,28 @@ const postPrComment = async (body: string): Promise<void> => {
   }
   const commentBody = `${PR_COMMENT_MARKER}\n${body}`
 
-  const commentsRes = await fetch(
-    `${apiBase}/issues/${prNumber}/comments?per_page=100`,
-    { headers }
-  )
-  const comments = (await commentsRes.json()) as readonly GithubComment[]
+  const listUrl = `${apiBase}/issues/${prNumber}/comments?per_page=100`
+  const commentsRes = await fetch(listUrl, { headers })
+  if (!commentsRes.ok) {
+    logHttpFailure('Listing PR comments', commentsRes, listUrl)
+    return
+  }
+  const commentsBody: unknown = await commentsRes.json()
+  const comments = isGithubCommentArray(commentsBody) ? commentsBody : []
   const existing = findMarkedComment(comments)
 
   const request = existing
     ? { url: `${apiBase}/issues/comments/${existing.id}`, method: 'PATCH' }
     : { url: `${apiBase}/issues/${prNumber}/comments`, method: 'POST' }
 
-  await fetch(request.url, {
+  const writeRes = await fetch(request.url, {
     method: request.method,
     headers,
     body: JSON.stringify({ body: commentBody }),
   })
+  if (!writeRes.ok) {
+    logHttpFailure('Posting PR comment', writeRes, request.url)
+  }
 }
 
 // -- Scope: plain git diff, then the config's own mutate negations -------
@@ -95,10 +114,20 @@ const escapeGlobLiteral = (chunk: string): string =>
 const convertGlobWildcards = (chunk: string): string =>
   escapeGlobLiteral(chunk).replace(/\*/g, '[^/]*').replace(/\?/g, '[^/]')
 
-const globToRegExp = (pattern: string): RegExp =>
-  new RegExp(
-    `^${pattern.split('**/').map(convertGlobWildcards).join('(?:.*/)?')}$`
-  )
+// Supports two globstar forms, matching the negations this project writes:
+// a mid-pattern `**/` (zero or more directories) and a trailing `/**`
+// (the directory itself plus everything under it, any depth). A bare `**`
+// anywhere else (e.g. `a**b`) is not a globstar here — it degrades to two
+// single-segment wildcards, same as before this function grew `**` support.
+const TRAILING_GLOBSTAR = /\/\*\*$/
+
+const globToRegExp = (pattern: string): RegExp => {
+  const hasTrailingGlobstar = TRAILING_GLOBSTAR.test(pattern)
+  const body = hasTrailingGlobstar ? pattern.slice(0, -'/**'.length) : pattern
+  const boundary = body.split('**/').map(convertGlobWildcards).join('(?:.*/)?')
+  const suffix = hasTrailingGlobstar ? '(?:/.*)?' : ''
+  return new RegExp(`^${boundary}${suffix}$`)
+}
 
 const changedTsFiles = (): readonly string[] =>
   execFileSync(
@@ -139,25 +168,27 @@ const resolveStrykerCliPath = (): string => {
   return join(dirname(corePackageJsonPath), 'bin/stryker.js')
 }
 
-const exitStatusOf = (error: unknown): number => {
+const numericExitStatusOf = (error: unknown): number => {
   const status =
     typeof error === 'object' && error !== null && 'status' in error
       ? (error as { status: unknown }).status
       : undefined
-  return typeof status === 'number' ? status : 1
+  if (typeof status !== 'number') throw error
+  return status
 }
 
 const runStryker = (mutateList: string): number => {
+  const strykerCliPath = resolveStrykerCliPath()
   console.log(`Running Stryker with --mutate ${mutateList}`)
   try {
     execFileSync(
       process.execPath,
-      [resolveStrykerCliPath(), 'run', '--mutate', mutateList],
+      [strykerCliPath, 'run', '--mutate', mutateList],
       { stdio: 'inherit' }
     )
     return 0
   } catch (error) {
-    return exitStatusOf(error)
+    return numericExitStatusOf(error)
   }
 }
 
@@ -210,10 +241,10 @@ const buildSummaryTable = (report: MutationReport): string => {
 
 // -- Reporting the outcome ------------------------------------------------
 
-const reportNotRun = (): void => {
-  console.log(NOT_RUN_MESSAGE)
-  console.log(`::notice::${NOT_RUN_MESSAGE}`)
-  appendStepSummary(NOT_RUN_MESSAGE)
+const reportNotRun = (message: string): void => {
+  console.log(message)
+  console.log(`::notice::${message}`)
+  appendStepSummary(message)
 }
 
 const reportGuardFailure = async (message: string): Promise<void> => {
@@ -224,12 +255,15 @@ const reportGuardFailure = async (message: string): Promise<void> => {
 
 const reportScore = async (
   report: MutationReport,
-  strykerExitStatus: number
+  strykerExitStatus: number,
+  verdict: 'measured' | 'no-coverage'
 ): Promise<void> => {
   const table = buildSummaryTable(report)
+  const noCoverageLine =
+    verdict === 'no-coverage' ? `${NO_TEST_COVERS_MESSAGE}\n` : ''
   const errorLine =
     strykerExitStatus === 0 ? '' : `::error::${BREAK_THRESHOLD_MESSAGE}\n`
-  const body = `${errorLine}${table}`
+  const body = `${noCoverageLine}${errorLine}${table}`
   console.log(body)
   appendStepSummary(body)
   await postPrComment(body)
@@ -245,7 +279,7 @@ const negations = negationsOf(strykerConfig.mutate)
 const scopedFiles = applyNegations(changedTsFiles(), negations)
 
 if (scopedFiles.length === 0) {
-  reportNotRun()
+  reportNotRun(NOT_RUN_MESSAGE)
   process.exit(0)
 }
 
@@ -258,7 +292,7 @@ const verdict = classifyRun(report)
 
 if (verdict === 'absent') {
   await reportGuardFailure(ABSENT_MESSAGE)
-  process.exit(strykerExitStatus)
+  process.exit(strykerExitStatus === 0 ? 1 : strykerExitStatus)
 }
 
 if (verdict === 'vacuous') {
@@ -266,5 +300,10 @@ if (verdict === 'vacuous') {
   process.exit(1)
 }
 
-await reportScore(report as MutationReport, strykerExitStatus)
+if (verdict === 'no-mutants') {
+  reportNotRun(NO_MUTANTS_MESSAGE)
+  process.exit(0)
+}
+
+await reportScore(report as MutationReport, strykerExitStatus, verdict)
 process.exit(strykerExitStatus)

--- a/tooling/mutationIncremental.ts
+++ b/tooling/mutationIncremental.ts
@@ -9,6 +9,7 @@ import { execFileSync } from 'node:child_process'
 import {
   appendFileSync,
   existsSync,
+  mkdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -63,6 +64,10 @@ const appendStepSummary = (text: string): void => {
 }
 
 const writeCommentFile = (body: string): void => {
+  // reports/ is gitignored and absent from a fresh checkout — the `absent`
+  // verdict means Stryker wrote no report, precisely the case where it may
+  // never have created this directory either.
+  mkdirSync(dirname(commentPath), { recursive: true })
   writeFileSync(commentPath, body)
 }
 
@@ -179,14 +184,21 @@ const tallyStatuses = (
   }, empty)
 }
 
-const scoreOf = (tally: MutantTally): number => {
+// null, not 0, when nothing was measured: a file whose mutants are all
+// Ignored (routine under ignoreStatic: true) or all RuntimeError/CompileError
+// (dropped by tallyStatuses's default arm) has no score to report — 0.00%
+// would read as a measurement that was never taken.
+const scoreOf = (tally: MutantTally): number | null => {
   const detected = tally.killed + tally.timeout
   const total = detected + tally.survived + tally.noCoverage
-  return total > 0 ? (detected / total) * 100 : 0
+  return total > 0 ? (detected / total) * 100 : null
 }
 
+const formatScore = (score: number | null): string =>
+  score === null ? 'n/a' : `${score.toFixed(2)}%`
+
 const summaryRow = (name: string, tally: MutantTally): string =>
-  `| ${name} | ${scoreOf(tally).toFixed(2)}% | ${tally.killed} | ${tally.survived} | ${tally.timeout} | ${tally.noCoverage} |`
+  `| ${name} | ${formatScore(scoreOf(tally))} | ${tally.killed} | ${tally.survived} | ${tally.timeout} | ${tally.noCoverage} |`
 
 const buildSummaryTable = (report: MutationReport): string => {
   const entries = Object.entries(report.files)
@@ -201,17 +213,14 @@ const buildSummaryTable = (report: MutationReport): string => {
 
 // -- Reporting the outcome ------------------------------------------------
 
+// Every not-run outcome — an empty scope that never reaches Stryker, or a
+// scoped diff whose mutants were all ignored — still needs a comment.md: the
+// mutation-comment job downloads whatever artifact this run produced, and a
+// missing file there is what turns an advisory gate into a hard failure.
 const reportNotRun = (message: string): void => {
   console.log(message)
   console.log(`::notice::${message}`)
   appendStepSummary(message)
-}
-
-// Distinct from reportNotRun: a scoped diff whose mutants were all ignored
-// still has something worth telling a reviewer, so it also gets a comment
-// file, unlike the empty-scope case above which never reaches Stryker.
-const reportNoMutants = (message: string): void => {
-  reportNotRun(message)
   writeCommentFile(message)
 }
 
@@ -272,7 +281,7 @@ if (verdict === 'vacuous') {
 }
 
 if (verdict === 'no-mutants') {
-  reportNoMutants(NO_MUTANTS_MESSAGE)
+  reportNotRun(NO_MUTANTS_MESSAGE)
   process.exit(0)
 }
 

--- a/tooling/mutationIncremental.ts
+++ b/tooling/mutationIncremental.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+// Computes the incremental mutation-testing scope from a plain git diff (no
+// shell, no pipeline — a non-zero git exit propagates instead of being
+// swallowed by a pipeline), runs Stryker against it, and reports the run
+// honestly: an empty scope says "not run", a runner that executed no tests
+// says "error" and prints no score, and only a real run reports one.
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, existsSync, readFileSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+import strykerConfigRaw from '../stryker.conf.mjs'
+import type { MutationReport } from './mutationVerdict.ts'
+import { classifyRun } from './mutationVerdict.ts'
+
+type StrykerConfigShape = Readonly<{
+  mutate: readonly string[]
+  jsonReporter: Readonly<{ fileName: string }>
+}>
+
+type MutantTally = Readonly<{
+  killed: number
+  survived: number
+  timeout: number
+  noCoverage: number
+}>
+
+type GithubComment = Readonly<{ id: number; body?: string }>
+
+const strykerConfig = strykerConfigRaw as StrykerConfigShape
+const reportPath = strykerConfig.jsonReporter.fileName
+
+const NOT_RUN_MESSAGE =
+  'Mutation testing not run: no mutable source changed against origin/main'
+const VACUOUS_MESSAGE =
+  'Mutation run executed no tests against any covered mutant — the test runner did not run, the score above is not a measurement'
+const ABSENT_MESSAGE =
+  'Mutation run produced no evidence: the report file was not written'
+const BREAK_THRESHOLD_MESSAGE =
+  'Mutation score is below the configured break threshold'
+const PR_COMMENT_MARKER = '<!-- incremental-mutation-testing -->'
+
+// -- Reporting surfaces: console annotation, step summary, PR comment ----
+
+const appendStepSummary = (text: string): void => {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  if (!summaryPath) return
+  appendFileSync(summaryPath, `${text}\n`)
+}
+
+const findMarkedComment = (
+  comments: readonly GithubComment[]
+): GithubComment | undefined =>
+  comments.find(comment => comment.body?.includes(PR_COMMENT_MARKER))
+
+const postPrComment = async (body: string): Promise<void> => {
+  const token = process.env.GITHUB_TOKEN
+  const repo = process.env.GITHUB_REPOSITORY
+  const prNumber = process.env.PR_NUMBER
+  if (!token || !repo || !prNumber) return
+
+  const [owner, repoName] = repo.split('/')
+  const apiBase = `https://api.github.com/repos/${owner}/${repoName}`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github.v3+json',
+    'Content-Type': 'application/json',
+  }
+  const commentBody = `${PR_COMMENT_MARKER}\n${body}`
+
+  const commentsRes = await fetch(
+    `${apiBase}/issues/${prNumber}/comments?per_page=100`,
+    { headers }
+  )
+  const comments = (await commentsRes.json()) as readonly GithubComment[]
+  const existing = findMarkedComment(comments)
+
+  const request = existing
+    ? { url: `${apiBase}/issues/comments/${existing.id}`, method: 'PATCH' }
+    : { url: `${apiBase}/issues/${prNumber}/comments`, method: 'POST' }
+
+  await fetch(request.url, {
+    method: request.method,
+    headers,
+    body: JSON.stringify({ body: commentBody }),
+  })
+}
+
+// -- Scope: plain git diff, then the config's own mutate negations -------
+
+const escapeGlobLiteral = (chunk: string): string =>
+  chunk.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+
+const convertGlobWildcards = (chunk: string): string =>
+  escapeGlobLiteral(chunk).replace(/\*/g, '[^/]*').replace(/\?/g, '[^/]')
+
+const globToRegExp = (pattern: string): RegExp =>
+  new RegExp(
+    `^${pattern.split('**/').map(convertGlobWildcards).join('(?:.*/)?')}$`
+  )
+
+const changedTsFiles = (): readonly string[] =>
+  execFileSync(
+    'git',
+    [
+      '--no-pager',
+      'diff',
+      '--name-only',
+      '--diff-filter=AM',
+      '--merge-base',
+      'origin/main',
+      '--',
+      'src',
+    ],
+    { encoding: 'utf-8' }
+  )
+    .split('\n')
+    .filter(path => path.endsWith('.ts'))
+
+const negationsOf = (mutate: readonly string[]): readonly RegExp[] =>
+  mutate
+    .filter(pattern => pattern.startsWith('!'))
+    .map(pattern => globToRegExp(pattern.slice(1)))
+
+const applyNegations = (
+  files: readonly string[],
+  negations: readonly RegExp[]
+): readonly string[] =>
+  files.filter(file => !negations.some(negation => negation.test(file)))
+
+// -- Stryker, run without a shell -----------------------------------------
+
+const resolveStrykerCliPath = (): string => {
+  const require = createRequire(import.meta.url)
+  const corePackageJsonPath = require.resolve(
+    '@stryker-mutator/core/package.json'
+  )
+  return join(dirname(corePackageJsonPath), 'bin/stryker.js')
+}
+
+const exitStatusOf = (error: unknown): number => {
+  const status =
+    typeof error === 'object' && error !== null && 'status' in error
+      ? (error as { status: unknown }).status
+      : undefined
+  return typeof status === 'number' ? status : 1
+}
+
+const runStryker = (mutateList: string): number => {
+  console.log(`Running Stryker with --mutate ${mutateList}`)
+  try {
+    execFileSync(
+      process.execPath,
+      [resolveStrykerCliPath(), 'run', '--mutate', mutateList],
+      { stdio: 'inherit' }
+    )
+    return 0
+  } catch (error) {
+    return exitStatusOf(error)
+  }
+}
+
+// -- Score summary, built only when the vacuity guard is silent ----------
+
+const tallyStatuses = (
+  mutants: readonly Readonly<{ status: string }>[]
+): MutantTally => {
+  const empty: MutantTally = {
+    killed: 0,
+    survived: 0,
+    timeout: 0,
+    noCoverage: 0,
+  }
+  return mutants.reduce((tally, mutant) => {
+    switch (mutant.status) {
+      case 'Killed':
+        return { ...tally, killed: tally.killed + 1 }
+      case 'Survived':
+        return { ...tally, survived: tally.survived + 1 }
+      case 'Timeout':
+        return { ...tally, timeout: tally.timeout + 1 }
+      case 'NoCoverage':
+        return { ...tally, noCoverage: tally.noCoverage + 1 }
+      default:
+        return tally
+    }
+  }, empty)
+}
+
+const scoreOf = (tally: MutantTally): number => {
+  const detected = tally.killed + tally.timeout
+  const total = detected + tally.survived + tally.noCoverage
+  return total > 0 ? (detected / total) * 100 : 0
+}
+
+const summaryRow = (name: string, tally: MutantTally): string =>
+  `| ${name} | ${scoreOf(tally).toFixed(2)}% | ${tally.killed} | ${tally.survived} | ${tally.timeout} | ${tally.noCoverage} |`
+
+const buildSummaryTable = (report: MutationReport): string => {
+  const entries = Object.entries(report.files)
+  const overall = tallyStatuses(entries.flatMap(([, file]) => file.mutants))
+  const header =
+    '| File | Score | Killed | Survived | Timeout | No Coverage |\n|-|-|-|-|-|-|'
+  const fileRows = entries.map(([filePath, file]) =>
+    summaryRow(filePath, tallyStatuses(file.mutants))
+  )
+  return [header, summaryRow('All files', overall), ...fileRows].join('\n')
+}
+
+// -- Reporting the outcome ------------------------------------------------
+
+const reportNotRun = (): void => {
+  console.log(NOT_RUN_MESSAGE)
+  console.log(`::notice::${NOT_RUN_MESSAGE}`)
+  appendStepSummary(NOT_RUN_MESSAGE)
+}
+
+const reportGuardFailure = async (message: string): Promise<void> => {
+  console.log(`::error::${message}`)
+  appendStepSummary(message)
+  await postPrComment(message)
+}
+
+const reportScore = async (
+  report: MutationReport,
+  strykerExitStatus: number
+): Promise<void> => {
+  const table = buildSummaryTable(report)
+  const errorLine =
+    strykerExitStatus === 0 ? '' : `::error::${BREAK_THRESHOLD_MESSAGE}\n`
+  const body = `${errorLine}${table}`
+  console.log(body)
+  appendStepSummary(body)
+  await postPrComment(body)
+}
+
+// -- Main -------------------------------------------------------------------
+
+if (existsSync(reportPath)) {
+  rmSync(reportPath)
+}
+
+const negations = negationsOf(strykerConfig.mutate)
+const scopedFiles = applyNegations(changedTsFiles(), negations)
+
+if (scopedFiles.length === 0) {
+  reportNotRun()
+  process.exit(0)
+}
+
+const strykerExitStatus = runStryker(scopedFiles.join(','))
+
+const report = existsSync(reportPath)
+  ? (JSON.parse(readFileSync(reportPath, 'utf-8')) as MutationReport)
+  : null
+const verdict = classifyRun(report)
+
+if (verdict === 'absent') {
+  await reportGuardFailure(ABSENT_MESSAGE)
+  process.exit(strykerExitStatus)
+}
+
+if (verdict === 'vacuous') {
+  await reportGuardFailure(VACUOUS_MESSAGE)
+  process.exit(1)
+}
+
+await reportScore(report as MutationReport, strykerExitStatus)
+process.exit(strykerExitStatus)

--- a/tooling/mutationIncremental.ts
+++ b/tooling/mutationIncremental.ts
@@ -6,7 +6,13 @@
 // says "error" and prints no score, and only a real run reports one.
 
 import { execFileSync } from 'node:child_process'
-import { appendFileSync, existsSync, readFileSync, rmSync } from 'node:fs'
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 
@@ -26,10 +32,9 @@ type MutantTally = Readonly<{
   noCoverage: number
 }>
 
-type GithubComment = Readonly<{ id: number; body?: string }>
-
 const strykerConfig = strykerConfigRaw as StrykerConfigShape
 const reportPath = strykerConfig.jsonReporter.fileName
+const commentPath = join(dirname(reportPath), 'comment.md')
 
 const NOT_RUN_MESSAGE =
   'Mutation testing not run: no mutable source changed against origin/main'
@@ -42,9 +47,14 @@ const ABSENT_MESSAGE =
   'Mutation run produced no evidence: the report file was not written'
 const BREAK_THRESHOLD_MESSAGE =
   'Mutation score is below the configured break threshold'
-const PR_COMMENT_MARKER = '<!-- incremental-mutation-testing -->'
 
-// -- Reporting surfaces: console annotation, step summary, PR comment ----
+// -- Reporting surfaces: console annotation, step summary, comment file --
+//
+// No GitHub token, repository or PR number is read here: this script runs
+// inside the same job that executes the pull request's own code under
+// Stryker, so it must not hold anything that can write to GitHub. Posting
+// is a separate job's job — see the `mutation-comment` job, which reads
+// the file this writes from the uploaded `mutation-report` artifact.
 
 const appendStepSummary = (text: string): void => {
   const summaryPath = process.env['GITHUB_STEP_SUMMARY']
@@ -52,58 +62,8 @@ const appendStepSummary = (text: string): void => {
   appendFileSync(summaryPath, `${text}\n`)
 }
 
-const findMarkedComment = (
-  comments: readonly GithubComment[]
-): GithubComment | undefined =>
-  comments.find(comment => comment.body?.includes(PR_COMMENT_MARKER))
-
-const isGithubCommentArray = (
-  value: unknown
-): value is readonly GithubComment[] => Array.isArray(value)
-
-// Never log the response body or headers here: the body can carry
-// GitHub's own diagnostic text and the headers carry the bearer token.
-const logHttpFailure = (action: string, res: Response, url: string): void => {
-  console.log(`::error::${action} failed: ${res.status} ${url}`)
-}
-
-const postPrComment = async (body: string): Promise<void> => {
-  const token = process.env['GITHUB_TOKEN']
-  const repo = process.env['GITHUB_REPOSITORY']
-  const prNumber = process.env['PR_NUMBER']
-  if (!token || !repo || !prNumber) return
-
-  const [owner, repoName] = repo.split('/')
-  const apiBase = `https://api.github.com/repos/${owner}/${repoName}`
-  const headers = {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github.v3+json',
-    'Content-Type': 'application/json',
-  }
-  const commentBody = `${PR_COMMENT_MARKER}\n${body}`
-
-  const listUrl = `${apiBase}/issues/${prNumber}/comments?per_page=100`
-  const commentsRes = await fetch(listUrl, { headers })
-  if (!commentsRes.ok) {
-    logHttpFailure('Listing PR comments', commentsRes, listUrl)
-    return
-  }
-  const commentsBody: unknown = await commentsRes.json()
-  const comments = isGithubCommentArray(commentsBody) ? commentsBody : []
-  const existing = findMarkedComment(comments)
-
-  const request = existing
-    ? { url: `${apiBase}/issues/comments/${existing.id}`, method: 'PATCH' }
-    : { url: `${apiBase}/issues/${prNumber}/comments`, method: 'POST' }
-
-  const writeRes = await fetch(request.url, {
-    method: request.method,
-    headers,
-    body: JSON.stringify({ body: commentBody }),
-  })
-  if (!writeRes.ok) {
-    logHttpFailure('Posting PR comment', writeRes, request.url)
-  }
+const writeCommentFile = (body: string): void => {
+  writeFileSync(commentPath, body)
 }
 
 // -- Scope: plain git diff, then the config's own mutate negations -------
@@ -247,17 +207,25 @@ const reportNotRun = (message: string): void => {
   appendStepSummary(message)
 }
 
-const reportGuardFailure = async (message: string): Promise<void> => {
-  console.log(`::error::${message}`)
-  appendStepSummary(message)
-  await postPrComment(message)
+// Distinct from reportNotRun: a scoped diff whose mutants were all ignored
+// still has something worth telling a reviewer, so it also gets a comment
+// file, unlike the empty-scope case above which never reaches Stryker.
+const reportNoMutants = (message: string): void => {
+  reportNotRun(message)
+  writeCommentFile(message)
 }
 
-const reportScore = async (
+const reportGuardFailure = (message: string): void => {
+  console.log(`::error::${message}`)
+  appendStepSummary(message)
+  writeCommentFile(message)
+}
+
+const reportScore = (
   report: MutationReport,
   strykerExitStatus: number,
   verdict: 'measured' | 'no-coverage'
-): Promise<void> => {
+): void => {
   const table = buildSummaryTable(report)
   const noCoverageLine =
     verdict === 'no-coverage' ? `${NO_TEST_COVERS_MESSAGE}\n` : ''
@@ -266,14 +234,17 @@ const reportScore = async (
   const body = `${noCoverageLine}${errorLine}${table}`
   console.log(body)
   appendStepSummary(body)
-  await postPrComment(body)
+  writeCommentFile(body)
 }
 
 // -- Main -------------------------------------------------------------------
 
-if (existsSync(reportPath)) {
-  rmSync(reportPath)
+const deleteStaleFile = (path: string): void => {
+  if (existsSync(path)) rmSync(path)
 }
+
+deleteStaleFile(reportPath)
+deleteStaleFile(commentPath)
 
 const negations = negationsOf(strykerConfig.mutate)
 const scopedFiles = applyNegations(changedTsFiles(), negations)
@@ -291,19 +262,19 @@ const report = existsSync(reportPath)
 const verdict = classifyRun(report)
 
 if (verdict === 'absent') {
-  await reportGuardFailure(ABSENT_MESSAGE)
+  reportGuardFailure(ABSENT_MESSAGE)
   process.exit(strykerExitStatus === 0 ? 1 : strykerExitStatus)
 }
 
 if (verdict === 'vacuous') {
-  await reportGuardFailure(VACUOUS_MESSAGE)
+  reportGuardFailure(VACUOUS_MESSAGE)
   process.exit(1)
 }
 
 if (verdict === 'no-mutants') {
-  reportNotRun(NO_MUTANTS_MESSAGE)
+  reportNoMutants(NO_MUTANTS_MESSAGE)
   process.exit(0)
 }
 
-await reportScore(report as MutationReport, strykerExitStatus, verdict)
+reportScore(report as MutationReport, strykerExitStatus, verdict)
 process.exit(strykerExitStatus)

--- a/tooling/mutationVerdict.ts
+++ b/tooling/mutationVerdict.ts
@@ -17,6 +17,7 @@ export type MutationRunVerdict =
   | 'vacuous'
   | 'measured'
   | 'no-coverage'
+  | 'no-mutants'
   | 'absent'
 
 const isCovered = (mutant: Mutant): boolean =>
@@ -40,6 +41,7 @@ export const classifyRun = (
 
   const mutants = flattenMutants(report)
 
+  if (mutants.length === 0) return 'no-mutants'
   if (!mutants.some(isCovered)) return 'no-coverage'
 
   const isVacuous =

--- a/tooling/mutationVerdict.ts
+++ b/tooling/mutationVerdict.ts
@@ -1,0 +1,49 @@
+// Classifies a mutation-testing report so a runner that executed no tests
+// is reported as an error rather than a fabricated 0% score.
+
+type MutantStatus = string // 'Killed' | 'Survived' | 'NoCoverage' | 'Timeout' | 'Ignored' | ...
+
+type Mutant = Readonly<{
+  status: MutantStatus
+  coveredBy?: readonly string[]
+  testsCompleted?: number
+}>
+
+export type MutationReport = Readonly<{
+  files: Readonly<Record<string, Readonly<{ mutants: readonly Mutant[] }>>>
+}>
+
+export type MutationRunVerdict =
+  | 'vacuous'
+  | 'measured'
+  | 'no-coverage'
+  | 'absent'
+
+const isCovered = (mutant: Mutant): boolean =>
+  (mutant.coveredBy?.length ?? 0) > 0
+
+const hasCompletedNoTests = (mutant: Mutant): boolean =>
+  mutant.testsCompleted === 0 || mutant.testsCompleted === undefined
+
+const isMeasuredStatus = (mutant: Mutant): boolean =>
+  mutant.status === 'Killed' || mutant.status === 'Timeout'
+
+const flattenMutants = (report: MutationReport): readonly Mutant[] =>
+  Object.values(report.files)
+    .flatMap(file => file.mutants)
+    .filter(mutant => mutant.status !== 'Ignored')
+
+export const classifyRun = (
+  report: MutationReport | null
+): MutationRunVerdict => {
+  if (report === null) return 'absent'
+
+  const mutants = flattenMutants(report)
+
+  if (!mutants.some(isCovered)) return 'no-coverage'
+
+  const isVacuous =
+    !mutants.some(isMeasuredStatus) && mutants.every(hasCompletedNoTests)
+
+  return isVacuous ? 'vacuous' : 'measured'
+}


### PR DESCRIPTION
## Explain your changes

---

Closes #1412 outright. Its five remaining items share one defect — **checks that report success without checking anything** — so every fix here had to make the check *capable of failing*, and each was **demonstrated failing before it was demonstrated passing**. A fix that only makes a check "better" is how all of these survived in the first place.

Three further instances of the same defect were found while doing the work and are fixed too, so this closes seven, not five.

| # | The check | What it did | Demonstrated |
|---|---|---|---|
| 1 | `phase.bench.ts` | One warm registry, pre-stripped paths, reused string objects — a 2× regression moved it **not at all** | old bench ratio **1.00** under the same probe the new cold benches track linearly (1.37/1.22 at one injected chain, 1.76/1.435 at two, against a linear prediction of 1.74/1.44; warm variants flat at 1.00) |
| 2 | `gitAdapter.bench.ts` | Benched the repo's own moving `HEAD~20..HEAD`, so a long branch faked a regression | 25 empty commits and **zero code change** moved the old bench **2.49×**; the fixed-fixture version moves <5% |
| 3 | `assertMeanWithinCeiling` | Ceilings floored at 100 ms → **16×–4673×** headroom; nothing plausible could trip them | a 50× injected slowdown **passed silently** on all 3 runs; now trips at 0.065 ms |
| 4 | `compareBaseline.mjs` | Dropped unmatched rows in **both** directions — a bench that crashed and produced no row vanished with no trace | base `{a,b,c}` vs PR `{a,b-renamed,d}` reported **only `a`**; now both directions land under their own headings |
| 5 | `repoGitDiff.test.ts` | Six tests named for `config.ignore` / `ignoreDestructive` couldn't observe those flags (helper mocked at module scope); three bodies byte-identical | pointing `config.ignore` at a **nonexistent path** still passed; behaviour relocated to the real seam, where swapping `DELETION`/`ADDITION` routing fails both new cases in opposite directions |
| 6 | the mutation gate | Dead four layers deep: runner ran zero tests, no such label existed, `continue-on-error` swallowed the exit, and the script's `else echo` reported success on an empty scope | same scope, same 228 covered mutants: **unpatched → 0 killed / 228 survived / `testsCompleted: 0`**, guard errors with no score; **patched → 225 killed / 100.00% / exit 0**, guard silent |
| 7 | the e2e baseline | `expected/` sat inside its own diff range, filtered back out by `--ignore-file` | stripping the fix made `validate` exit **118** — 118 files of the harness's own baseline copied into itself |

Item 5 of #1412 (`vitest.shared` extension) already shipped in #1430 and is not redone here.

**There is no production `src/` change in this PR.** `git diff main..HEAD -- src` is empty, by design — this is test-infrastructure, tooling and documentation only. The only `src/` edits were throwaway measurement probes, each reverted and verified absent from the diff.

### Three defects found during the work, not in the issue

- **The perf ceilings could not fail** (#3 above) — and after tightening them I got the derivation wrong in a way that would have **broken CI**: the constants came from a local M3 machine while the assertion runs on `ubuntu-latest`, where the gap is 3.0–3.45×. Checked against the live gh-pages series, two pipeline ceilings were **already breached on 3 of 4 recent runs**. Worse, one breach makes the reporter write no JSON, `compareBaseline` then throws, and *all* perf reporting vanishes — 52 published series to zero, taking the base leg of every later PR with it. Ceilings are now derived from CI numbers, and a breach warns and still publishes.
- **Three of four `gitAdapter` benches still timed cache hits** after the fixture fix — they reused one adapter across every sample, so tsgit's `deltaCache` served them (cold/warm 2.3×, 2.7×, 8.1×). The file's own header promised these caught "a materialize-everything code path"; they could not. Now cold, via the `beforeEach` hook the registry-bench work added — the fix for one item supplied the mechanism for the other.
- **The wireit fingerprint was under-declared three separate times** — `tooling/**/*.ts` missing from `files`, then `stryker.conf.mjs` missing from `files`, then `reports/mutation/**` missing from `output`. Each was found only after closing the previous one, each demonstrated the same way (`Ran 0 scripts and skipped 3` on an edit the cache could not see). Same task, same mechanism, three holes: this is a configuration surface where omission is invisible by construction, which is the issue's thesis in miniature.

## Does this close any currently open issues?

---

closes #1412

- [x] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [x] E2E tests added to cover the fix.

Unit **1707 → 1736** at 100/100/100/100 (six unobservable tests deleted, coverage unmoved — which is the evidence they were genuinely redundant); integration **417 → 428**. NUT unchanged: this PR changes no CLI behaviour.

## Any particular element that can be tested locally

---

```bash
npm test                                              # 7/7 wireit scripts, cache-invalidated
npx vitest run --coverage                             # 1736, 100% thresholds
npx vitest run --config vitest.integration.config.ts  # 428
rtk proxy npx vitest bench --config vitest.config.perf.ts   # 51/51, all ceilings held
```

To see the mutation gate tell the truth, add the new **`mutation-testing`** label to any PR that changes `src/`. On today's runner the job reports an **error** — *the test runner did not run; the score above is not a measurement* — instead of a fabricated 0%.

To see the e2e fix: in `e2e/`, remove `--source-dir test` from both scripts and run `npm run clean && npm run test:e2e:local && npm run validate`.

## Any other comments

---

### Decisions

17 ADRs (013–029). Two went **against** the design's recommendation, deliberately:

- **ADR-013 — wait for upstream** rather than patch the Stryker runner (stryker-js #6210 / PR #6214 both open; nothing past `vitest-runner@10.0.0` published). `node_modules` ships unpatched. The vacuity guard is what makes that safe, and is therefore load-bearing rather than belt-and-braces.
- **ADR-019 — keep `/expected`** in `e2e/.sgdignore`. `--source-dir test` is what actually scopes the baseline out; the ignore line stays as live `--ignore-file` coverage against a real populated directory. Documented in-file and in CONTRIBUTING so it isn't deleted as redundant later.

Also: the mutation job stays **advisory** (ADR-014) — the `main` ruleset is untouched; the `mutation-testing` label was created (ADR-015); the comment now posts from a job that **runs no PR code** (mirroring this repo's existing `comment` job), because `continue-on-error` masks `needs.<job>.result` and a naive gate would have silently never fired.

### Known limitations, stated rather than glossed

- **Four `gitAdapter` ceilings are provisional** (20 / 53 / 71 / 58 ms) and must be re-seeded from this branch's first CI perf run. Their fixture is new *and* now cold, so no CI history applies. Safe to land because a breach now warns instead of blanking the report.
- **Mutation testing says nothing about this PR.** It ran and exited 0 reporting *not run* — there is no mutable `src/` in scope. That is an honest limitation, not a pass.
- **No DoD file exists and the architecture phase is off**, so nothing here asserts module-boundary alignment.

### Carried findings — not fixed here, deliberately

- `__mocks__/.forceignore` may now be an orphan; the only remaining references are bare string literals in `flowTranslationProcessor.test.ts`.
- `scoreOf` / `formatScore` in `tooling/mutationIncremental.ts` are untested — it's a top-level script with module-level `process.exit`, so it never loads under the unit run. Extracting the pure helpers alongside `mutationVerdict.ts` would fix it.
- **`tooling/` is still outside every type-check.** The four TS4111 errors it hid are fixed, but the blindness that let them land is not: `tsconfig.json`'s `include` is `src/**` only.
- **`reusable-perf.yml`'s `perf` job holds `pull-requests: write` while checking out and running PR code** — the same shape the mutation job was just moved off. Pre-existing and out of scope here.
