### PR TITLE
ci: stop caching benchmark results so the perf job always measures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,15 @@ this run*. A throwing bench body fails the run and nothing is written; a
 npm run test:perf
 ```
 
+`test:perf` deliberately declares **no** wireit `files` array, so it is never
+fingerprinted and always executes. Wireit caches a script only when both `files`
+and `output` are declared, and a benchmark must not be cached: its result depends
+on the machine and the moment, not only on its inputs. With `files` present, CI
+restored `perf-runtime.json`/`perf-memory.json` for *both* sides of a pull request
+comparison and reported a full regression table having run nothing — the comment
+still labelled "(same runner)" while comparing two machines. `build` remains cached,
+because a build output genuinely is a function of its inputs. Do not add `files` back.
+
 ### Mutation Testing
 
 Mutation testing runs via Stryker against the unit-test bucket. The

--- a/package.json
+++ b/package.json
@@ -327,16 +327,6 @@
     },
     "test:perf": {
       "command": "vitest bench --config vitest.config.perf.ts",
-      "files": [
-        "src/**/*.ts",
-        "__tests__/perf/**",
-        "tsconfig.json",
-        "__tests__/tsconfig.json",
-        "tooling/tsconfig.json",
-        "vitest.config.perf.ts",
-        "package.json",
-        "package-lock.json"
-      ],
       "output": [
         "perf-runtime.json",
         "perf-memory.json"


### PR DESCRIPTION
## Explain your changes

---

`test:perf` declared both a `files` and an `output` array, which is exactly wireit's condition
for caching:

> To enable caching for a script, ensure you have defined both the `files` and `output` arrays.
> — wireit README, §Caching

That treats benchmark results as a reproducible build artifact. They are not. A build output is a
function of its inputs; a **measurement** depends on the machine and the moment as well. So wireit
was free to restore `perf-runtime.json` / `perf-memory.json` instead of running the benchmarks —
and in CI, where the wireit cache is shared across runs, it did.

### What that broke

The perf job runs the base branch's benchmarks and the pull request's benchmarks back to back
**inside the same job**, so machine-to-machine variance cancels. That is the whole reason the
baseline step exists, and why the comment is titled *"(same runner)"*.

Caching silently removed that control:

| context | behaviour |
|---|---|
| main push | genuinely measures — every commit is a novel fingerprint, so the gh-pages trend is real |
| pull request **baseline** | almost always a cache restore, because it checks out main, whose fingerprint main's own run already cached |
| pull request **head** | measured on the first run of new code, restored on every re-run of the branch |

So the comparison became *machine A at time T* versus *machine B at time T′* while still claiming
one runner. It did not produce no signal — it produced a confident false one, in either direction,
and re-running a pull request's CI could flip the verdict.

Observed on #1435 (both lines are inside the perf job):

```
Run CURRENT_REF=$(git rev-parse HEAD)      <- baseline step
Ran 0 scripts and skipped 2 in 0.7s        <- baseline benchmarks: skipped
Run npm run test:perf                      <- head step
Ran 0 scripts and skipped 2 in 0.7s        <- head benchmarks: skipped
Run node __tests__/perf/compareBaseline.mjs
```

The head benchmarks "completed" in 0.9 s and the comment reported **100 regressions / 2 stable**
for a change that touched no runtime code. The decisive cross-check: commit `9184da8` measured
`shallow-equal` at 3,747,081 as #1432's head, at 7,056,900 as #1435's baseline, while #1435's own
head measured 3,736,142 — main's real value to within 0.3 %. Same commit, two numbers, 1.9x apart.

### The change

Remove the `files` array from `test:perf`. Caching requires both keys, so dropping `files` leaves
the script unfingerprinted and it always executes. `output` stays, because it still drives
cleaning. Wireit has no `cache` option.

`build` remains cached — a build output really is a function of its inputs. Only the measurement
stops being treated as one.

`package.json` cannot carry a comment, so the reasoning is recorded in `CONTRIBUTING.md` next to
the perf instructions, ending with "Do not add `files` back."

## Does this close any currently open issues?

---

No issue. Found while investigating the perf comment on #1435.

- [ ] Vitest tests added to cover the fix.
- [ ] NUT tests added to cover the fix.
- [ ] E2E tests added to cover the fix.

No test is added: the behaviour is wireit's scheduling, observable only in the runner's own
output, and asserting on it would mean asserting on wireit's log format. It is verified by
execution instead, below.

## Any particular element that can be tested locally

---

Before the change, the second run skips the benchmarks entirely:

```bash
rm -rf .wireit
npm run test:perf   # Ran 2 scripts and skipped 0 in 105.2s
npm run test:perf   # Ran 0 scripts and skipped 2 in 0.1s   <-- measured nothing
```

After it, both runs measure, while `build` still caches (`skipped 1`):

```bash
npm run test:perf   # Ran 1 script and skipped 1 in 101.3s
npm run test:perf   # Ran 1 script and skipped 1 in 103.2s
```

## Any other comments

---

The cost is that `npm run test:perf` no longer skips locally when nothing changed. For a benchmark
that is the correct behaviour, but it is a real cost if you run it repeatedly — roughly 100 s a
run on this machine.

**This does not affect the gh-pages trend data.** Main pushes were already measuring genuinely,
verified on `1fa3ad19`: `Ran 1 script and skipped 1 in 111.9s`. The defect was confined to the
pull request comparison.

Verification: unit 1771, `tsc` on all three projects, biome, knip all clean.
